### PR TITLE
feat: also use opener plugin on android

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,6 @@ tauri-build = { version = "2.0.0", features = [] }
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 clap = { version = "4.5.19", features = ["derive"] }
 tauri-plugin-log = "2.0.0"
-tauri-plugin-opener = "2.2.0"
 tauri-plugin-updater = "2.0.1"
 thiserror = "2.0.0"
 tokio = "1.40.0"
@@ -24,6 +23,7 @@ serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 tauri = { version = "2.0.0", features = [] }
 tauri-plugin-clipboard-manager = "2.0.0"
+tauri-plugin-opener = "2.2.0"
 
 # local
 models = { path = "../models" }

--- a/src-tauri/capabilities/mobile.json
+++ b/src-tauri/capabilities/mobile.json
@@ -7,7 +7,8 @@
     ],
     "permissions": [
         "core:default",
-        "clipboard-manager:allow-write-text"
+        "clipboard-manager:allow-write-text",
+        "opener:allow-open-url"
     ],
     "platforms": [
         "android"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,12 +12,9 @@ use std::{
     net::IpAddr,
     sync::{Arc, Mutex},
 };
-#[cfg(desktop)]
-use tauri::AppHandle;
 use tauri::Emitter;
-use tauri::{Manager, State, Window};
+use tauri::{AppHandle, Manager, State, Window};
 use tauri_plugin_clipboard_manager::ClipboardExt;
-#[cfg(desktop)]
 use tauri_plugin_opener::OpenerExt;
 
 #[cfg(desktop)]
@@ -232,7 +229,6 @@ fn send_metrics(window: Window, state: State<ManagedState>) {
     }
 }
 
-#[cfg(desktop)]
 #[tauri::command]
 fn open_url(app: AppHandle, url: String) {
     let opener = app.opener();
@@ -503,6 +499,7 @@ pub fn run() {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run_mobile() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_clipboard_manager::init())
         .manage(ManagedState::new())
         .invoke_handler(tauri::generate_handler![
@@ -510,6 +507,7 @@ pub fn run_mobile() {
             browse_types,
             copy_to_clipboard,
             is_desktop,
+            open_url,
             send_metrics,
             stop_browse,
             verify,


### PR DESCRIPTION
With #618 we got a new version of the plugin where an issue with a wrong package name is resolved.

Partially reverts 4cfd60bc30f3dcec57d4e34f20dd28083834632b