### PR TITLE
chore(ci): fix publish release assets permissions

### DIFF
--- a/.github/workflows/release-checksums.yml
+++ b/.github/workflows/release-checksums.yml
@@ -9,6 +9,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   release_name:
     name: Get release name


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update GitHub Actions workflow to explicitly set write permissions for release asset publishing