### PR TITLE
chore(ci): Don't ask for confirmation in CI

### DIFF
--- a/.github/workflows/publish-arch-linux-aur.yml
+++ b/.github/workflows/publish-arch-linux-aur.yml
@@ -94,7 +94,7 @@ jobs:
             fi
             makepkg --printsrcinfo > .SRCINFO
             makepkg
-            makepkg --install
+            makepkg --install --noconfirm
             git config user.name "hrzlgnm"
             git config user.email "hrzlgnm@users.noreply.github.com"
             git add PKGBUILD .SRCINFO


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add --noconfirm flag to makepkg installation step to suppress interactive prompts during CI package installation