### PR TITLE
bugfix: properly determine the instance name

### DIFF
--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -457,7 +457,36 @@ mod tests {
         assert!(service.dead);
         assert_eq!(service.updated_at_ms, 0);
     }
+    #[test]
+    fn test_get_instance_name() {
+        // Test with standard service name format
+        let service = ResolvedService {
+            instance_fullname: "My Service._http._tcp.local".to_string(),
+            service_type: "_http._tcp.local".to_string(),
+            hostname: "hostname.local".to_string(),
+            port: 80,
+            addresses: vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))],
+            subtype: None,
+            txt: vec![],
+            updated_at_ms: 0,
+            dead: false,
+        };
+        assert_eq!(service.get_instance_name(), "My Service");
 
+        // Test with dot in the instance name
+        let service = ResolvedService {
+            instance_fullname: "My.Complex.Service._http._tcp.local".to_string(),
+            service_type: "_http._tcp.local".to_string(),
+            hostname: "hostname.local".to_string(),
+            port: 80,
+            addresses: vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))],
+            subtype: None,
+            txt: vec![],
+            updated_at_ms: 0,
+            dead: false,
+        };
+        assert_eq!(service.get_instance_name(), "My.Complex.Service");
+    }
     #[test]
     fn test_matches_query() {
         let service = ResolvedService {

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -31,7 +31,7 @@ impl TxtRecord {
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedService {
-    pub instance_name: String,
+    pub instance_fullname: String,
     pub service_type: String,
     pub hostname: String,
     pub port: u16,
@@ -43,6 +43,15 @@ pub struct ResolvedService {
 }
 
 impl ResolvedService {
+    pub fn get_instance_name(&self) -> String {
+        self.instance_fullname
+            .strip_suffix(&self.service_type)
+            .unwrap_or(&self.instance_fullname)
+            .strip_suffix('.')
+            .unwrap_or(&self.instance_fullname)
+            .to_string()
+    }
+
     pub fn die_at(&mut self, at_ms: u64) {
         self.dead = true;
         self.updated_at_ms = at_ms;
@@ -52,7 +61,7 @@ impl ResolvedService {
         if query.is_empty() {
             return true;
         }
-        self.instance_name.to_lowercase().contains(&query)
+        self.instance_fullname.to_lowercase().contains(&query)
             || self.service_type.to_lowercase().contains(&query)
             || self.hostname.to_lowercase().contains(&query)
             || self.port.to_string().contains(&query)
@@ -353,7 +362,7 @@ mod tests {
 
         // Act
         let service = ResolvedService {
-            instance_name: instance_name.clone(),
+            instance_fullname: instance_name.clone(),
             service_type: service_type.clone(),
             hostname: hostname.clone(),
             port,
@@ -365,7 +374,7 @@ mod tests {
         };
 
         // Assert
-        assert_eq!(service.instance_name, instance_name);
+        assert_eq!(service.instance_fullname, instance_name);
         assert_eq!(service.service_type, service_type);
         assert_eq!(service.hostname, hostname);
         assert_eq!(service.port, port);
@@ -380,7 +389,7 @@ mod tests {
     fn test_die_at_method() {
         // Arrange
         let mut service = ResolvedService {
-            instance_name: "test_service".to_string(),
+            instance_fullname: "test_service".to_string(),
             service_type: "_banan._tcp.local.".to_string(),
             hostname: "test.local".to_string(),
             port: 8080,
@@ -405,7 +414,7 @@ mod tests {
     fn test_die_at_when_already_dead() {
         // Arrange
         let mut service = ResolvedService {
-            instance_name: "test_service".to_string(),
+            instance_fullname: "test_service".to_string(),
             service_type: "_banan._tcp.local.".to_string(),
             hostname: "test.local".to_string(),
             port: 8080,
@@ -430,7 +439,7 @@ mod tests {
     fn test_die_at_with_boundary_timestamp() {
         // Arrange
         let mut service = ResolvedService {
-            instance_name: "test_service".to_string(),
+            instance_fullname: "test_service".to_string(),
             service_type: "_banan._tcp.local.".to_string(),
             hostname: "test.local".to_string(),
             port: 8080,
@@ -452,7 +461,7 @@ mod tests {
     #[test]
     fn test_matches_query() {
         let service = ResolvedService {
-            instance_name: "MyService".to_string(),
+            instance_fullname: "MyService".to_string(),
             service_type: "_http._tcp".to_string(),
             hostname: "my-host.local".to_string(),
             port: 8080,
@@ -508,7 +517,7 @@ mod tests {
     #[test]
     fn test_matches_query_empty_fields() {
         let service = ResolvedService {
-            instance_name: "".to_string(),
+            instance_fullname: "".to_string(),
             service_type: "".to_string(),
             hostname: "".to_string(),
             port: 0,
@@ -526,7 +535,7 @@ mod tests {
     #[test]
     fn test_matches_query_partial_matches() {
         let service = ResolvedService {
-            instance_name: "MyService".to_string(),
+            instance_fullname: "MyService".to_string(),
             service_type: "_http._tcp".to_string(),
             hostname: "my-host.local".to_string(),
             port: 8080,

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -457,7 +457,10 @@ fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
                 <CardHeader>
                     <Flex justify=FlexJustify::SpaceAround align=FlexAlign::Stretch>
                         <CopyToClipBoardButton
-                            class=get_class(&is_desktop, "resolved-service-card-title resolved-service-card-title")
+                            class=get_class(
+                                &is_desktop,
+                                "resolved-service-card-title resolved-service-card-title",
+                            )
                             size=ButtonSize::Large
                             text=Some(resolved_service.instance_fullname.clone())
                             button_text=Some(card_title)
@@ -514,7 +517,10 @@ fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
                                             <DialogBody class="resolved-service-details-dialog-body">
                                                 <Scrollbar class="resolved-service-details-dialog-scrollarea">
                                                     <Flex vertical=true>
-                                                        <DialogTitle class=get_class(&is_desktop, "resolved-service-details-dialog-title resolved-service-details-dialog-title")>{details_title}</DialogTitle>
+                                                        <DialogTitle class=get_class(
+                                                            &is_desktop,
+                                                            "resolved-service-details-dialog-title resolved-service-details-dialog-title",
+                                                        )>{details_title}</DialogTitle>
                                                         <ValuesTable values=subtype title="subtype" />
                                                         <ValuesTable values=addrs title="IPs" />
                                                         <ValuesTable values=txts title="txt" />

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -65,7 +65,7 @@ async fn listen_for_resolve_events(event_writer: WriteSignal<ResolvedServices>) 
         "service-resolved",
         move |event: ServiceResolvedEventRes| {
             event_writer.update(|evts| {
-                evts.retain(|r| r.instance_name != event.service.instance_name);
+                evts.retain(|r| r.instance_fullname != event.service.instance_fullname);
                 evts.push(event.service);
             });
         },
@@ -73,7 +73,7 @@ async fn listen_for_resolve_events(event_writer: WriteSignal<ResolvedServices>) 
         move |event: ServiceRemovedEventRes| {
             event_writer.update(|evts| {
                 for item in evts.iter_mut() {
-                    if item.instance_name == event.instance_name {
+                    if item.instance_fullname == event.instance_name {
                         item.die_at(event.at_ms);
                         break;
                     }
@@ -122,14 +122,6 @@ async fn verify_instance(instance_fullname: String) {
         )
         .await;
     });
-}
-
-fn get_instance_name(input: &str) -> String {
-    if let Some(prefix) = input.split('.').next() {
-        prefix.to_string()
-    } else {
-        input.to_string()
-    }
 }
 
 fn is_subsequence(search_term: &str, target: &str) -> bool {
@@ -397,7 +389,7 @@ fn ResolvedRow(
 /// Component that shows a resolved service as a card
 #[component]
 fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
-    let instance_fullname = RwSignal::new(resolved_service.instance_name.clone());
+    let instance_fullname = RwSignal::new(resolved_service.instance_fullname.clone());
     let verify_action = Action::new_local(|instance_fullname: &String| {
         let instance_fullname = instance_fullname.clone();
         async move { verify_instance(instance_fullname.clone()).await }
@@ -425,6 +417,8 @@ fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
         }
     };
 
+    let card_title = resolved_service.get_instance_name().clone();
+    let details_title = card_title.clone();
     let host_to_copy = drop_trailing_dot(&resolved_service.hostname);
     let host_to_show = drop_local_and_trailing_dot(&resolved_service.hostname);
     let service_type_to_copy = drop_trailing_dot(&resolved_service.service_type);
@@ -448,8 +442,6 @@ fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
         Some(s) => vec![s],
     };
 
-    let card_title = get_instance_name(resolved_service.instance_name.as_str());
-    let details_title = card_title.clone();
     let show_details = RwSignal::new(false);
     let first_address = addrs.first().cloned().unwrap_or_default();
 
@@ -465,8 +457,9 @@ fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
                 <CardHeader>
                     <Flex justify=FlexJustify::SpaceAround align=FlexAlign::Stretch>
                         <CopyToClipBoardButton
+                            class=get_class(&is_desktop, "resolved-service-card-title resolved-service-card-title")
                             size=ButtonSize::Large
-                            text=Some(card_title.clone())
+                            text=Some(resolved_service.instance_fullname.clone())
                             button_text=Some(card_title)
                             disabled=resolved_service.dead
                         />
@@ -521,7 +514,7 @@ fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
                                             <DialogBody class="resolved-service-details-dialog-body">
                                                 <Scrollbar class="resolved-service-details-dialog-scrollarea">
                                                     <Flex vertical=true>
-                                                        <DialogTitle>{details_title}</DialogTitle>
+                                                        <DialogTitle class=get_class(&is_desktop, "resolved-service-details-dialog-title resolved-service-details-dialog-title")>{details_title}</DialogTitle>
                                                         <ValuesTable values=subtype title="subtype" />
                                                         <ValuesTable values=addrs title="IPs" />
                                                         <ValuesTable values=txts title="txt" />
@@ -639,8 +632,12 @@ pub fn Browse() -> impl IntoView {
                 std::cmp::Ordering::Equal => b.service_type.cmp(&a.service_type),
                 other => other,
             }),
-            SortKind::InstanceAsc => sorted.sort_by(|a, b| a.instance_name.cmp(&b.instance_name)),
-            SortKind::InstanceDesc => sorted.sort_by(|a, b| b.instance_name.cmp(&a.instance_name)),
+            SortKind::InstanceAsc => {
+                sorted.sort_by(|a, b| a.instance_fullname.cmp(&b.instance_fullname))
+            }
+            SortKind::InstanceDesc => {
+                sorted.sort_by(|a, b| b.instance_fullname.cmp(&a.instance_fullname))
+            }
             SortKind::ServiceTypeAsc => sorted.sort_by(|a, b| a.service_type.cmp(&b.service_type)),
             SortKind::ServiceTypeDesc => sorted.sort_by(|a, b| b.service_type.cmp(&a.service_type)),
             SortKind::TimestampAsc => sorted.sort_by_key(|i| i.updated_at_ms),
@@ -882,7 +879,7 @@ pub fn Browse() -> impl IntoView {
             <Grid class=grid_class>
                 <For
                     each=move || filtered_services.get()
-                    key=|rs| format!("{}{}", rs.instance_name.clone(), rs.updated_at_ms)
+                    key=|rs| format!("{}{}", rs.instance_fullname.clone(), rs.updated_at_ms)
                     children=move |resolved_service| {
                         view! { <ResolvedServiceItem resolved_service /> }
                     }

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -457,10 +457,7 @@ fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
                 <CardHeader>
                     <Flex justify=FlexJustify::SpaceAround align=FlexAlign::Stretch>
                         <CopyToClipBoardButton
-                            class=get_class(
-                                &is_desktop,
-                                "resolved-service-card-title resolved-service-card-title",
-                            )
+                            class=get_class(&is_desktop, "resolved-service-card-title")
                             size=ButtonSize::Large
                             text=Some(resolved_service.instance_fullname.clone())
                             button_text=Some(card_title)
@@ -519,7 +516,7 @@ fn ResolvedServiceItem(resolved_service: ResolvedService) -> impl IntoView {
                                                     <Flex vertical=true>
                                                         <DialogTitle class=get_class(
                                                             &is_desktop,
-                                                            "resolved-service-details-dialog-title resolved-service-details-dialog-title",
+                                                            "resolved-service-details-dialog-title",
                                                         )>{details_title}</DialogTitle>
                                                         <ValuesTable values=subtype title="subtype" />
                                                         <ValuesTable values=addrs title="IPs" />

--- a/src/app/css.rs
+++ b/src/app/css.rs
@@ -10,7 +10,7 @@ pub fn get_class(is_desktop: &ReadSignal<bool>, base_class: &str) -> Signal<Stri
             } else {
                 "mobile-"
             };
-            format!("{}{}", prefix, &base_class)
+            format!("{}{} {}", prefix, &base_class, &base_class)
         }
     })
 }

--- a/styles.css
+++ b/styles.css
@@ -1,97 +1,125 @@
 body {
-    margin: 0;
-    padding: 0;
-    border: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
 }
 
 .hidden {
-    display: none;
+  display: none;
 }
 .mobile-outer-layout {
-    border: 0;
+  border: 0;
 }
 
 .mobile-metrics-layout {
-    border: 0;
+  border: 0;
 }
 
 .mobile-browse-layout {
-    padding-top: 5px;
+  padding-top: 5px;
 }
 .mobile-resolved-service-card {
-    width: 480px;
+  width: 480px;
 }
 .mobile-resolved-service-grid {
-    grid-template-columns: repeat(auto-fill, minmax(480px, 1fr)) !important;
-    grid-gap: 8px 8px !important;
+  grid-template-columns: repeat(auto-fill, minmax(480px, 1fr)) !important;
+  grid-gap: 8px 8px !important;
 }
 .mobile-resolved-service-value-cell {
-    width: 350px;
+  width: 350px;
 }
 
 .desktop-outer-layout {
-    padding: 10px
+  padding: 10px;
 }
 .desktop-browse-layout {
-    padding-top: 10px;
+  padding-top: 10px;
 }
 
 .desktop-metrics-layout {
-    border: 0;
+  border: 0;
 }
 
 .metrics-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 0px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0px;
 }
 
 .metric-item {
-    border: var(--strokeWidthThin) solid var(--colorNeutralStroke2);
-    padding: 2px 5px 2px 5px;
-    min-width: 160px;
+  border: var(--strokeWidthThin) solid var(--colorNeutralStroke2);
+  padding: 2px 5px 2px 5px;
+  min-width: 160px;
 }
 
 .desktop-resolved-service-card {
-    width: 520px;
+  width: 520px;
 }
 .desktop-resolved-service-grid {
-    grid-template-columns: repeat(auto-fill, minmax(520px, 1fr)) !important;
-    grid-gap: 10px 10px !important;
+  grid-template-columns: repeat(auto-fill, minmax(520px, 1fr)) !important;
+  grid-gap: 10px 10px !important;
 }
 .desktop-resolved-service-value-cell {
-    width: 400px;
+  width: 400px;
+}
+
+.resolved-service-card-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+}
+
+.mobile-resolved-service-card-title {
+  max-width: 475px;
+}
+
+.desktop-resolved-service-card-title {
+  max-width: 510px;
 }
 
 .mobile-input > .thaw-input {
-    min-width: 180px;
-    max-width: 180px;
+  min-width: 180px;
+  max-width: 180px;
 }
 .mobile-input > .thaw-input__input {
-    min-width: 180px;
-    max-width: 180px;
+  min-width: 180px;
+  max-width: 180px;
 }
 
 .desktop-input > .thaw-input__input {
-    border: 0;
+  border: 0;
 }
 
 .thaw-card-header__header {
-    justify-content: space-between;
+  justify-content: space-between;
 }
 
 .service-type-invalid > .thaw-input {
-    border: 2px groove var(--colorStatusDangerBorder1);
+  border: 2px groove var(--colorStatusDangerBorder1);
 }
 .service-type-valid > .thaw-input {
-    outline: 1px solid var(--colorTransparentStroke);
+  outline: 1px solid var(--colorTransparentStroke);
+}
+
+.resolved-service-details-dialog-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+}
+.desktop-resolved-service-details-dialog-title {
+  max-width: 520px;
+}
+.mobile-resolved-service-details-dialog-title {
+  max-width: 480px;
 }
 
 .resolved-service-details-dialog-body {
-    display: flex;
-    max-width: 90vw;
+  display: flex;
+  max-width: 90vw;
 }
 
 .resolved-service-details-dialog-scrollarea {
-    max-height: 90vh;
+  max-height: 90vh;
 }


### PR DESCRIPTION
Add text eliding to card title and details dialog when the service type gets too long.
Copy the full instance name to clipboard instead of the shortened one.

## Summary by Sourcery

Rename `instance_name` to `instance_fullname` for service identification and derive a shorter display name from it. Update UI components to use the full name for copying and the derived name for display, adding text eliding for long names.

Bug Fixes:
- Copy the full instance name to the clipboard instead of the display name.
- Use the full instance name consistently for service identification, sorting, and filtering.

Enhancements:
- Elide long instance names in card titles and details dialogs using CSS.
- Improve debug logging during service discovery.

Tests:
- Update tests to reflect the `instance_fullname` field rename.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved display of resolved service names with enhanced truncation and formatting for long text in cards and dialogs.
  - Added new visual styles for service card and dialog titles to improve readability on both mobile and desktop.
  - Added a method to extract simplified instance names from full service names for clearer display.

- **Refactor**
  - Updated all references to use the full instance name for resolved services, ensuring consistent identification and sorting.
  - Enhanced event handling and display logic to utilize the derived instance name for titles and actions.

- **Style**
  - Improved CSS formatting and indentation for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->