### PR TITLE
fix: Make details view scrollable

### DIFF
--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -12,8 +12,8 @@ use tauri_sys::event::listen;
 use thaw::{
     AutoComplete, AutoCompleteOption, AutoCompleteRef, AutoCompleteSize, Button, ButtonAppearance,
     ButtonSize, Card, CardHeader, CardPreview, ComponentRef, Dialog, DialogBody, DialogSurface,
-    DialogTitle, Flex, FlexAlign, FlexGap, FlexJustify, Grid, GridItem, Input, Layout, Select,
-    Table, TableBody, TableCell, TableRow, Text, TextTag,
+    DialogTitle, Flex, FlexAlign, FlexGap, FlexJustify, Grid, GridItem, Input, Layout, Scrollbar,
+    Select, Table, TableBody, TableCell, TableRow, Text, TextTag,
 };
 use thaw_utils::Model;
 
@@ -404,13 +404,15 @@ fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
                                     </Button>
                                     <Dialog open=show_details>
                                         <DialogSurface>
-                                            <DialogBody attr:style="display: flex;">
-                                                <Flex vertical=true>
-                                                    <DialogTitle>{details_title}</DialogTitle>
-                                                    <ValuesTable values=subtype title="subtype" />
-                                                    <ValuesTable values=addrs title="IPs" />
-                                                    <ValuesTable values=txts title="txt" />
-                                                </Flex>
+                                            <DialogBody attr:style="display: flex; max-width: 90vw;">
+                                                <Scrollbar style="max-height: 90vh;">
+                                                    <Flex vertical=true>
+                                                        <DialogTitle>{details_title}</DialogTitle>
+                                                        <ValuesTable values=subtype title="subtype" />
+                                                        <ValuesTable values=addrs title="IPs" />
+                                                        <ValuesTable values=txts title="txt" />
+                                                    </Flex>
+                                                </Scrollbar>
                                             </DialogBody>
                                         </DialogSurface>
                                     </Dialog>


### PR DESCRIPTION
Closes #855

## Summary by Sourcery

Add scrollability to the service details dialog to improve usability for services with long or multiple information tables

Bug Fixes:
- Resolve issue with dialog content overflowing when multiple service details are present

Enhancements:
- Implement a scrollbar for the dialog body to enable viewing all service details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the service details dialog with a scrollable content area. The dialog now automatically adjusts to a maximum of 90% of the viewport dimensions, ensuring that lengthy details remain accessible and easy to navigate. 
  - Introduced a new `Scrollbar` component for improved content visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->