### PR TITLE
chore(ci): publish checksums on released event

### DIFF
--- a/.github/workflows/release-checksums.yml
+++ b/.github/workflows/release-checksums.yml
@@ -7,7 +7,7 @@ on:
         type: string
         required: true
   release:
-    types: [published]
+    types: [released]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Modify release-checksums workflow to use 'released' event type instead of 'published'