### PR TITLE
chore(attestation): Use correct path in SBOM attestation

### DIFF
--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -215,4 +215,4 @@ jobs:
             contains(matrix.os, 'windows') && 'target/release/mdns-browser.exe' ||
             contains(matrix.os, 'macos') && 'target/universal-apple-darwin/release/mdns-browser'
             }}
-          sbom-path: "sbom.spdx.json"
+          sbom-path: "${{ matrix.os }}${{ matrix.args }}.sbom.spdx.json"


### PR DESCRIPTION
## Summary by Sourcery

Update SBOM attestation path to use dynamic file naming based on matrix configuration

CI:
- Update desktop-tauri.yml workflow to use a more flexible SBOM file path generation

Chores:
- Modify GitHub workflow to generate SBOM file paths dynamically using matrix OS and arguments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the build configuration to dynamically generate uniquely named build artifacts based on operating system and configuration settings for better traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->