### PR TITLE
chore: No Auto Merge for Auto Bump PRs

### DIFF
--- a/.github/workflows/auto-bump-pr.yml
+++ b/.github/workflows/auto-bump-pr.yml
@@ -34,7 +34,6 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7
         with:
-          token: ${{ secrets.PAT }}
           commit-message: "chore(version) : bump to ${{ env.new_version }}"
           sign-commits: true
           base: main
@@ -43,15 +42,6 @@ jobs:
           labels: |
             chore
             automated pr
-
           delete-branch: true
           title: "chore(version): bump version to ${{ env.new_version }}"
           draft: false
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
-        with:
-          token: ${{ secrets.PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash


### PR DESCRIPTION
The issue is that actions don't start if using the default token, but we cannot sign commits with another token, therefore we just merge those by hand without running all the required checks.