### PR TITLE
chrore(renovate): tweak renovate settings

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,20 @@
     prConcurrentLimit: 0,
     lockFileMaintenance: {
         enabled: true,
+        schedule: ["on the first day of the month"]
     },
+    packageRules: [
+        {
+            matchPackagePrefixes: ['tauri'],
+            automerge: true,
+            automergeType: 'branch',
+            automergeSchedule: ['at any time'],
+            prCreation: 'not-pending',
+            delayAutomerge: true,
+            automergeDelay: '5 days',
+            matchUpdateTypes: ['minor', 'patch']
+        }
+    ],
     customManagers: [
         {
             matchStringsStrategy: 'any',


### PR DESCRIPTION
- Set auto merge delay for crates having a prefix `tauri` to 5 days
- Tweak lockFileMaintenance schedule to on the first day of the month

## Summary by Sourcery

Update Renovate configuration to adjust auto-merge settings and maintenance schedule

Chores:
- Modify Renovate settings to extend auto-merge delay for Tauri-related crates
- Adjust lock file maintenance to run on the first day of each month