### PR TITLE
fix: workaround not being able to set autocapitalize attribute to inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,5 +6,6 @@
     <link data-trunk rel="css" href="styles.css" />
     <link data-trunk rel="copy-dir" href="public" />
     <link data-trunk rel="rust" data-wasm-opt="s" />
+    <script data-trunk src="index.js" rel="index.js" href="public"></script>
   </head>
 </html>

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
  * which is what we want
  */
 window.addEventListener("TrunkApplicationStarted", function () {
-    const inputs = document.getElementsByClassName("thaw-input__input");
+    const inputs = document.querySelectorAll("input.thaw-input__input");
     for (const input of inputs) {
         input.setAttribute("autocapitalize", "none");
     }

--- a/index.js
+++ b/index.js
@@ -1,0 +1,12 @@
+/**
+ * Workaround for thaw inputs wrapped by components `AutoComplete` or `Input`
+ * having no possibility to set autocapitalize="none" which
+ * prevents mobile inputs to auto-capitalize the first letter,
+ * which is what we want
+ */
+window.addEventListener("TrunkApplicationStarted", function () {
+    const inputs = document.getElementsByClassName("thaw-input__input");
+    for (const input of inputs) {
+        input.setAttribute("autocapitalize", "none");
+    }
+});


### PR DESCRIPTION
Closes #802

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the autocapitalize attribute could not be set on input elements wrapped by AutoComplete or Input components.