### PR TITLE
refactor: Deduplicate getting class for desktop/mobile

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -35,7 +35,7 @@ macro_rules! log_fn {
 fn get_class(is_desktop: &ReadSignal<bool>, base_class: &str) -> Signal<String> {
     let base_class = base_class.to_string();
     Signal::derive({
-        let is_desktop = is_desktop.clone();
+        let is_desktop = *is_desktop;
         move || {
             let prefix = if is_desktop.get() {
                 "desktop-"


### PR DESCRIPTION
## Summary by Sourcery

Introduces a `get_class` function to reduce code duplication when determining CSS classes based on whether the application is running on desktop or mobile. This function centralizes the logic for prefixing class names with 'desktop-' or 'mobile-' based on the `is_desktop` signal.

Enhancements:
- Introduces a `get_class` function to reduce code duplication when determining CSS classes based on whether the application is running on desktop or mobile.
- Replaces multiple instances of duplicated code with calls to the new `get_class` function.