### PR TITLE
chore(void-package): Publish x86_64-repodata, too

### DIFF
--- a/.github/workflows/void-linux-package.yml
+++ b/.github/workflows/void-linux-package.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           subject-path: |
             ~/void-packages/hostdir/binpkgs/*.xbps
+            ~/void-packages/hostdir/binpkgs/x86_64-repodata
 
       - name: 🚀 Publish
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
@@ -78,3 +79,4 @@ jobs:
           generate_release_notes: false
           files: |
             /github/home/void-packages/hostdir/binpkgs/mdns-browser-${{ steps.get-version.outputs.current-version }}_1.x86_64.xbps
+            /github/home/void-packages/hostdir/binpkgs/x86_64-repodata


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add x86_64-repodata to the artifact upload and release process in the Void Linux package workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the Void Linux package build and release process to include additional repository metadata, ensuring more comprehensive package validation and enriched release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->