### PR TITLE
chore: cleanup workflows

### DIFF
--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -17,4 +17,3 @@ jobs:
     with:
       tagName: mdns-browser-v__VERSION__
       releaseName: "mDNS-Browser Release v__VERSION__"
-      releaseBody: "See the assets to download this version and install."

--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -6,9 +6,6 @@ on:
       tagName:
         required: false
         type: string
-      releaseBody:
-        required: false
-        type: string
       releaseName:
         required: false
         type: string
@@ -31,7 +28,7 @@ jobs:
             symbol: 🐧
             install: |
               sudo apt-get update
-              sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf python3-pip
+              sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
             platform: Linux
           - os: "windows-latest"
             symbol: 🪟
@@ -155,7 +152,6 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         with:
           tagName: ${{ inputs.tagName }}
-          releaseBody: ${{ inputs.releaseBody }}
           releaseName: ${{ inputs.releaseName }}
           releaseDraft: false
           prerelease: false


### PR DESCRIPTION
- remove python3-pip requirement
- remove optional releaseBody input to tauri-apps/tauri-action

## Summary by Sourcery

Clean up GitHub Actions workflows by removing unnecessary inputs and dependencies

CI:
- Simplified workflow configuration by removing redundant inputs and package installations

Chores:
- Remove optional releaseBody input from Tauri GitHub Action workflow
- Remove python3-pip package from Linux installation dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configurations by removing the release description field from the publishing process.
	- Adjusted Linux runner setup by omitting installation of an unnecessary package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->