### PR TITLE
docs: Document new command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,12 @@ For instructions on building the application, checkout the document [BUILDING](B
 Usage: mdns-browser [OPTIONS]
 
 Options:
-  -l, --log-level <LOG_LEVEL>  [default: info] [possible values: trace, debug, info, warn, error]
-  -f, --log-to-file            Enable logging to file
-  -h, --help                   Print help
+  -l, --log-level <LOG_LEVEL>    [default: info] [possible values: trace, debug, info, warn, error]
+  -f, --log-to-file              Enable logging to file
+  -d, --disable-dmabuf-renderer  Disable dmabuf renderer, useful when having rendering issues
+  -h, --help                     Print help
+  -V, --version                  Print version
+
 ```
 
 ### log-to-file
@@ -68,9 +71,14 @@ If enabled, a log file will be created in a platform-specific location:
 
 - Windows: `%LOCALAPPDATA%\com.github.hrzlgnm.mdns-browser\logs`
 - Linux: `$XDG_DATA_HOME/com.github.hrzlgnm.mdns-browser/logs` or `$HOME/.local/share/com.github.hrzlgnm.mdns-browser/logs`
-- nacOS: `~/Library/Logs/com.github.hrzlgnm.mdns-browser`
+- macOS: `~/Library/Logs/com.github.hrzlgnm.mdns-browser`
 
 The log file will be named `mdns-browser.log` and will contain log messages with a log-level having at least a level specified by the `log-level` option.
+
+### disable-dmabuf-renderer (Linux only)
+
+This option disables the dmabuf renderer, which is used to improve performance on Linux.
+If you experience rendering issues, you can try disabling this option to see if it resolves the problem.
 
 ## Where to find the executables?
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The log file will be named `mdns-browser.log` and will contain log messages with
 This option disables the dmabuf renderer, which is used to improve performance on Linux.
 If you experience rendering issues, you can try disabling this option to see if it resolves the problem.
 
+This option has been added with release [v0.12.0](https://github.com/hrzlgnm/mdns-browser/releases/tag/mdns-browser-v0.12.0)
+
 ## Where to find the executables?
 
 ### GitHub Releases


### PR DESCRIPTION
Closes #997 

## Summary by Sourcery

Update documentation to describe new command line options for the application

New Features:
- Add a new command line option `--disable-dmabuf-renderer` to allow users to disable the dmabuf renderer on Linux
- Add a version print option `--version` to the command line interface

Documentation:
- Add documentation for a new command line option to disable dmabuf renderer
- Fix a typo in the macOS log path description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to document new command line options for disabling the dmabuf renderer (Linux only) and displaying the application version.
  - Clarified the log file location for macOS.
  - Improved formatting and fixed minor typos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->