### PR TITLE
fix: ignore invalid service types when browsing service types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3251,6 +3251,7 @@ name = "models"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.210", features = ["derive"] }
+thiserror = "2.0.0"

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -167,7 +167,7 @@ pub struct UpdateMetadata {
 pub enum MdnsError {
     #[error("The trailing dot is missing")]
     MissingTrailingDot,
-    #[error("The service type lavel is not well formed")]
+    #[error("The service type label is not well formed")]
     InvalidService,
     #[error("The service sub type label is not well formed")]
     InvalidSubtype,

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -163,13 +163,21 @@ pub struct UpdateMetadata {
     pub current_version: String,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub enum MdnsError {
+    #[error("The trailing dot is missing")]
     MissingTrailingDot,
+    #[error("The service type lavel is not well formed")]
     InvalidService,
+    #[error("The service sub type label is not well formed")]
     InvalidSubtype,
+    #[error("The service sub label is invalid, expected `_sub`")]
+    InvalidSublabel,
+    #[error("The protocol is invalid, expected `_tcp` or `_udp`")]
     InvalidProtocol,
+    #[error("The domain is invalid, expected `.local.`")]
     InvalidDomain,
+    #[error("The service type format is incorrect, expected to contain 3 or 5 parts")]
     IncorrectFormat,
 }
 
@@ -253,14 +261,14 @@ pub fn check_service_type_fully_qualified(service_type: &str) -> Result<(), Mdns
     // Validate optional subtype if present
     if parts.len() == 5 {
         let sub_label = parts[1];
-        let subtype = parts[0];
+        let sub_type = parts[0];
 
         // Ensure the second part is "_sub"
         if sub_label != "_sub" {
             return Err(MdnsError::IncorrectFormat);
         }
 
-        check_mdns_label(subtype, true)?;
+        check_mdns_label(sub_type, true)?;
     }
 
     Ok(())
@@ -583,6 +591,10 @@ mod tests {
             Err(MdnsError::IncorrectFormat)
         ); // Missing service in format
         assert_eq!(
+            check_service_type_fully_qualified("_sub._http._tcp.local."),
+            Err(MdnsError::IncorrectFormat)
+        ); // Missing subtype
+        assert_eq!(
             check_service_type_fully_qualified("_-http_tcp._tcp.local."),
             Err(MdnsError::InvalidService)
         ); // Invalid service name format
@@ -593,6 +605,10 @@ mod tests {
         assert_eq!(
             check_service_type_fully_qualified("_printer-._sub._http._tcp.local."),
             Err(MdnsError::InvalidSubtype)
+        ); // Invalid subtype name format
+        assert_eq!(
+            check_service_type_fully_qualified("_printer._pub._http._tcp.local."),
+            Err(MdnsError::InvalidSublabel)
         ); // Invalid subtype name format
         assert_eq!(
             check_service_type_fully_qualified("_http-._tcp.local."),

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -265,7 +265,7 @@ pub fn check_service_type_fully_qualified(service_type: &str) -> Result<(), Mdns
 
         // Ensure the second part is "_sub"
         if sub_label != "_sub" {
-            return Err(MdnsError::IncorrectFormat);
+            return Err(MdnsError::InvalidSublabel);
         }
 
         check_mdns_label(sub_type, true)?;
@@ -620,7 +620,7 @@ mod tests {
         ); // Invalid subtype without _sub keyword
         assert_eq!(
             check_service_type_fully_qualified("_myprinter.____._sub._tcp.local."),
-            Err(MdnsError::IncorrectFormat)
+            Err(MdnsError::InvalidSublabel)
         ); // Invalid subtype format
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -68,10 +68,10 @@ fn from_service_info(info: &ServiceInfo) -> ResolvedService {
 }
 
 /// Emits an event to the window.
-/// 
+///
 /// This helper centralizes event emission and handles any errors internally.
 /// If window.emit returns an error, it is logged and not propagated.
-/// Use this helper across your codebase to avoid repetitive error handling.
+/// Use this helper to avoid repetitive error handling.
 fn emit_event<T>(window: &Window, event: &str, payload: &T)
 where
     T: serde::Serialize,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,6 +67,11 @@ fn from_service_info(info: &ServiceInfo) -> ResolvedService {
     }
 }
 
+/// Emits an event to the window.
+/// 
+/// This helper centralizes event emission and handles any errors internally.
+/// If window.emit returns an error, it is logged and not propagated.
+/// Use this helper across your codebase to avoid repetitive error handling.
 fn emit_event<T>(window: &Window, event: &str, payload: &T)
 where
     T: serde::Serialize,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -103,7 +103,7 @@ fn browse_types(window: Window, state: State<ManagedState>) {
                                 );
                             }
                             Err(e) => {
-                                log::warn!("Ignoring invalid service type `{full_name}`: {}", e)
+                                log::warn!("Ignoring invalid service type `{}`: {}", full_name, e)
                             }
                         }
                     }
@@ -120,7 +120,7 @@ fn browse_types(window: Window, state: State<ManagedState>) {
                                 );
                             }
                             Err(e) => {
-                                log::warn!("Ignoring invalid service type `{full_name}`: {}", e);
+                                log::warn!("Ignoring invalid service type `{}`: {}", full_name, e)
                             }
                         }
                     }


### PR DESCRIPTION
Closes #841

## Summary by Sourcery

Adds validation to service types to ensure they are fully qualified before emitting events, preventing issues with invalid service types.

Bug Fixes:
- Fixes an issue where invalid service types were being processed, leading to errors or unexpected behavior.
- Fixes an issue where the application would crash when browsing service types with invalid names.
- Fixes an issue where the application would display invalid service types in the UI.