### PR TITLE
chore(ci): publish release assets checksums

### DIFF
--- a/.github/workflows/release-checksums.yml
+++ b/.github/workflows/release-checksums.yml
@@ -10,9 +10,11 @@ on:
     types: [published]
 
 jobs:
-  checksums:
-    name: checksums
+  sha256:
+    name: Generate sha256 checksums
     runs-on: ubuntu-24.04
+    outputs:
+      file: sha256sums.txt
     steps:
       - name: sha256
         uses: MCJack123/ghaction-generate-release-hashes@v4
@@ -20,14 +22,45 @@ jobs:
           get-assets: true
           hash-type: sha256
           file-name: sha256sums.txt
+      - name: Upload sha256 checksum
+        uses: actions/upload-artifact@v3
+        with:
+          name: sha256sums
+          path: sha256sums.txt
 
+  sha512:
+    name: Generate sha512 checksums
+    runs-on: ubuntu-24.04
+    outputs:
+      file: sha512sums.txt
+    steps:
       - name: sha512
         uses: MCJack123/ghaction-generate-release-hashes@v4
         with:
           get-assets: true
           hash-type: sha512
           file-name: sha512sums.txt
+      - name: Upload sha512 checksum
+        uses: actions/upload-artifact@v3
+        with:
+          name: sha512sums
+          path: sha512sums.txt
 
+  publish:
+    name: Publish checksum assets
+    runs-on: ubuntu-24.04
+    needs:
+      - sha256
+      - sha512
+    steps:
+      - name: Download sha256 checksum
+        uses: actions/download-artifact@v3
+        with:
+          name: sha256sums
+      - name: Download sha512 checksum
+        uses: actions/download-artifact@v3
+        with:
+          name: sha512sums
       - name: determine release name
         id: release_name
         run: |
@@ -36,7 +69,6 @@ jobs:
           else
             echo "RELEASE_NAME=mDNS-Browser Release v${{ github.event.inputs.semver }}" >> $GITHUB_ENV
           fi
-
       - name: publish checksum assets
         uses: softprops/action-gh-release@cfe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
         env:

--- a/.github/workflows/release-checksums.yml
+++ b/.github/workflows/release-checksums.yml
@@ -1,0 +1,51 @@
+name: Create and publish checksums for release artifacts
+on:
+  workflow_dispatch:
+    inputs:
+      semver:
+        description: The semver of the release to publish for
+        type: string
+        required: true
+  release:
+    types: [published]
+
+jobs:
+  checksums:
+    name: checksums
+    runs-on: ubuntu-24.04
+    steps:
+      - name: sha256
+        uses: MCJack123/ghaction-generate-release-hashes@v4
+        with:
+          get-assets: true
+          hash-type: sha256
+          file-name: sha256sums.txt
+
+      - name: sha512
+        uses: MCJack123/ghaction-generate-release-hashes@v4
+        with:
+          get-assets: true
+          hash-type: sha512
+          file-name: sha512sums.txt
+
+      - name: determine release name
+        id: release_name
+        run: |
+          if [ -n "${{ github.event.release.name }}" ]; then
+            echo "RELEASE_NAME=${{ github.event.release.name }}" >> $GITHUB_ENV
+          else
+            echo "RELEASE_NAME=mDNS-Browser Release v${{ github.event.inputs.semver }}" >> $GITHUB_ENV
+          fi
+
+      - name: publish checksum assets
+        uses: softprops/action-gh-release@cfe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ env.RELEASE_NAME }}
+          append_body: true
+          make_latest: false
+          generate_release_notes: false
+          files: |
+            sha256sums.txt
+            sha512sums.txt


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Create a new GitHub Actions workflow that generates SHA256 and SHA512 checksums for release assets and attaches them to the release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Now, release artifacts come with automatically generated checksum files, allowing users to verify the integrity and security of downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->