### PR TITLE
refactor: Move inline style to CSS

### DIFF
--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -455,7 +455,7 @@ fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
                                     </Button>
                                     <Dialog open=show_details>
                                         <DialogSurface>
-                                            <DialogBody class="details-dialog">
+                                            <DialogBody class="details-dialog-body">
                                                 <Scrollbar class="details-dialog-scrollarea">
                                                     <Flex vertical=true>
                                                         <DialogTitle>{details_title}</DialogTitle>

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -455,8 +455,8 @@ fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
                                     </Button>
                                     <Dialog open=show_details>
                                         <DialogSurface>
-                                            <DialogBody attr:style="display: flex; max-width: 90vw;">
-                                                <Scrollbar style="max-height: 90vh;">
+                                            <DialogBody class="details-dialog">
+                                                <Scrollbar class="details-dialog-scrollarea">
                                                     <Flex vertical=true>
                                                         <DialogTitle>{details_title}</DialogTitle>
                                                         <ValuesTable values=subtype title="subtype" />

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -455,8 +455,8 @@ fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
                                     </Button>
                                     <Dialog open=show_details>
                                         <DialogSurface>
-                                            <DialogBody class="details-dialog-body">
-                                                <Scrollbar class="details-dialog-scrollarea">
+                                            <DialogBody class="resolved-service-details-dialog-body">
+                                                <Scrollbar class="resolved-service-details-dialog-scrollarea">
                                                     <Flex vertical=true>
                                                         <DialogTitle>{details_title}</DialogTitle>
                                                         <ValuesTable values=subtype title="subtype" />

--- a/styles.css
+++ b/styles.css
@@ -69,3 +69,11 @@ body {
     outline: 1px solid var(--colorTransparentStroke);
 }
 
+.details-dialog-body {
+    display: flex;
+    max-width: 90vw;
+}
+
+.details-dialog-scrollarea {
+    max-height: 90vh;
+}

--- a/styles.css
+++ b/styles.css
@@ -69,11 +69,11 @@ body {
     outline: 1px solid var(--colorTransparentStroke);
 }
 
-.details-dialog-body {
+.resolved-service-details-dialog-body {
     display: flex;
     max-width: 90vw;
 }
 
-.details-dialog-scrollarea {
+.resolved-service-details-dialog-scrollarea {
     max-height: 90vh;
 }


### PR DESCRIPTION
#Closes #862

## Summary by Sourcery

Enhancements:
- Move inline styles for dialog body and scrollbar to dedicated CSS classes for improved maintainability and separation of concerns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Transitioned from inline styling to a class-based approach for the service detail view.
  - Enhanced layout consistency and responsiveness for dialog elements through updated CSS styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->