### PR TITLE
feat: disable any autocorrection attribute along with autocapitalization

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 /**
  * Workaround for thaw inputs wrapped by components `AutoComplete` or `Input`
- * having no possibility to set autocapitalize="none" which
- * prevents mobile inputs to auto-capitalize the first letter,
- * which is what we want
+ * providing no possibility to set attributes.
+ * We want no spell checking no autocorrection or capitalization in our inputs 
+ * mostly dealing with lower case characters.
  */
 window.addEventListener("TrunkApplicationStarted", function () {
     const inputs = document.querySelectorAll("input.thaw-input__input");
     for (const input of inputs) {
         input.setAttribute("autocapitalize", "none");
+        input.setAttribute("autocorrect", "off");
+        input.setAttribute("spellcheck", "false");
     }
 });


### PR DESCRIPTION
Closes #806

## Summary by Sourcery

Disable spellcheck, autocorrection, and autocapitalization on thaw inputs to prevent unwanted text modifications, especially when dealing with lowercase characters.

Chores:
- Disable autocapitalization on thaw inputs.
- Disable autocorrection on thaw inputs.
- Disable spellcheck on thaw inputs.