### PR TITLE
Revert "chore: Move treat warnings as error flag to config (#484)"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-D", "warnings"]

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -69,6 +69,7 @@ jobs:
           cargo --locked auditable tauri android build
         env:
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/27.0.11902837
+          RUSTFLAGS: "-D warnings"
 
       - name: 🔑 Extract android signing key from env (publish only)
         run: |

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -133,6 +133,7 @@ jobs:
       - name: 🔨 Build using tauri action (publish artifacts on release)
         uses: tauri-apps/tauri-action@8c3e0753aa015d00d03631d6d4f64ad59489251d # v0.5.15
         env:
+          RUSTFLAGS: "-D warnings"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}


### PR DESCRIPTION
This reverts commit 3a3136b65a9b2ba7fe8747ba48f55eacf3fc0368.

Otherwise running cargo tuari dev recompiles too much on each run
