### PR TITLE
chore(void-package): Fix typo in XBPS_ALLOW_RESTRICTED

### DIFF
--- a/.github/workflows/void-linux-package.yml
+++ b/.github/workflows/void-linux-package.yml
@@ -6,7 +6,7 @@ on:
       - "mdns-browser-v*"
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  XBPS_LLOW_RESTRICTED: yes
+  XBPS_ALLOW_RESTRICTED: yes
   XBPS_CHROOT_CMD: ethereal
   XBPS_ALLOW_CHROOT_BREAKOUT: yes
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Corrected the spelling of XBPS_ALLOW_RESTRICTED environment variable in the Void Linux package workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
  - Corrected the build configuration for Void Linux packages to ensure proper handling of restricted packages during the publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->