### PR TITLE
chore(void-package): Speed up building by prebuilding build dependencies

### DIFF
--- a/.github/docker/mdns-browser-void-package-builder/Dockerfile
+++ b/.github/docker/mdns-browser-void-package-builder/Dockerfile
@@ -3,6 +3,13 @@ RUN xbps-install -Syu || xbps-install -yu xbps \
     && xbps-install -yu \
     && xbps-install -y bash git rustup base-devel curl jq util-linux coreutils binutils bsdtar findutils \
     && xbps-remove -Ooy
+RUN rustup-init -y -q \
+    && . $HOME/.cargo/env \
+    && rustup target add wasm32-unknown-unknown \
+    && cargo --locked install trunk@0.21.12 --no-default-features --features rustls \
+    && cargo --locked install tauri-cli@2.4.0 \
+    && cargo --locked install cargo-auditable@0.6.6 \
+    && rm -rf $HOME/.cargo/registry $HOME/.cargo/git
 LABEL org.opencontainers.image.source="https://github.com/hrzlgnm/mdns-browser"
 LABEL org.opencontainers.image.title="mDNS-Browser Void Package Builder"
 LABEL org.opencontainers.image.base.name="ghcr.io/void-linux/void-glibc"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,7 +39,7 @@
             matchStringsStrategy: 'any',
             customType: 'regex',
             fileMatch: [
-                'xbps-template/srcpkgs/template',
+                '^\\.github/docker/**/Dockerfile$',
             ],
             matchStrings: [
                 'cargo.*install (?<depName>\\S+)@(?<currentValue>\\S+)'

--- a/xbps-template/srcpkgs/template
+++ b/xbps-template/srcpkgs/template
@@ -15,12 +15,7 @@ distfiles="https://github.com/hrzlgnm/mdns-browser/archive/${pkgname}-v${version
 checksum=placeholder
 
 do_build() {
-    rustup-init -y -q
     . $HOME/.cargo/env
-    rustup target add wasm32-unknown-unknown
-    cargo --locked install trunk@0.21.12 --no-default-features --features=rustls
-    cargo --locked install tauri-cli@2.4.0
-    cargo --locked install cargo-auditable@0.6.6
     cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
     cargo fetch --locked --target wasm32-unknown-unknown
     cargo --locked auditable tauri build -b deb || true


### PR DESCRIPTION
## Summary by Sourcery

Optimize the Docker build process for the mDNS-Browser Void Package Builder by preinstalling Rust toolchain and build dependencies

Build:
- Add Rust toolchain initialization with specific target and tool installations in the Dockerfile

Chores:
- Enhance Docker build image by preinstalling specific Rust tools and dependencies to speed up subsequent builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the build process with a more consistent setup for essential toolchains, ensuring stable, reliable builds.
  - Expanded automated dependency checks to cover a broader range of configuration files for improved maintenance.
  - Streamlined build steps by removing redundant operations, resulting in more efficient build times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->