### PR TITLE
refactor: move imports and remove redundant cloning

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,8 +5,6 @@ use clap::Parser;
 use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
 use models::check_service_type_fully_qualified;
 use models::*;
-#[cfg(not(windows))]
-use pnet::datalink;
 #[cfg(all(desktop, not(debug_assertions)))]
 use shared_constants::SPLASH_SCREEN_DURATION;
 use shared_constants::{
@@ -279,6 +277,7 @@ fn browse_many(service_types: Vec<String>, window: Window, state: State<ManagedS
 
 #[cfg(not(windows))]
 fn has_mdns_capable_interfaces() -> bool {
+    use pnet::datalink;
     let interfaces = datalink::interfaces();
     interfaces.iter().any(|interface| {
         let capable = !interface.ips.is_empty()

--- a/src/app/about.rs
+++ b/src/app/about.rs
@@ -95,7 +95,7 @@ pub fn About() -> impl IntoView {
     let github_action = Action::new_local(|action: &String| {
         let action = action.clone();
         async move {
-            open_url(action.clone().as_str()).await;
+            open_url(action.as_str()).await;
         }
     });
 


### PR DESCRIPTION
also reduce cloning

## Summary by Sourcery

Refactor the import of pnet::datalink and reduce unnecessary cloning in the codebase

Enhancements:
- Move pnet::datalink import to the specific function where it's used
- Eliminate unnecessary .clone() call in open_url function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal code structure for better efficiency and maintainability. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->