### PR TITLE
chore: ignore version bump in release drafter

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,4 +1,5 @@
 enhancement: ["feature/*", "feat/*"]
+ignore: ["bump/version*"]
 chore: ["chore/*"]
 refactor: ["refactor/*"]
 documentation: ["docs/*"]

--- a/.github/workflows/auto-bump-pr.yml
+++ b/.github/workflows/auto-bump-pr.yml
@@ -37,7 +37,7 @@ jobs:
           commit-message: "chore(version) : bump to ${{ env.new_version }}"
           sign-commits: true
           base: main
-          branch: chore/bump-version-${{ env.new_version }}
+          branch: bump/version-${{ env.new_version }}
           branch-suffix: random
           labels: |
             chore


### PR DESCRIPTION
## Summary by Sourcery

Modify release workflow to use a different branch naming convention and ignore version bump PRs in labeling

CI:
- Update auto-bump workflow to use 'bump/version-' prefix instead of 'chore/bump-version-'

Chores:
- Configure PR labeler to ignore version bump branches