### PR TITLE
chore(trunk): address deprecation of serve.address in Trunk.toml

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -5,6 +5,6 @@ target = "./index.html"
 ignore = ["./src-tauri"]
 
 [serve]
-address = "127.0.0.1"
+addresses = ["127.0.0.1"]
 port = 1420
 open = false


### PR DESCRIPTION
Closes #389