### PR TITLE
docs: add command line options documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Options:
 If enabled, a log file will be created in a platform specific location:
 
 - Windows: `%LOCALAPPDATA%\com.github.hrzlgnm.mdns-browser\logs`
-- Linux: `$XDG_DATA_HOME/com.github.hrzlgnm.mdns_browser/logs` or `$HOME/.local/share/com.github.hrzlgnm.mdns-browser/logs`
-- MacOS: `~/Library/Logs/com.github.hrzlgnm.mdns_browser`
+- Linux: `$XDG_DATA_HOME/com.github.hrzlgnm.mdns-browser/logs` or `$HOME/.local/share/com.github.hrzlgnm.mdns-browser/logs`
+- MacOS: `~/Library/Logs/com.github.hrzlgnm.mdns-browser`
 
 See [Persisting logs](https://v2.tauri.app/plugin/logging/#persisting-logs) section of the documentation for the tuari plugin logging for more details.
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ If enabled, a log file will be created in a platform specific location:
 - Linux: `$XDG_DATA_HOME/com.github.hrzlgnm.mdns-browser/logs` or `$HOME/.local/share/com.github.hrzlgnm.mdns-browser/logs`
 - MacOS: `~/Library/Logs/com.github.hrzlgnm.mdns-browser`
 
-See [Persisting logs](https://v2.tauri.app/plugin/logging/#persisting-logs) section of the documentation for the tuari plugin logging for more details.
-
 The log file will be named `mdns-browser.log` and will contain log messages with a log-level having at least a level specified by the `log-level` option.
 
 ## Where to find the executables?

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Screenshots from [v0.9.5](https://github.com/hrzlgnm/mdns-browser/releases/tag/m
 
 - [mDNS-Browser Overview](#mdns-browser)
   - [How to Build](#building)
+  - [Command line options](#command-line-options)
   - [Where to find the executables?](#where-to-find-the-executables)
     - [GitHub Release](#github-releases)
     - [Winget Installation](#winget-installation)
@@ -49,6 +50,29 @@ Screenshots from [v0.9.5](https://github.com/hrzlgnm/mdns-browser/releases/tag/m
 ## Building
 
 For instructions on building the application, checkout the document [BUILDING](BUILDING.md).
+
+## Command line options
+
+```
+Usage: mdns-browser [OPTIONS]
+
+Options:
+  -l, --log-level <LOG_LEVEL>  [default: info] [possible values: trace, debug, info, warn, error]
+  -f, --log-to-file            Enable logging to file
+  -h, --help                   Print help
+```
+
+### log-to-file
+
+If enabled, a log file will be created in a platform specific location:
+
+- Windows: `%LOCALAPPDATA%\com.github.hrzlgnm.mdns-browser\logs`
+- Linux: `$XDG_DATA_HOME/com.github.hrzlgnm.mdns_browser/logs` or `$HOME/.local/share/com.github.hrzlgnm.mdns-browser/logs`
+- MacOS: `~/Library/Logs/com.github.hrzlgnm.mdns_browser`
+
+See [Persisting logs](https://v2.tauri.app/plugin/logging/#persisting-logs) section of the documentation for the tuari plugin logging for more details.
+
+The log file will be named `mdns-browser.log` and will contain log messages with a log-level having at least a level specified by the `log-level` option.
 
 ## Where to find the executables?
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For instructions on building the application, checkout the document [BUILDING](B
 
 ## Command line options
 
-```
+```console
 Usage: mdns-browser [OPTIONS]
 
 Options:
@@ -64,11 +64,11 @@ Options:
 
 ### log-to-file
 
-If enabled, a log file will be created in a platform specific location:
+If enabled, a log file will be created in a platform-specific location:
 
 - Windows: `%LOCALAPPDATA%\com.github.hrzlgnm.mdns-browser\logs`
 - Linux: `$XDG_DATA_HOME/com.github.hrzlgnm.mdns-browser/logs` or `$HOME/.local/share/com.github.hrzlgnm.mdns-browser/logs`
-- MacOS: `~/Library/Logs/com.github.hrzlgnm.mdns-browser`
+- nacOS: `~/Library/Logs/com.github.hrzlgnm.mdns-browser`
 
 The log file will be named `mdns-browser.log` and will contain log messages with a log-level having at least a level specified by the `log-level` option.
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -292,9 +292,6 @@ fn x11_workaround() {
     match std::env::var(session_type_key) {
         Ok(val) => {
             if val == "x11" {
-                log::debug!(
-                    "Setting WEBKIT_DISABLE_DMABUF_RENDERER=1 to workaround rendering issues with x11 session"
-                );
                 std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1")
             }
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -292,7 +292,7 @@ fn x11_workaround() {
     match std::env::var(session_type_key) {
         Ok(val) => {
             if val == "x11" {
-                println!(
+                log::debug!(
                     "Setting WEBKIT_DISABLE_DMABUF_RENDERER=1 to workaround rendering issues with x11 session"
                 );
                 std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1")


### PR DESCRIPTION
Closes #915

## Summary by Sourcery

Documentation:
- Add a new section to the README detailing the available command line options for the mDNS-Browser application, including usage, log-level configuration, and log-to-file option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a “Command line options” section with clear instructions on how to utilize various CLI parameters, including options for setting logging levels, enabling file logging, and displaying help information.
  
- **Refactor**
  - Streamlined application output by removing an unnecessary console message, resulting in cleaner and more focused feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->