### PR TITLE
feat: Block browsing if no network interface is up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
  "objc2-foundation 0.3.0",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -1308,7 +1308,7 @@ dependencies = [
  "rustc_version",
  "toml",
  "vswhom",
- "winreg",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -1377,7 +1377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2637,10 +2637,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg 0.50.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is-docker"
@@ -3088,9 +3109,11 @@ name = "mdns-browser"
 version = "0.12.1"
 dependencies = [
  "clap",
+ "ipconfig",
  "log",
  "mdns-sd",
  "models",
+ "pnet",
  "serde",
  "serde_json",
  "shared_constants",
@@ -3281,6 +3304,12 @@ dependencies = [
  "libc",
  "memoffset",
 ]
+
+[[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "nodrop"
@@ -3963,6 +3992,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "pnet"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "682396b533413cc2e009fbb48aadf93619a149d3e57defba19ff50ce0201bd0d"
+dependencies = [
+ "ipnetwork",
+ "pnet_base",
+ "pnet_datalink",
+ "pnet_packet",
+ "pnet_sys",
+ "pnet_transport",
+]
+
+[[package]]
+name = "pnet_base"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc190d4067df16af3aba49b3b74c469e611cad6314676eaf1157f31aa0fb2f7"
+dependencies = [
+ "no-std-net",
+]
+
+[[package]]
+name = "pnet_datalink"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79e70ec0be163102a332e1d2d5586d362ad76b01cec86f830241f2b6452a7b7"
+dependencies = [
+ "ipnetwork",
+ "libc",
+ "pnet_base",
+ "pnet_sys",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_macros"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13325ac86ee1a80a480b0bc8e3d30c25d133616112bb16e86f712dcf8a71c863"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed67a952585d509dd0003049b1fc56b982ac665c8299b124b90ea2bdb3134ab"
+dependencies = [
+ "pnet_base",
+]
+
+[[package]]
+name = "pnet_packet"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c96ebadfab635fcc23036ba30a7d33a80c39e8461b8bd7dc7bb186acb96560f"
+dependencies = [
+ "glob",
+ "pnet_base",
+ "pnet_macros",
+ "pnet_macros_support",
+]
+
+[[package]]
+name = "pnet_sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_transport"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f604d98bc2a6591cf719b58d3203fd882bdd6bf1db696c4ac97978e9f4776bf"
+dependencies = [
+ "libc",
+ "pnet_base",
+ "pnet_packet",
+ "pnet_sys",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4223,7 +4343,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4643,7 +4763,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4656,7 +4776,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5746,7 +5866,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6662,6 +6782,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
+name = "widestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6683,7 +6809,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7155,6 +7281,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -156,6 +156,11 @@ pub struct ServiceRemovedEventRes {
     pub at_ms: u64,
 }
 
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct CanBrowseChangedEventRes {
+    pub can_browse: bool,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateMetadata {

--- a/shared_constants/src/lib.rs
+++ b/shared_constants/src/lib.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 pub const MDNS_SD_META_SERVICE: &str = "_services._dns-sd._udp.local.";
 pub const METRICS_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+pub const INTERFACES_CAN_BROWSE_CHECK_INTERVAL: Duration = Duration::from_millis(500);
 
 #[cfg(debug_assertions)]
 pub const SPLASH_SCREEN_DURATION: Duration = Duration::from_secs(0);

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [build-dependencies]
 tauri-build = { version = "2.0.0", features = [] }
 
-[target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
+[target.'cfg(not(any(target_os="android",target_os="ios")))'.dependencies]
 clap = { version = "4.5.19", features = ["derive"] }
 tauri-plugin-log = "2.0.0"
 tauri-plugin-updater = "2.0.1"
@@ -28,6 +28,13 @@ tokio = { version = "1.40.0", features = ["time"] }
 # local
 models = { path = "../models" }
 shared_constants = { path = "../shared_constants" }
+
+# platform-specific dependencies
+[target.'cfg(not(windows))'.dependencies]
+pnet = "0.35.0"
+
+[target.'cfg(windows)'.dependencies]
+ipconfig = "0.3.2"
 
 [lib]
 name = "mdns_browser_lib"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -304,8 +304,9 @@ fn subscribe_can_browse(window: Window, state: State<ManagedState>) {
             );
             loop {
                 tokio::time::sleep(INTERFACES_CAN_BROWSE_CHECK_INTERVAL).await;
-                if has_mcast_capable_itfs != has_multicast_capable_interfaces() {
-                    has_mcast_capable_itfs = has_multicast_capable_interfaces();
+                let current = has_multicast_capable_interfaces();
+                if has_mcast_capable_itfs != current {
+                    has_mcast_capable_itfs = current;
                     emit_event(
                         &window,
                         "can-browse-changed",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,9 +5,14 @@ use clap::Parser;
 use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
 use models::check_service_type_fully_qualified;
 use models::*;
+#[cfg(not(windows))]
+use pnet::datalink;
 #[cfg(all(desktop, not(debug_assertions)))]
 use shared_constants::SPLASH_SCREEN_DURATION;
-use shared_constants::{MDNS_SD_META_SERVICE, METRICS_CHECK_INTERVAL, VERIFY_TIMEOUT};
+use shared_constants::{
+    INTERFACES_CAN_BROWSE_CHECK_INTERVAL, MDNS_SD_META_SERVICE, METRICS_CHECK_INTERVAL,
+    VERIFY_TIMEOUT,
+};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     collections::HashMap,
@@ -28,6 +33,7 @@ struct ManagedState {
     daemon: SharedServiceDaemon,
     running_browsers: Arc<Mutex<Vec<String>>>,
     metrics_subscribed: AtomicBool,
+    can_browse_subscribed: AtomicBool,
 }
 
 impl ManagedState {
@@ -36,6 +42,7 @@ impl ManagedState {
             daemon: get_shared_daemon(),
             running_browsers: Arc::new(Mutex::new(Vec::new())),
             metrics_subscribed: AtomicBool::new(false),
+            can_browse_subscribed: AtomicBool::new(false),
         }
     }
 }
@@ -243,6 +250,80 @@ fn browse_many(service_types: Vec<String>, window: Window, state: State<ManagedS
                 }
             }
         }
+    }
+}
+
+#[cfg(not(windows))]
+fn has_multicast_capable_interfaces() -> bool {
+    let interfaces = datalink::interfaces();
+    interfaces.iter().any(|interface| {
+        let capable = !interface.ips.is_empty()
+            && !interface.is_loopback()
+            && interface.is_multicast()
+            && interface.is_up();
+        log::trace!("interface {} can multicast {}", interface.name, capable);
+
+        capable
+    })
+}
+
+#[cfg(windows)]
+fn has_multicast_capable_interfaces() -> bool {
+    use ipconfig::{IfType, OperStatus};
+
+    if let Ok(adapters) = ipconfig::get_adapters() {
+        adapters.iter().any(|adapter| {
+            let capable = !adapter.ip_addresses().is_empty()
+                && adapter.oper_status() == OperStatus::IfOperStatusUp
+                && (adapter.if_type() == IfType::EthernetCsmacd || adapter.if_type() == IfType::Ieee80211);
+            log::trace!("adapter {} can multicast {}, {:?}", adapter.friendly_name(), capable, adapter.if_type());
+
+            capable
+        })
+    } else {
+        log::warn!("Unable to determine whether we have multicast capable adapter, assuming true");
+        true
+    }
+}
+
+#[tauri::command]
+fn subscribe_can_browse(window: Window, state: State<ManagedState>) {
+    if state
+        .can_browse_subscribed
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        tauri::async_runtime::spawn(async move {
+            let mut has_mcast_capable_itfs = has_multicast_capable_interfaces();
+            emit_event(
+                &window,
+                "can-browse-changed",
+                &CanBrowseChangedEventRes {
+                    can_browse: has_mcast_capable_itfs,
+                },
+            );
+            loop {
+                tokio::time::sleep(INTERFACES_CAN_BROWSE_CHECK_INTERVAL).await;
+                if has_mcast_capable_itfs != has_multicast_capable_interfaces() {
+                    has_mcast_capable_itfs = has_multicast_capable_interfaces();
+                    emit_event(
+                        &window,
+                        "can-browse-changed",
+                        &CanBrowseChangedEventRes {
+                            can_browse: has_mcast_capable_itfs,
+                        },
+                    );
+                }
+            }
+        });
+    } else {
+        emit_event(
+            &window,
+            "can-browse-changed",
+            &CanBrowseChangedEventRes {
+                can_browse: has_multicast_capable_interfaces(),
+            },
+        );
     }
 }
 
@@ -610,6 +691,7 @@ pub fn run() {
             copy_to_clipboard,
             is_desktop,
             open_url,
+            subscribe_can_browse,
             subscribe_metrics,
             stop_browse,
             verify,
@@ -632,6 +714,7 @@ pub fn run_mobile() {
             copy_to_clipboard,
             is_desktop,
             open_url,
+            subscribe_can_browse,
             subscribe_metrics,
             stop_browse,
             verify,


### PR DESCRIPTION
Closes #978 
## Summary by Sourcery

Implement network interface detection to block browsing when no multicast-capable network interface is available

New Features:
- Add capability to detect and monitor network interfaces for multicast support across different platforms (Windows and non-Windows)

Bug Fixes:
- Prevent network browsing attempts when no active network interfaces are available

Enhancements:
- Introduce a mechanism to dynamically check network interface status and prevent browsing when no suitable network interface is detected

Documentation:
- Add user-facing warning message when no network interfaces are detected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented real-time network browsing capability detection to automatically update the user interface.
  - Introduced periodic background checks that enable or disable the browse button based on network interface availability.
  - Added contextual notifications to inform users when no suitable network interfaces are present.
  - Enhanced cross-platform support to ensure a smooth network browsing experience across different operating systems.
  - Introduced a new structure for handling browsing capability events.
  - Added a new timing configuration for browsing interface checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->