### PR TITLE
feat: enabled building debug symbols

### DIFF
--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -158,23 +158,19 @@ jobs:
             target/**/release/bundle
             target/**/release/mdns-browser*
 
-      - name: find
-        shell: bash
-        run: find -name '*.pdb'
-
       - name: 📤 Upload debug symbols (windows only)
         if: contains(matrix.os, 'windows')
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: "debug-symbols-${{matrix.os}}${{matrix.args}}"
           path: |
-            target/release/mdns-browser.pdb
+            target/release/mdns_browser.pdb
 
       - name: 📤 Publish debug symbols to release (windows only)
         if: contains(matrix.os, 'windows') && (inputs.tagName != '')
         uses: softprops/action-gh-release@v2
         with:
-          files: target/release/mdns-browser.pdb
+          files: target/release/mdns_browser.pdb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -190,7 +186,7 @@ jobs:
             target/release/bundle/rpm/*.rpm
             target/**/release/mdns-browser
             target/release/mdns-browser.exe
-            target/release/mdns-browser.pdb
+            target/release/mdns_browser.pdb
 
       - name: 📜 Create SBOM
         uses: anchore/sbom-action@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -158,6 +158,14 @@ jobs:
             target/**/release/bundle
             target/**/release/mdns-browser*
 
+      - name: 📤 Upload debug symbols (windows only)
+        if: contains(matrix.os, 'windows')
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: "debug-symbols-${{matrix.os}}${{matrix.args}}"
+          path: |
+            target/**/release/mdns-browser.pdb
+
       - name: 🛡️ Attest build provenance (publish release only)
         if: inputs.tagName != ''
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
@@ -170,6 +178,7 @@ jobs:
             target/release/bundle/rpm/*.rpm
             target/**/release/mdns-browser
             target/release/mdns-browser.exe
+            target/release/mdns-browser.pdb
 
       - name: 📜 Create SBOM
         uses: anchore/sbom-action@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -166,6 +166,14 @@ jobs:
           path: |
             target/**/release/mdns-browser.pdb
 
+      - name: 📤 Publish debug symbols to release (windows only)
+        if: contains(matrix.os, 'windows') && (inputs.tagName != '')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/**/release/mdns-browser.pdb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: 🛡️ Attest build provenance (publish release only)
         if: inputs.tagName != ''
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: find
         shell: bash
-        run: find ./target/
+        run: find -name '*.pdb'
 
       - name: 📤 Upload debug symbols (windows only)
         if: contains(matrix.os, 'windows')

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -164,13 +164,13 @@ jobs:
         with:
           name: "debug-symbols-${{matrix.os}}${{matrix.args}}"
           path: |
-            target/**/release/mdns-browser.pdb
+            target/release/mdns-browser.pdb
 
       - name: 📤 Publish debug symbols to release (windows only)
         if: contains(matrix.os, 'windows') && (inputs.tagName != '')
         uses: softprops/action-gh-release@v2
         with:
-          files: target/**/release/mdns-browser.pdb
+          files: target/release/mdns-browser.pdb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -159,6 +159,7 @@ jobs:
             target/**/release/mdns-browser*
 
       - name: find
+        shell: bash
         run: find ./target/
 
       - name: 📤 Upload debug symbols (windows only)

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -158,6 +158,9 @@ jobs:
             target/**/release/bundle
             target/**/release/mdns-browser*
 
+      - name: find
+        run: find ./target/
+
       - name: 📤 Upload debug symbols (windows only)
         if: contains(matrix.os, 'windows')
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ codegen-units = 1
 lto = true
 opt-level = "s"
 strip = true
+debug = true
 
 [dependencies]
 # crates


### PR DESCRIPTION
Closes #829 

## Summary by Sourcery

Enable building debug symbols for Windows releases and upload them as artifacts.

Build:
- Enable debug symbols in release builds.
- Upload debug symbols for Windows releases as artifacts.
- Publish debug symbols to release (windows only)