### PR TITLE
Revert "chore(bundler): enable all desktop targets"

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -9,7 +9,13 @@
         "active": true,
         "licenseFile": "../LICENSE",
         "license": "MIT",
-        "targets": "all",
+        "targets": [
+            "app",
+            "deb",
+            "dmg",
+            "nsis",
+            "rpm"
+        ],
         "icon": [
             "icons/32x32.png",
             "icons/128x128.png",


### PR DESCRIPTION
Reverts hrzlgnm/mdns-browser#905
Currently only causes hassles with latest.json windows entry being overwritten by the msi installer...