### PR TITLE
feat: Use dark theme on mobile platform by default

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -486,6 +486,8 @@ fn copy_to_clipboard(window: Window, contents: String) -> Result<(), String> {
         .map_err(|e| format!("Failed to copy to clipboard: {:?}", e))?;
     Ok(())
 }
+
+#[cfg(desktop)]
 #[tauri::command]
 fn theme(window: Window) -> Theme {
     match window.theme() {
@@ -495,6 +497,12 @@ fn theme(window: Window) -> Theme {
             Theme::Dark
         }
     }
+}
+
+#[cfg(mobile)]
+#[tauri::command]
+fn theme() -> Theme {
+    Theme::Dark
 }
 
 #[cfg(desktop)]


### PR DESCRIPTION
Closes #1090

## Summary by Sourcery

Implement platform-specific theme handling, setting dark theme as default for mobile platforms

New Features:
- Add mobile-specific theme function that always returns dark theme

Enhancements:
- Modify theme retrieval to be platform-specific

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for theme detection on mobile platforms, defaulting to dark mode.
  - Maintained existing theme detection on desktop platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->