### PR TITLE
Improve handling of network status changes

### DIFF
--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -653,6 +653,7 @@ enum SortKind {
 fn start_auto_focus_timer(
     comp_ref: impl Fn() -> Option<AutoCompleteRef> + 'static,
     tutorial_timeout: impl FnOnce(Option<TimeoutHandle>) + 'static,
+    duration: std::time::Duration,
 ) {
     spawn_local(async move {
         if let Ok(h) = set_timeout_with_handle(
@@ -661,7 +662,7 @@ fn start_auto_focus_timer(
                     comp.focus();
                 }
             },
-            SPLASH_SCREEN_DURATION + AUTO_COMPLETE_AUTO_FOCUS_DELAY,
+            duration,
         ) {
             tutorial_timeout(Some(h));
         }
@@ -799,6 +800,7 @@ pub fn Browse() -> impl IntoView {
             move |h| {
                 tutorial_timeout.set_value(h);
             },
+            SPLASH_SCREEN_DURATION + AUTO_COMPLETE_AUTO_FOCUS_DELAY,
         );
     });
 
@@ -829,6 +831,7 @@ pub fn Browse() -> impl IntoView {
             move |h| {
                 tutorial_timeout.set_value(h);
             },
+            AUTO_COMPLETE_AUTO_FOCUS_DELAY,
         );
     };
 
@@ -843,6 +846,7 @@ pub fn Browse() -> impl IntoView {
                     move |h| {
                         tutorial_timeout.set_value(h);
                     },
+                    AUTO_COMPLETE_AUTO_FOCUS_DELAY,
                 );
             } else {
                 clear_tutorial_timer();

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -650,6 +650,24 @@ enum SortKind {
     TimestampDesc,
 }
 
+fn start_auto_focus_timer(
+    comp_ref: impl Fn() -> Option<AutoCompleteRef> + 'static,
+    tutorial_timeout: impl FnOnce(Option<TimeoutHandle>) + 'static,
+) {
+    spawn_local(async move {
+        if let Ok(h) = set_timeout_with_handle(
+            move || {
+                if let Some(comp) = comp_ref() {
+                    comp.focus();
+                }
+            },
+            SPLASH_SCREEN_DURATION + AUTO_COMPLETE_AUTO_FOCUS_DELAY,
+        ) {
+            tutorial_timeout(Some(h));
+        }
+    });
+}
+
 /// Renders the main browsing interface for network services.
 ///
 /// This component sets up reactive state and event listeners to manage service discovery and browsing.
@@ -727,6 +745,8 @@ pub fn Browse() -> impl IntoView {
             && check_service_type_fully_qualified(service_type.get().clone().as_str()).is_err()
     });
 
+    let browsing_or_cannot_browse = Signal::derive(move || browsing.get() || !can_browse.get());
+
     let browsing_or_service_type_invalid_or_cannot_browse =
         Signal::derive(move || !can_browse.get() || browsing.get() || service_type_invalid.get());
 
@@ -774,18 +794,12 @@ pub fn Browse() -> impl IntoView {
     Effect::new(move |_| {
         // Set a timeout to focus the autocomplete after splash screen
         // This is part of the tutorial timer that should be stopped on user interaction
-        spawn_local(async move {
-            if let Ok(h) = set_timeout_with_handle(
-                move || {
-                    if let Some(comp) = comp_ref.get_untracked() {
-                        comp.focus();
-                    }
-                },
-                SPLASH_SCREEN_DURATION + AUTO_COMPLETE_AUTO_FOCUS_DELAY,
-            ) {
-                tutorial_timeout.set_value(Some(h));
-            }
-        });
+        start_auto_focus_timer(
+            move || comp_ref.get_untracked(),
+            move |h| {
+                tutorial_timeout.set_value(h);
+            },
+        );
     });
 
     let on_quick_filter_focus = move |_| {
@@ -810,26 +824,32 @@ pub fn Browse() -> impl IntoView {
         browsing.set(false);
         stop_browsing_action.dispatch(());
         service_type.set(String::new());
-        if let Some(comp) = comp_ref.get_untracked() {
-            comp.focus();
-        }
+        start_auto_focus_timer(
+            move || comp_ref.get_untracked(),
+            move |h| {
+                tutorial_timeout.set_value(h);
+            },
+        );
     };
 
     Effect::watch(
         move || can_browse.get(),
         move |can_browse, previous_can_browse, _| {
             if *can_browse && !previous_can_browse.unwrap_or(&false) {
-                set_resolved.set(Vec::new());
                 service_type.set(String::new());
-                browsing.set(false);
                 spawn_local(invoke_no_args("browse_types"));
+                start_auto_focus_timer(
+                    move || comp_ref.get_untracked(),
+                    move |h| {
+                        tutorial_timeout.set_value(h);
+                    },
+                );
             } else {
+                clear_tutorial_timer();
+                set_service_types.set(Vec::new());
                 browsing.set(false);
                 stop_browsing_action.dispatch(());
                 service_type.set(String::new());
-                if let Some(comp) = comp_ref.get_untracked() {
-                    comp.focus();
-                }
             }
         },
         false,
@@ -866,7 +886,7 @@ pub fn Browse() -> impl IntoView {
                     <AutoCompleteServiceType
                         invalid=service_type_invalid
                         value=service_type
-                        disabled=browsing
+                        disabled=browsing_or_cannot_browse
                         comp_ref=comp_ref
                     />
                     <Button


### PR DESCRIPTION
Preview resolved services are not cleared anymore when the network comes back after it was detected as being absent.
Restart the auto focus tutorial timer when the network comes online.

Closes 995

## Summary by Sourcery

Improve network status change handling in the browse component, addressing service discovery and auto-focus behavior

New Features:
- Add a new function to start auto-focus timer with more flexible handling

Bug Fixes:
- Prevent clearing of resolved services when network is restored
- Restart auto-focus tutorial timer when network comes online

Enhancements:
- Refactor auto-focus timer logic into a reusable function
- Improve handling of network status changes in the browse component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Autocomplete input is now automatically focused after splash and delay, improving usability.
  - Autocomplete input is disabled when browsing is active or not allowed, providing clearer feedback.
  - Browsing state transitions and tutorial timers are handled more smoothly for a better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->