### PR TITLE
fix: move counter badge next to stop button

### DIFF
--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -907,6 +907,21 @@ pub fn Browse() -> impl IntoView {
                     >
                         "Stop"
                     </Button>
+                    <Badge
+                        appearance=BadgeAppearance::Tint
+                        size=BadgeSize::Large
+                        color=BadgeColor::Subtle
+                    >
+                        {{
+                            move || {
+                                format!(
+                                    "{} / {}",
+                                    filtered_services.get().len(),
+                                    resolved.get().len(),
+                                )
+                            }
+                        }}
+                    </Badge>
                 </Flex>
                 <Flex gap=FlexGap::Small align=FlexAlign::Center justify=FlexJustify::Start>
                     <Text>"Sort by"</Text>
@@ -926,21 +941,6 @@ pub fn Browse() -> impl IntoView {
                         class=input_class
                         on_focus=on_quick_filter_focus
                     />
-                    <Badge
-                        appearance=BadgeAppearance::Tint
-                        size=BadgeSize::Large
-                        color=BadgeColor::Subtle
-                    >
-                        {{
-                            move || {
-                                format!(
-                                    "{} / {}",
-                                    filtered_services.get().len(),
-                                    resolved.get().len(),
-                                )
-                            }
-                        }}
-                    </Badge>
                 </Flex>
             </Flex>
             <Grid class=grid_class>


### PR DESCRIPTION
otherwise the badge is shown partly cut off on android

## Summary by Sourcery

Bug Fixes:
- Resolved visual issue where the badge was partially cut off on Android devices by repositioning it next to the stop button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Moved the service count badge to appear next to the "Browse" and "Stop" buttons for improved visibility. The badge's appearance and displayed information remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->