### PR TITLE
refactor: Make logging a noop in macro log_fn in release build

### DIFF
--- a/src/app/macros.rs
+++ b/src/app/macros.rs
@@ -1,9 +1,14 @@
 #[macro_export]
 macro_rules! log_fn {
     ($name:expr, $body:block) => {{
+        #[cfg(debug_assertions)]
         log::debug!("-> {}", $name);
+
         let result = { $body };
+
+        #[cfg(debug_assertions)]
         log::debug!("<- {}", $name);
+
         result
     }};
 }


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add conditional compilation to debug logging in log_fn macro to eliminate logging overhead in release builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved logging management by ensuring that detailed debug messages are only enabled during development builds. This adjustment reduces unnecessary log clutter and enhances overall performance in production environments by automatically suppressing non-essential output. These changes contribute to a smoother developer experience while maintaining system efficiency for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->