### PR TITLE
feat: add number of displayed / total services badge

### DIFF
--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -10,11 +10,11 @@ use strsim::jaro_winkler;
 use tauri_sys::core::invoke;
 use tauri_sys::event::listen;
 use thaw::{
-    AutoComplete, AutoCompleteOption, AutoCompleteRef, AutoCompleteSize, Button, ButtonAppearance,
-    ButtonSize, Card, CardHeader, CardPreview, ComponentRef, Dialog, DialogBody, DialogSurface,
-    DialogTitle, Flex, FlexAlign, FlexGap, FlexJustify, Grid, GridItem, Input, Layout, MessageBar,
-    MessageBarBody, MessageBarIntent, MessageBarTitle, Scrollbar, Select, Table, TableBody,
-    TableCell, TableRow, Text, TextTag,
+    AutoComplete, AutoCompleteOption, AutoCompleteRef, AutoCompleteSize, Badge, BadgeAppearance,
+    BadgeColor, BadgeSize, Button, ButtonAppearance, ButtonSize, Card, CardHeader, CardPreview,
+    ComponentRef, Dialog, DialogBody, DialogSurface, DialogTitle, Flex, FlexAlign, FlexGap,
+    FlexJustify, Grid, GridItem, Input, Layout, MessageBar, MessageBarBody, MessageBarIntent,
+    MessageBarTitle, Scrollbar, Select, Table, TableBody, TableCell, TableRow, Text, TextTag,
 };
 use thaw_utils::Model;
 
@@ -926,6 +926,21 @@ pub fn Browse() -> impl IntoView {
                         class=input_class
                         on_focus=on_quick_filter_focus
                     />
+                    <Badge
+                        appearance=BadgeAppearance::Tint
+                        size=BadgeSize::Large
+                        color=BadgeColor::Subtle
+                    >
+                        {{
+                            move || {
+                                format!(
+                                    "{} / {}",
+                                    filtered_services.get().len(),
+                                    resolved.get().len(),
+                                )
+                            }
+                        }}
+                    </Badge>
                 </Flex>
             </Flex>
             <Grid class=grid_class>


### PR DESCRIPTION
Closes #1022

## Summary by Sourcery

New Features:
- Introduce a badge that shows the count of filtered services compared to the total number of services in the browse interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a badge next to the quick filter input that dynamically displays the current count of filtered services over the total number of services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->