### PR TITLE
chore: remove unused dependency leptos_meta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,17 +146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "any_spawner"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1384d3fe1eecb464229fcf6eebb72306591c56bf27b373561489458a7c73027d"
-dependencies = [
- "futures",
- "thiserror 2.0.12",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,12 +870,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-str"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e991226a70654b49d34de5ed064885f0bef0348a8e70018b8ff1ac80aa984a2"
-
-[[package]]
 name = "const_format"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,15 +915,6 @@ name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1396,12 +1370,6 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "erased"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1731451909bde27714eacba19c2566362a7f35224f52b153d3f42cf60f72472"
 
 [[package]]
 name = "erased-serde"
@@ -2175,21 +2143,7 @@ dependencies = [
  "or_poisoned",
  "pin-project-lite",
  "serde",
- "throw_error 0.2.0",
-]
-
-[[package]]
-name = "hydration_context"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8714ae4adeaa846d838f380fbd72f049197de629948f91bf045329e0cf0a283"
-dependencies = [
- "futures",
- "once_cell",
- "or_poisoned",
- "pin-project-lite",
- "serde",
- "throw_error 0.3.0",
+ "throw_error",
 ]
 
 [[package]]
@@ -2885,67 +2839,31 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b8731cb00f3f0894058155410b95c8955b17273181d2bc72600ab84edd24f1"
 dependencies = [
- "any_spawner 0.2.0",
+ "any_spawner",
  "cfg-if",
  "either_of",
  "futures",
- "hydration_context 0.2.1",
- "leptos_config 0.7.8",
- "leptos_dom 0.7.8",
- "leptos_hot_reload 0.7.8",
- "leptos_macro 0.7.9",
- "leptos_server 0.7.8",
+ "hydration_context",
+ "leptos_config",
+ "leptos_dom",
+ "leptos_hot_reload",
+ "leptos_macro",
+ "leptos_server",
  "oco_ref",
  "or_poisoned",
  "paste",
- "reactive_graph 0.1.8",
+ "reactive_graph",
  "rustc-hash",
  "send_wrapper",
  "serde",
- "serde_qs 0.13.0",
- "server_fn 0.7.8",
+ "serde_qs",
+ "server_fn",
  "slotmap",
- "tachys 0.1.8",
+ "tachys",
  "thiserror 2.0.12",
- "throw_error 0.2.0",
- "typed-builder 0.20.1",
- "typed-builder-macro 0.20.1",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "leptos"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebeea243876c96655d064a28af6d9918f226fed14af9f781e3778bcf7fed66e"
-dependencies = [
- "any_spawner 0.3.0",
- "cfg-if",
- "either_of",
- "futures",
- "hydration_context 0.3.0",
- "leptos_config 0.8.0",
- "leptos_dom 0.8.0",
- "leptos_hot_reload 0.8.0",
- "leptos_macro 0.8.0",
- "leptos_server 0.8.0",
- "oco_ref",
- "or_poisoned",
- "paste",
- "reactive_graph 0.2.0",
- "rustc-hash",
- "rustc_version",
- "send_wrapper",
- "serde",
- "serde_qs 0.14.0",
- "server_fn 0.8.0",
- "slotmap",
- "tachys 0.2.0",
- "thiserror 2.0.12",
- "throw_error 0.3.0",
- "typed-builder 0.21.0",
- "typed-builder-macro 0.21.0",
+ "throw_error",
+ "typed-builder",
+ "typed-builder-macro",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -2960,20 +2878,7 @@ dependencies = [
  "regex",
  "serde",
  "thiserror 2.0.12",
- "typed-builder 0.20.1",
-]
-
-[[package]]
-name = "leptos_config"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c811cf9507f4a0399f5eb5914e1e94f3b255a2ba3637de63fe68ddf42a47eff"
-dependencies = [
- "config",
- "regex",
- "serde",
- "thiserror 2.0.12",
- "typed-builder 0.21.0",
+ "typed-builder",
 ]
 
 [[package]]
@@ -2984,24 +2889,9 @@ checksum = "f89d4eb263bd5a9e7c49f780f17063f15aca56fd638c90b9dfd5f4739152e87d"
 dependencies = [
  "js-sys",
  "or_poisoned",
- "reactive_graph 0.1.8",
+ "reactive_graph",
  "send_wrapper",
- "tachys 0.1.8",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "leptos_dom"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50558217ef975ac3bec7d72a52bf95bc03c5dcc60d6f89ce15874e9d3c142c7"
-dependencies = [
- "js-sys",
- "or_poisoned",
- "reactive_graph 0.2.0",
- "send_wrapper",
- "tachys 0.2.0",
+ "tachys",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -3011,24 +2901,6 @@ name = "leptos_hot_reload"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e80219388501d99b246f43b6e7d08a28f327cdd34ba630a35654d917f3e1788e"
-dependencies = [
- "anyhow",
- "camino",
- "indexmap 2.9.0",
- "parking_lot",
- "proc-macro2",
- "quote",
- "rstml",
- "serde",
- "syn 2.0.101",
- "walkdir",
-]
-
-[[package]]
-name = "leptos_hot_reload"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62f95f3deb52e84d008c68136f6f91a484cf75249d888e6cdda1ae8674ba2cc"
 dependencies = [
  "anyhow",
  "camino",
@@ -3053,54 +2925,15 @@ dependencies = [
  "convert_case 0.7.1",
  "html-escape",
  "itertools",
- "leptos_hot_reload 0.7.8",
+ "leptos_hot_reload",
  "prettyplease",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
  "rstml",
- "server_fn_macro 0.7.8",
+ "server_fn_macro",
  "syn 2.0.101",
  "uuid",
-]
-
-[[package]]
-name = "leptos_macro"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7905c8937da27d55cbfc6c5983bc166af7863c4ecdd6f1c5b9880dca1b1082"
-dependencies = [
- "attribute-derive",
- "cfg-if",
- "convert_case 0.8.0",
- "html-escape",
- "itertools",
- "leptos_hot_reload 0.8.0",
- "prettyplease",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "rstml",
- "rustc_version",
- "server_fn_macro 0.8.0",
- "syn 2.0.101",
- "uuid",
-]
-
-[[package]]
-name = "leptos_meta"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9f7283b9b203d93f8f9489aa284945888825815712a3fcba7ab29eb4031471"
-dependencies = [
- "futures",
- "indexmap 2.9.0",
- "leptos 0.8.0",
- "once_cell",
- "or_poisoned",
- "send_wrapper",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -3109,38 +2942,18 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66985242812ec95e224fb48effe651ba02728beca92c461a9464c811a71aab11"
 dependencies = [
- "any_spawner 0.2.0",
+ "any_spawner",
  "base64 0.22.1",
  "codee",
  "futures",
- "hydration_context 0.2.1",
+ "hydration_context",
  "or_poisoned",
- "reactive_graph 0.1.8",
+ "reactive_graph",
  "send_wrapper",
  "serde",
  "serde_json",
- "server_fn 0.7.8",
- "tachys 0.1.8",
-]
-
-[[package]]
-name = "leptos_server"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bfdc78e05acacb767c24ce87e5393b76467ae568d4eac181e20c04f434713bf"
-dependencies = [
- "any_spawner 0.3.0",
- "base64 0.22.1",
- "codee",
- "futures",
- "hydration_context 0.3.0",
- "or_poisoned",
- "reactive_graph 0.2.0",
- "send_wrapper",
- "serde",
- "serde_json",
- "server_fn 0.8.0",
- "tachys 0.2.0",
+ "server_fn",
+ "tachys",
 ]
 
 [[package]]
@@ -3320,8 +3133,7 @@ dependencies = [
  "futures",
  "icondata",
  "js-sys",
- "leptos 0.7.8",
- "leptos_meta",
+ "leptos",
  "log",
  "models",
  "serde",
@@ -4696,36 +4508,14 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a0ccddbc11a648bd09761801dac9e3f246ef7641130987d6120fced22515e6"
 dependencies = [
- "any_spawner 0.2.0",
+ "any_spawner",
  "async-lock",
  "futures",
  "guardian",
- "hydration_context 0.2.1",
+ "hydration_context",
  "or_poisoned",
  "pin-project-lite",
  "rustc-hash",
- "send_wrapper",
- "serde",
- "slotmap",
- "thiserror 2.0.12",
- "web-sys",
-]
-
-[[package]]
-name = "reactive_graph"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2b7d6c997a1d0024142726a6a044cd061827dd25709429fdc99ca294dedc8"
-dependencies = [
- "any_spawner 0.3.0",
- "async-lock",
- "futures",
- "guardian",
- "hydration_context 0.3.0",
- "or_poisoned",
- "pin-project-lite",
- "rustc-hash",
- "rustc_version",
  "send_wrapper",
  "serde",
  "slotmap",
@@ -4743,26 +4533,9 @@ dependencies = [
  "itertools",
  "or_poisoned",
  "paste",
- "reactive_graph 0.1.8",
- "reactive_stores_macro 0.1.8",
+ "reactive_graph",
+ "reactive_stores_macro",
  "rustc-hash",
-]
-
-[[package]]
-name = "reactive_stores"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19194e9cd482f92fa24fac9b96e0b0295af0b519b1ebc2df9f048ea95fff1e9"
-dependencies = [
- "dashmap",
- "guardian",
- "itertools",
- "or_poisoned",
- "paste",
- "reactive_graph 0.2.0",
- "reactive_stores_macro 0.2.0",
- "rustc-hash",
- "send_wrapper",
 ]
 
 [[package]]
@@ -4772,19 +4545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "221095cb028dc51fbc2833743ea8b1a585da1a2af19b440b3528027495bf1f2d"
 dependencies = [
  "convert_case 0.7.1",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "reactive_stores_macro"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f5d6b557ce3b0ac9644faf1677b8f45253c02fa69e14acc55d9695955e4af9"
-dependencies = [
- "convert_case 0.8.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -5233,17 +4993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b417bedc008acbdf6d6b4bc482d29859924114bbe2650b7921fb68a261d0aa6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5345,43 +5094,10 @@ dependencies = [
  "send_wrapper",
  "serde",
  "serde_json",
- "serde_qs 0.13.0",
- "server_fn_macro_default 0.7.8",
+ "serde_qs",
+ "server_fn_macro_default",
  "thiserror 2.0.12",
- "throw_error 0.2.0",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "xxhash-rust",
-]
-
-[[package]]
-name = "server_fn"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e058e6709b0ffb2976e03230916219d1ad50746686681beaf9b42b1beca0e298"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "const-str",
- "const_format",
- "dashmap",
- "futures",
- "gloo-net",
- "http",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "rustversion",
- "send_wrapper",
- "serde",
- "serde_json",
- "serde_qs 0.14.0",
- "server_fn_macro_default 0.8.0",
- "thiserror 2.0.12",
- "throw_error 0.3.0",
+ "throw_error",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -5405,37 +5121,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "server_fn_macro"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ed61a2cbd3d1fd9cd84b5eedcf9168ace43da68273b5e3055e5aafc0b0860a"
-dependencies = [
- "const_format",
- "convert_case 0.8.0",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.101",
- "xxhash-rust",
-]
-
-[[package]]
 name = "server_fn_macro_default"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb8b274f568c94226a8045668554aace8142a59b8bca5414ac5a79627c825568"
 dependencies = [
- "server_fn_macro 0.7.8",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "server_fn_macro_default"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c87b8d55da875a8b16fbe4992cc0ab6d2524b1fb1a0e488f16922f7c46b82f"
-dependencies = [
- "server_fn_macro 0.8.0",
+ "server_fn_macro",
  "syn 2.0.101",
 ]
 
@@ -5727,7 +5418,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d42b7c1545705f77d871228eb52cbb1376b35dc0a237be9fb11e2d9e4e20818"
 dependencies = [
- "any_spawner 0.2.0",
+ "any_spawner",
  "async-trait",
  "const_str_slice_concat",
  "drain_filter_polyfill",
@@ -5745,47 +5436,12 @@ dependencies = [
  "or_poisoned",
  "parking_lot",
  "paste",
- "reactive_graph 0.1.8",
- "reactive_stores 0.1.8",
+ "reactive_graph",
+ "reactive_stores",
  "rustc-hash",
  "send_wrapper",
  "slotmap",
- "throw_error 0.2.0",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "tachys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd309a35ec8282f0793ff8b58ebd4764779fd056f447c58a026331443b77ddae"
-dependencies = [
- "any_spawner 0.3.0",
- "async-trait",
- "const_str_slice_concat",
- "drain_filter_polyfill",
- "either_of",
- "erased",
- "futures",
- "html-escape",
- "indexmap 2.9.0",
- "itertools",
- "js-sys",
- "linear-map",
- "next_tuple",
- "oco_ref",
- "once_cell",
- "or_poisoned",
- "parking_lot",
- "paste",
- "reactive_graph 0.2.0",
- "reactive_stores 0.2.0",
- "rustc-hash",
- "rustc_version",
- "send_wrapper",
- "slotmap",
- "throw_error 0.3.0",
+ "throw_error",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -6234,7 +5890,7 @@ dependencies = [
  "chrono",
  "icondata_ai",
  "icondata_core",
- "leptos 0.7.8",
+ "leptos",
  "num-traits",
  "palette",
  "send_wrapper",
@@ -6254,7 +5910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "243dc24f885b1880372cac1cadd64929e05044c094fee1b82f8a8497c90059cb"
 dependencies = [
  "cfg-if",
- "leptos 0.7.8",
+ "leptos",
  "send_wrapper",
  "thaw_utils",
  "uuid",
@@ -6280,8 +5936,8 @@ checksum = "4a02051778efb4e365286e3cc79eb7c988f373855587453dcd367c34a36d1451"
 dependencies = [
  "cfg-if",
  "chrono",
- "leptos 0.7.8",
- "reactive_stores 0.1.8",
+ "leptos",
+ "reactive_stores",
  "send_wrapper",
  "wasm-bindgen",
  "web-sys",
@@ -6338,15 +5994,6 @@ name = "throw_error"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4ef8bf264c6ae02a065a4a16553283f0656bd6266fc1fcb09fd2e6b5e91427b"
-dependencies = [
- "pin-project-lite",
-]
-
-[[package]]
-name = "throw_error"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e42a6afdde94f3e656fae18f837cb9bbe500a5ac5de325b09f3ec05b9c28e3"
 dependencies = [
  "pin-project-lite",
 ]
@@ -6626,16 +6273,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
 dependencies = [
- "typed-builder-macro 0.20.1",
-]
-
-[[package]]
-name = "typed-builder"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce63bcaf7e9806c206f7d7b9c1f38e0dce8bb165a80af0898161058b19248534"
-dependencies = [
- "typed-builder-macro 0.21.0",
+ "typed-builder-macro",
 ]
 
 [[package]]
@@ -6643,17 +6281,6 @@ name = "typed-builder-macro"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d8d828da2a3d759d3519cdf29a5bac49c77d039ad36d0782edadbf9cd5415b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ futures = "0.3.30"
 icondata = "0.5.0"
 js-sys = "0.3.70"
 leptos = { version = "0.7", features = ["csr"] }
-leptos_meta = { version = "0.8" }
 log = "0.4.22"
 serde = { version = "1.0.210", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -1,5 +1,4 @@
 use leptos::prelude::*;
-use leptos_meta::provide_meta_context;
 use thaw::{
     ConfigProvider, Flex, FlexJustify, Grid, GridItem, Icon, Layout, Text, Theme, ToasterProvider,
 };
@@ -15,7 +14,6 @@ use super::{
 /// The main app component
 #[component]
 pub fn Main() -> impl IntoView {
-    provide_meta_context();
     let theme = RwSignal::new(Theme::dark());
     let set_body_background_color = move |color: String| {
         if let Some(document) = window().document() {


### PR DESCRIPTION
## Summary by Sourcery

Remove unused leptos_meta dependency from the project

Chores:
- Remove leptos_meta dependency from Cargo.toml
- Remove provide_meta_context() call in main.rs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed an unused dependency to streamline the application.
- **Refactor**
  - Cleaned up the main component by removing unnecessary code related to the deleted dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->