### PR TITLE
feat: integrate latest changes of dependency mdns-sd

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 tauri-build = { version = "1.5.3", features = [] }
 
 [dependencies]
-mdns-sd = { version = "0.11.2", default-features = false, features = [
+mdns-sd = { git = "https://github.com/keepsimple1/mdns-sd.git", rev = "f055c78", default-features = false, features = [
     "async",
     "log",
 ] }


### PR DESCRIPTION
This integratest the following two changes:
- https://github.com/keepsimple1/mdns-sd/pull/239
- https://github.com/keepsimple1/mdns-sd/pull/240