### PR TITLE
chore: set auto bump label to ignore

### DIFF
--- a/.github/workflows/auto-bump-pr.yml
+++ b/.github/workflows/auto-bump-pr.yml
@@ -40,7 +40,7 @@ jobs:
           branch: bump/version-${{ env.new_version }}
           branch-suffix: random
           labels: |
-            chore
+            ignore
             automated pr
           delete-branch: true
           title: "chore(version): bump version to ${{ env.new_version }}"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the GitHub workflow label for auto-generated version bump pull requests from 'chore' to 'ignore'