### PR TITLE
Revert "fix(deps): update rust crate mdns-sd to v0.13.4 (#845)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3179,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "mdns-sd"
-version = "0.13.4"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9982861e33796f41051f04a703baa7512a75ea349b3ec7af3115f126c5a301e"
+checksum = "400c6168c6a7d2cd936365dc51e0ee4159830876aac224b5e3e042605dcb73f3"
 dependencies = [
  "fastrand",
  "flume",
@@ -6783,7 +6783,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
This reverts commit a9b2ee3f5d01fe05e1141c71e4e596095a688bab.
Which introduced a regression with resolving: https://github.com/keepsimple1/mdns-sd/issues/333

## Summary by Sourcery

Bug Fixes:
- Reverts a regression introduced by updating the mdns-sd crate to v0.13.4.