### PR TITLE
Draft: Add resolve feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 log = "^0.4.21"
+console_error_panic_hook = "0.1.7"
+console_log = "1.0.0"
 
 [workspace]
 members = ["src-tauri"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,19 +1,50 @@
-use leptos::*;
-use serde_wasm_bindgen::from_value;
+use std::{collections::HashSet, net::IpAddr};
+
+use leptos::{html::Input, *};
+use serde::{Deserialize, Serialize};
+use serde_wasm_bindgen::{from_value, to_value};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "tauri"])]
-    async fn invoke(cmd: &str) -> JsValue;
+    async fn invoke(cmd: &str, args: JsValue) -> JsValue;
 }
 
 type ServiceTypes = Vec<String>;
 
 async fn enum_service_types() -> ServiceTypes {
-    let service_types: ServiceTypes = from_value(invoke("enum_service_types").await).unwrap();
-    log::info!("Received {:#?}", service_types);
+    let service_types: ServiceTypes =
+        from_value(invoke("enum_service_types", JsValue::UNDEFINED).await).unwrap();
     service_types
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct ResolvedService {
+    instance_name: String,
+    hostname: String,
+    port: u16,
+    addresses: HashSet<IpAddr>,
+}
+type ResolvedServices = Vec<ResolvedService>;
+
+#[derive(Serialize, Deserialize)]
+#[allow(non_snake_case)]
+struct ResolveServiceArgs<'a> {
+    serviceType: &'a str,
+}
+
+async fn resolve_service(service_type: String) -> ResolvedServices {
+    log::debug!("resolve service: {}", service_type);
+
+    let args = to_value(&ResolveServiceArgs {
+        serviceType: &service_type,
+    })
+    .unwrap();
+    let resolved_services: ResolvedServices =
+        from_value(invoke("resolve_service", args).await).unwrap();
+    log::debug!("Resolved: {:#?}", resolved_services);
+    resolved_services
 }
 
 #[component]
@@ -53,9 +84,62 @@ fn ServiceTypeList() -> impl IntoView {
 }
 
 #[component]
+fn ShowResolvedServices(services: ResolvedServices) -> impl IntoView {
+    view! {
+        <ul>
+            {services.into_iter()
+                .map(|n|
+                     view! {
+                    <div>Instance name: {n.instance_name}</div>
+                    <div>Hostname: {n.hostname}</div>
+                    <div>Port: {n.port}</div>
+                    <div>IPs: {n.addresses.iter().map(|n|n.to_string()).collect::<Vec<String>>().join(", ")}</div>
+                })
+                .collect::<Vec<_>>()}
+        </ul>
+    }
+}
+
+#[component]
+fn ResolveService() -> impl IntoView {
+    let (service, _) = create_signal("".to_string());
+    let resolve_action = create_action(|input: &String| {
+        let input = input.clone();
+        async move { resolve_service(input.clone()).await }
+    });
+    let input_element: NodeRef<Input> = create_node_ref();
+    let on_submit = move |ev: ev::SubmitEvent| {
+        ev.prevent_default();
+        let value = input_element.get().expect("<input> to exist").value();
+        resolve_action.dispatch(value);
+    };
+
+    let value = resolve_action.value();
+
+    view! {
+        <form on:submit=on_submit>
+            <input type="text"
+                value=service
+                node_ref=input_element
+            />
+            <button type="submit">"Resolve"</button>
+        </form>
+         {move || match value.get() {
+            None => view! { <p>Click on Resolve</p> }.into_view(),
+            Some(services) => {
+                view! {
+                    <ShowResolvedServices services />
+                }.into_view()
+            }
+         }}
+    }
+}
+
+#[component]
 pub fn App() -> impl IntoView {
     view! {
         <main class="container">
+            <ResolveService />
             <ServiceTypeList />
         </main>
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ use app::*;
 use leptos::*;
 
 fn main() {
+    _ = console_log::init_with_level(log::Level::Debug);
+    console_error_panic_hook::set_once();
     mount_to_body(|| {
         view! {
             <App/>


### PR DESCRIPTION
Todos:
- [x] Add txt to ResolvedService => #26 
- [x] Add subdomains to ResolvedService => #27 
- [x] Automatically append `.local.` if not present to services to resolve => #28
- [x] Allow resolving of enumerated service => #25
- [x] Own struct for service type? => #29
```rust
struct ServiceType {
   name: String,
   protocol: String, // ._tcp, _udp and so on...
}
````

Closes #12
Closes #22