### PR TITLE
fix: handle txt values properly

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -75,7 +75,7 @@ fn bytes_option_to_string_option_with_escaping(maybe_bytes: Option<&[u8]>) -> Op
     maybe_bytes.map(|bytes| match String::from_utf8(bytes.to_vec()) {
         Ok(utf8_string) => {
             let result = string_with_control_characters_escaped(utf8_string);
-            log::info!("bytes {:#?} -> str {}", bytes, result);
+            log::debug!("bytes {:#?} -> str {}", bytes, result);
 
             result
         }
@@ -99,7 +99,7 @@ impl From<&ServiceInfo> for ResolvedService {
             .get_properties()
             .iter()
             .map(|r| {
-                log::info!("txt prop {:#?}", r.val());
+                log::debug!("txt prop {:#?}", r.val());
                 TxtRecord {
                     key: r.key().into(),
                     val: bytes_option_to_string_option_with_escaping(r.val()),

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,15 +25,15 @@ type ServiceTypes = Vec<String>;
 #[derive(Deserialize, Clone, Debug)]
 struct TxtRecord {
     key: String,
-    val: String,
+    val: Option<String>,
 }
 
 impl Display for TxtRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.val.is_empty() {
+        if self.val.is_none() {
             write!(f, "{}", self.key)
         } else {
-            write!(f, "{}={}", self.key, self.val)
+            write!(f, "{}={}", self.key, self.val.clone().unwrap())
         }
     }
 }


### PR DESCRIPTION
- show only valueless txt properties withthout a value
- escape binary values as far as possible

Closes #169