### PR TITLE
chore: Use Swatinem/rust-cache for caching

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -53,6 +53,15 @@ jobs:
         with:
           targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android,wasm32-unknown-unknown
 
+      - name: 📦 Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+          workspaces: |
+            shared_constants -> ./target
+            models -> ./target
+            src-tauri -> ./target
+
       - name: 📝 Check spelling using typos-action
         uses: crate-ci/typos@b1a1ef3893ff35ade0cfa71523852a49bfd05d19 # v1.31.1
 

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -63,13 +63,14 @@ jobs:
           components: rustfmt, clippy
           targets: ${{ matrix.os == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin,wasm32-unknown-unknown' || 'wasm32-unknown-unknown' }}
 
-      - name: 🌍 Export GitHub Actions cache environment variables windows
-        if: contains(matrix.os, 'windows')
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+      - name: 📦 Rust cache
+        uses: Swatinem/rust-cache@v2
         with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+          workspaces: |
+            shared_constants -> ./target
+            models -> ./target
+            src-tauri -> ./target
 
       - name: 🛠️ Setup | Install dependencies
         if: matrix.install != ''


### PR DESCRIPTION
Closes: #924 

## Summary by Sourcery

Replace GitHub Actions cache environment variables with Swatinem/rust-cache for more efficient Rust build caching

CI:
- Update GitHub Actions workflows to use Swatinem/rust-cache for improved Rust build caching across desktop and Android workflows

Chores:
- Simplify caching configuration by replacing manual cache environment variable exports with a standardized Rust caching action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced build workflows with improved caching of Rust build artifacts.
  - Replaced legacy caching steps with a structured caching approach to potentially accelerate build times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->