### PR TITLE
feat: use async runtime instead of threads

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tauri-plugin-opener = "2.2.0"
 # local
 models = { path = "../models" }
 shared_constants = { path = "../shared_constants" }
+tokio = { version = "1.40.0", features = ["time"] }
 
 [lib]
 name = "mdns_browser_lib"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,6 @@ clap = { version = "4.5.19", features = ["derive"] }
 tauri-plugin-log = "2.0.0"
 tauri-plugin-updater = "2.0.1"
 thiserror = "2.0.0"
-tokio = "1.40.0"
 
 [dependencies]
 # crates
@@ -24,11 +23,11 @@ serde_json = "1.0.128"
 tauri = { version = "2.0.0", features = [] }
 tauri-plugin-clipboard-manager = "2.0.0"
 tauri-plugin-opener = "2.2.0"
+tokio = { version = "1.40.0", features = ["time"] }
 
 # local
 models = { path = "../models" }
 shared_constants = { path = "../shared_constants" }
-tokio = { version = "1.40.0", features = ["time"] }
 
 [lib]
 name = "mdns_browser_lib"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -249,7 +249,7 @@ fn subscribe_metrics(window: Window, state: State<ManagedState>) {
             loop {
                 tokio::time::sleep(METRICS_CHECK_INTERVAL).await;
                 if let Ok(metrics_receiver) = mdns_for_task.get_metrics() {
-                    if let Ok(metrics) = metrics_receiver.recv() {
+                    if let Ok(metrics) = metrics_receiver.recv_async().await {
                         if old_metrics != metrics {
                             emit_event(
                                 &window,


### PR DESCRIPTION
Closes #917

## Summary by Sourcery

Replace thread-based concurrency with async runtime in Tauri application

New Features:
- Implement async task spawning using tauri::async_runtime instead of std::thread::spawn

Enhancements:
- Migrate from std::thread to Tauri's async runtime for improved concurrency handling

Chores:
- Update concurrency mechanisms to use async/await syntax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Transitioned internal operations to an asynchronous model for handling service browsing and metric updates.
	- Switched from blocking operations to non-blocking asynchronous tasks, leading to improved responsiveness and smoother user interactions.
	- Updated the dependency for `tokio` to include the "time" feature, enhancing time-related functionalities within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->