### PR TITLE
fix: Move copy to clipboard button to front of text

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -362,7 +362,6 @@ fn ToClipBoardCopyable(
     };
 
     view! {
-        {text}
         <Button
             disabled=disabled
             on_click=on_copy_to_clibboard_click
@@ -370,6 +369,7 @@ fn ToClipBoardCopyable(
             icon=icondata::TbClipboardText
             size=ButtonSize::Tiny
         />
+        {text}
     }
 }
 


### PR DESCRIPTION
Closes #434 