### PR TITLE
Revert "chore: remap path prefix for reproducible builds"

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -74,7 +74,6 @@ jobs:
           cargo --locked auditable tauri android build
         env:
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/27.0.11902837
-          RUSTFLAGS: "--remap-path-prefix ${{ github.workspace }}=/static-placeholder"
 
       - name: 🔑 Extract android signing key from env (publish only)
         run: |

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -139,7 +139,6 @@ jobs:
         uses: tauri-apps/tauri-action@8c3e0753aa015d00d03631d6d4f64ad59489251d # v0.5.15
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUSTFLAGS: "--remap-path-prefix ${{ github.workspace }}=/static-placeholder"
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         with:


### PR DESCRIPTION
Reverts hrzlgnm/mdns-browser#451

I had a look at the produced binaries and those still did contain paths from the build system, so the changes was useless or incomplete and needs more investigation. Or perhaps we should wait when [trim-paths](https://github.com/rust-lang/cargo/issues/12137)  from  [RFC-3127](https://rust-lang.github.io/rfcs/3127-trim-paths.html)is available in rust / cargo.
