### PR TITLE
Revert "chore: pin winget-releaser to v2 (#542)"

### DIFF
--- a/.github/workflows/winget-publish-release.yml
+++ b/.github/workflows/winget-publish-release.yml
@@ -12,7 +12,7 @@ jobs:
           $VERSION = "${{ github.event.release.tag_name }}" -replace '.*-v(\d+)\.(\d+\.\d+)', '$1.$2'
           "version=$VERSION" >> $env:GITHUB_OUTPUT
         shell: pwsh
-      - uses: vedantmgoyal9/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # v2
+      - uses: vedantmgoyal9/winget-releaser@main # v2
         with:
           identifier: hrzlgnm.mdns-browser
           max-versions-to-keep: 10


### PR DESCRIPTION
This reverts commit 746e34570f0d3da15c1b060ad87229289c5faf0a.