### PR TITLE
chore(ci): fix publish release assets download repository name

### DIFF
--- a/.github/workflows/release-checksums.yml
+++ b/.github/workflows/release-checksums.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: robinraju/release-downloader@v1.12
         with:
-          repository: "owner/repo"
+          repository: ${{ env.GITHUB_REPOSITORY }}
           latest: true
           fileName: "*"
       - name: sha256
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: robinraju/release-downloader@v1.12
         with:
-          repository: "owner/repo"
+          repository: ${{ env.GITHUB_REPOSITORY }}
           latest: true
           fileName: "*"
       - name: sha512


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Replace hardcoded repository name with a dynamic GitHub repository environment variable in release-checksums workflow