### PR TITLE
feat: Add support for opening resolved services

### DIFF
--- a/src/app/about.rs
+++ b/src/app/about.rs
@@ -28,7 +28,7 @@ struct OpenArgs<'a> {
     url: &'a str,
 }
 
-async fn open_url(url: &str) {
+pub async fn open_url(url: &str) {
     log_fn!(format!("open_url({})", &url), {
         let _ = invoke::<()>("open_url", &OpenArgs { url }).await;
     });

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -295,14 +295,6 @@ fn get_open_url(resolved_service: &ResolvedService) -> Option<String> {
             path.unwrap_or_else(|| "/".to_string())
         )),
         ("_home-assistant._tcp.local.", Some(internal_url)) => Some(internal_url.clone()),
-        ("_ftp._tcp.local.", _) => Some(format!(
-            "ftp://{}:{}{}",
-            address
-                .map(|t| t.to_string())
-                .unwrap_or_else(|| resolved_service.hostname.clone()),
-            resolved_service.port,
-            path.unwrap_or_else(|| "/".to_string())
-        )),
         _ => None,
     }
 }

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -282,7 +282,15 @@ fn get_open_url(resolved_service: &ResolvedService) -> Option<String> {
             "http://{}:{}{}",
             address
                 .map(|t| t.to_string())
-                .unwrap_or(resolved_service.hostname.clone()),
+                .unwrap_or_else(|| resolved_service.hostname.clone()),
+            resolved_service.port,
+            path.unwrap_or_else(|| "/".to_string())
+        )),
+        ("_https._tcp.local.", _) => Some(format!(
+            "https://{}:{}{}",
+            address
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| resolved_service.hostname.clone()),
             resolved_service.port,
             path.unwrap_or_else(|| "/".to_string())
         )),

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -295,6 +295,14 @@ fn get_open_url(resolved_service: &ResolvedService) -> Option<String> {
             path.unwrap_or_else(|| "/".to_string())
         )),
         ("_home-assistant._tcp.local.", Some(internal_url)) => Some(internal_url.clone()),
+        ("_ftp._tcp.local.", _) => Some(format!(
+            "ftp://{}:{}{}",
+            address
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| resolved_service.hostname.clone()),
+            resolved_service.port,
+            path.unwrap_or_else(|| "/".to_string())
+        )),
         _ => None,
     }
 }
@@ -487,7 +495,7 @@ fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
                                             on_click=on_open_click
                                             disabled=url.get_untracked().is_none()
                                                 || resolved_service.dead
-                                            icon=icondata::MdiFirefox
+                                            icon=icondata::MdiOpenInNew
                                         >
                                             "Open"
                                         </Button>


### PR DESCRIPTION
Closes #860

## Summary by Sourcery

Add support for opening resolved services directly from the browse view

New Features:
- Implement an 'Open' button for resolved services that supports opening HTTP and Home Assistant services based on their resolved metadata

Enhancements:
- Create a utility function to generate open URLs for different service types
- Add flexibility to handle various service URL formats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an “Open” button in the service listing interface so users can directly launch a service URL when available.
  - Enhanced URL resolution to correctly handle different service types, ensuring a seamless connection when the “Open” option is used.
  - Introduced a new function to construct URLs based on service properties.
  - Made the `open_url` function publicly accessible for external use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->