### PR TITLE
fix: bring back service type invalid on input feedback

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -16,3 +16,10 @@ body {
 .thaw-card-header__header {
     justify-content: space-between;
 }
+
+.service-type-invalid > .thaw-input {
+    border: 2px groove var(--colorStatusDangerBorder1);
+}
+.service-type-valid > .thaw-input {
+    outline: 1px solid var(--colorTransparentStroke);
+}


### PR DESCRIPTION
Closes #779

## Summary by Sourcery

Bug Fixes:
- Fixes the service type input field to display an error state when the input is invalid.