### PR TITLE
refactor: use single source of truth for version

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -410,13 +410,8 @@ fn open_url(app: AppHandle, url: String) -> Result<(), String> {
 
 #[cfg(desktop)]
 #[tauri::command]
-fn version(window: Window) -> String {
-    window
-        .app_handle()
-        .config()
-        .version
-        .clone()
-        .unwrap_or(String::from("Unknown"))
+fn version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
 }
 
 #[cfg(desktop)]


### PR DESCRIPTION
Closes #1080

## Summary by Sourcery

Enhancements:
- Simplify version retrieval by using the Cargo package version directly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the version command to always return the app’s static version string. The version information is now directly provided and no longer depends on runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->