### PR TITLE
feat: use a table to visualize the resolved service card

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -199,7 +199,7 @@ fn ValuesTable(values: Vec<String>, #[prop(into)] title: String) -> impl IntoVie
         <Show
             when=move || !values.get().is_empty()
             fallback=move || {
-                view! { <p class="invisible"></p> }
+                view! { <p class="hidden"></p> }
             }
         >
             <Table>
@@ -1042,7 +1042,7 @@ pub fn About() -> impl IntoView {
                             <Show
                                 when=move || { can_auto_update.get() }
                                 fallback=move || {
-                                    view! { <div /> }
+                                    view! { <div class="hidden" /> }
                                 }
                             >
                                 <Show
@@ -1182,7 +1182,7 @@ pub fn App() -> impl IntoView {
                             <GridItem column=0>
                                 <Show
                                     when=move || { is_desktop.get() }
-                                    fallback=|| view! { <div /> }
+                                    fallback=|| view! { <div class="hidden" /> }
                                 >
                                     <About />
                                 </Show>

--- a/styles.css
+++ b/styles.css
@@ -4,7 +4,7 @@ body {
     border: 0;
 }
 
-.invisible {
+.hidden {
     display: none;
 }
 .mobile-outer-layout {

--- a/styles.css
+++ b/styles.css
@@ -4,15 +4,9 @@ body {
     border: 0;
 }
 
-.desktop-outer-layout {
-    padding: 10px
+.invisible {
+    display: none;
 }
-.desktop-browse-layout {
-    padding-top: 10px;
-}
-.desktop-metrics-layout {
-}
-
 .mobile-outer-layout {
 }
 
@@ -22,23 +16,34 @@ body {
 .mobile-browse-layout {
     padding-top: 5px;
 }
-
 .mobile-resolved-service-card {
     width: 480px; !important;
 }
-
 .mobile-resolved-service-grid {
     grid-template-columns: repeat(auto-fill, minmax(480px, 1fr)) !important;
     grid-gap: 8px 8px; !important;
 }
+.mobile-resolved-service-table-cell {
+    width: 350px;
+}
 
+.desktop-outer-layout {
+    padding: 10px
+}
+.desktop-browse-layout {
+    padding-top: 10px;
+}
+.desktop-metrics-layout {
+}
 .desktop-resolved-service-card {
     width: 520px; !important;
 }
-
 .desktop-resolved-service-grid {
     grid-template-columns: repeat(auto-fill, minmax(520px, 1fr)) !important;
-    grid-gap: 8px 8px; !important;
+    grid-gap: 10px 10px; !important;
+}
+.desktop-resolved-service-table-cell {
+    width: 400px;
 }
 
 .mobile-input > .thaw-input {
@@ -63,3 +68,4 @@ body {
 .service-type-valid > .thaw-input {
     outline: 1px solid var(--colorTransparentStroke);
 }
+


### PR DESCRIPTION
also remove color branding while at it
Closes #807

## Summary by Sourcery

Refactors the ResolvedServiceItem component to display service details in a table format instead of using multiple Flex containers and buttons. This change improves the layout and readability of the service information. It also removes the custom color branding and uses the default dark/light themes.

Enhancements:
- Refactors the ResolvedServiceItem component to use a table for displaying service details, improving layout and readability.
- Removes custom color branding and uses the default dark/light themes.