### PR TITLE
chore: add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,6 @@ body:
       label: What happened?
       description: Also tell us, what did you expect to happen?
       placeholder: Tell us what you see!
-      value: "A bug happened!"
     validations:
       required: true
   - type: textarea
@@ -37,8 +36,28 @@ body:
         - Windows
         - macOS
         - Linux
+        - Android
+        - Other
     validations:
       required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Install Method
+      description: What installation method did you use
+      options:
+        - rpm
+        - deb
+        - xbps
+        - apk
+        - dmg
+        - setup.exe
+        - app.tar.gz
+        - AUR
+        - winget
+        - Other
+    validations:
+      required: false
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: File a bug report to help us improve
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Please provide detailed steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What operating system are you using?
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell


### PR DESCRIPTION
Closes #251 
## Summary by Sourcery

Chores:
- Create a GitHub issue template for bug reports with structured input fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a standardized "Bug Report" issue template to guide users in submitting detailed and consistent bug reports on GitHub. The template includes required fields for descriptions, reproduction steps, operating system selection, and optional log uploads, helping streamline the bug triage process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->