### PR TITLE
feat: validate service type while user is typing

### DIFF
--- a/.github/workflows/tauri-pr-build.yml
+++ b/.github/workflows/tauri-pr-build.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: run tests
         run: |
-          cargo tests
+          cargo test
 
       - name: cached install trunk
         uses: taiki-e/cache-cargo-install-action@v2.0.1

--- a/.github/workflows/tauri-pr-build.yml
+++ b/.github/workflows/tauri-pr-build.yml
@@ -72,6 +72,10 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
 
+      - name: run tests
+        run: |
+          cargo tests
+
       - name: cached install trunk
         uses: taiki-e/cache-cargo-install-action@v2.0.1
         with:

--- a/.github/workflows/tauri-publish.yml
+++ b/.github/workflows/tauri-publish.yml
@@ -70,6 +70,10 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
 
+      - name: run tests
+        run: |
+          cargo tests
+
       - name: cached install trunk
         uses: taiki-e/cache-cargo-install-action@v2.0.1
         with:

--- a/.github/workflows/tauri-publish.yml
+++ b/.github/workflows/tauri-publish.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: run tests
         run: |
-          cargo tests
+          cargo test
 
       - name: cached install trunk
         uses: taiki-e/cache-cargo-install-action@v2.0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ chrono = "0.4.38"
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 futures = "0.3.30"
+icondata = "0.4.0"
 js-sys = "0.3.69"
 leptos = { version = "0.6.13", features = ["csr"] }
 leptos_meta = { version = "0.6.13", features = ["csr"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -460,14 +460,13 @@ fn Browse() -> impl IntoView {
     let service_type = use_context::<ServiceTypesSignal>().unwrap().0;
 
     let service_type_invalid = Signal::derive(move || {
-        // todo report a meaningfull error to the user
+        // TODO: report a meaningful error to the user
         check_mdns_service_type(service_type.get().clone().as_str()).is_err()
     });
     let browsing = use_context::<BrowsingSignal>().unwrap().0;
     let not_browsing = Signal::derive(move || !browsing.get());
-    let browsing_or_service_type_invalid = Signal::derive(move || {
-        browsing.get() || service_type.get().is_empty() || service_type_invalid.get()
-    });
+    let browsing_or_service_type_invalid =
+        Signal::derive(move || browsing.get() || service_type_invalid.get());
 
     let browse_action = create_action(|input: &String| {
         let input = input.clone();


### PR DESCRIPTION
Fullfill the requirement to have a valid service type required since the added sanity check in upstream library
https://github.com/keepsimple1/mdns-sd/pull/231