### PR TITLE
feat: Pressing enter in quick filter starts browsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ window.addEventListener("TrunkApplicationStarted", function () {
         if (input.getAttribute("placeholder")?.includes("Quick")) {
             input.addEventListener("keydown", function (event) {
                 if (event.key === "Enter") {
-                    browseButton.click();
+                    if (browseButton) browseButton.click();
                 }
             });
         }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
  * mostly dealing with lower case characters.
  */
 window.addEventListener("TrunkApplicationStarted", function () {
-    const browseButton = document.querySelector("button.thaw-button--primary");
+    const browseButton = document.querySelector("button.thaw-button--primary[contains(text(), 'Browse')]");
     const inputs = document.querySelectorAll("input.thaw-input__input");
     for (const input of inputs) {
         input.setAttribute("autocapitalize", "none");

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
  * mostly dealing with lower case characters.
  */
 window.addEventListener("TrunkApplicationStarted", function () {
-    const browseButton = document.querySelector("button.thaw-button--primary[contains(text(), 'Browse')]");
+    const browseButton = document.querySelector("button.thaw-button--primary");
     const inputs = document.querySelectorAll("input.thaw-input__input");
     for (const input of inputs) {
         input.setAttribute("autocapitalize", "none");

--- a/index.js
+++ b/index.js
@@ -1,14 +1,22 @@
 /**
- * Workaround for thaw inputs wrapped by components `AutoComplete` or `Input`
- * providing no possibility to set attributes.
+ * Workarounds for thaw inputs wrapped by components `AutoComplete` or `Input`
+ * providing no possibility to set attributes or to add onkeydown event listeners.
  * We want no spell checking no autocorrection or capitalization in our inputs 
  * mostly dealing with lower case characters.
  */
 window.addEventListener("TrunkApplicationStarted", function () {
+    const browseButton = document.querySelector("button.thaw-button--primary");
     const inputs = document.querySelectorAll("input.thaw-input__input");
     for (const input of inputs) {
         input.setAttribute("autocapitalize", "none");
         input.setAttribute("autocorrect", "off");
         input.setAttribute("spellcheck", "false");
+        if (input.getAttribute("placeholder")?.includes("Quick")) {
+            input.addEventListener("keydown", function (event) {
+                if (event.key === "Enter") {
+                    browseButton.click();
+                }
+            });
+        }
     }
 });

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -726,7 +726,12 @@ pub fn Browse() -> impl IntoView {
                         <option label="Last Updated (Ascending)" value="TimestampAsc" />
                         <option label="Last Updated (Descending)" value="TimestampDesc" />
                     </Select>
-                    <Input value=query placeholder="Quick filter" class=input_class on_focus=on_quick_filter_focus/>
+                    <Input
+                        value=query
+                        placeholder="Quick filter"
+                        class=input_class
+                        on_focus=on_quick_filter_focus
+                    />
                 </Flex>
             </Flex>
             <Grid class=grid_class>

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -635,11 +635,11 @@ pub fn Browse() -> impl IntoView {
         false,
     );
 
-    let handle: StoredValue<Option<TimeoutHandle>> = StoredValue::new(None);
+    let tutorial_timeout: StoredValue<Option<TimeoutHandle>> = StoredValue::new(None);
     let comp_ref = ComponentRef::<AutoCompleteRef>::new();
 
-    let clear_focus_timeout = move || {
-        if let Some(h) = handle.get_value() {
+    let clear_tutorial_timer = move || {
+        if let Some(h) = tutorial_timeout.get_value() {
             h.clear();
         }
     };
@@ -655,17 +655,17 @@ pub fn Browse() -> impl IntoView {
                 },
                 SPLASH_SCREEN_DURATION + AUTO_COMPLETE_AUTO_FOCUS_DELAY,
             ) {
-                handle.set_value(Some(h));
+                tutorial_timeout.set_value(Some(h));
             }
         });
     });
 
     let on_quick_filter_focus = move |_| {
-        clear_focus_timeout();
+        clear_tutorial_timer();
     };
 
     let on_browse_click = move |_| {
-        clear_focus_timeout();
+        clear_tutorial_timer();
         set_resolved.set(Vec::new());
         browsing.set(true);
         let value = service_type.get_untracked();

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -638,7 +638,14 @@ pub fn Browse() -> impl IntoView {
     let handle: StoredValue<Option<TimeoutHandle>> = StoredValue::new(None);
     let comp_ref = ComponentRef::<AutoCompleteRef>::new();
 
+    let clear_focus_timeout = move || {
+        if let Some(h) = handle.get_value() {
+            h.clear();
+        }
+    };
     Effect::new(move |_| {
+        // Set a timeout to focus the autocomplete after splash screen
+        // This is part of the tutorial timer that should be stopped on user interaction
         spawn_local(async move {
             if let Ok(h) = set_timeout_with_handle(
                 move || {
@@ -654,15 +661,11 @@ pub fn Browse() -> impl IntoView {
     });
 
     let on_quick_filter_focus = move |_| {
-        if let Some(h) = handle.get_value() {
-            h.clear();
-        }
+        clear_focus_timeout();
     };
 
     let on_browse_click = move |_| {
-        if let Some(h) = handle.get_value() {
-            h.clear();
-        }
+        clear_focus_timeout();
         set_resolved.set(Vec::new());
         browsing.set(true);
         let value = service_type.get_untracked();


### PR DESCRIPTION
Closes #856 

## Summary by Sourcery

Enhance tutorial timer behavior and input interactions in the browse page

New Features:
- Add ability to stop tutorial timer when quick filtering or browsing
- Implement Enter key press to trigger browse action on quick filter input

Enhancements:
- Improve auto-focus mechanism for service type autocomplete
- Add timeout handle management for tutorial timer

Chores:
- Remove redundant autocapitalize attribute
- Simplify input attribute setting logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced keyboard interaction: Pressing "Enter" in certain input fields now triggers the primary action for a smoother user experience.
	- Improved autocomplete behavior: Focus management has been refined with a smart timeout mechanism to ensure responsive and intuitive interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->