### PR TITLE
feat: build macos bundle using universal-apple-darwin target

### DIFF
--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -23,12 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: "macos-latest" # for Arm based macs (M1 and above).
-            args: "--target aarch64-apple-darwin"
+          - os: "macos-latest"
+            args: "--target universal-apple-darwin"
             symbol: 🍏
-          - os: "macos-latest" # for Intel based macs.
-            args: "--target x86_64-apple-darwin"
-            symbol: 🍎
           - os: "ubuntu-22.04"
             symbol: 🐧
             install: |


### PR DESCRIPTION
## Summary by Sourcery

Modify macOS build workflow to use universal binary target for improved cross-architecture compatibility

Build:
- Replace separate builds for x86_64 and aarch64 macOS targets with a single universal-apple-darwin target

CI:
- Update GitHub Actions workflow to build a universal macOS binary that supports both Intel (x86_64) and Apple Silicon (ARM) architectures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Streamlined the macOS build configuration by consolidating architecture targets to support a universal build, enhancing the build process without altering public functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->