### PR TITLE
feat: allow for switching off usage of IPv4 or IPv6 for browsing

### DIFF
--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -169,7 +169,22 @@ pub struct CanBrowseChangedEventRes {
     pub can_browse: bool,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq, Debug)]
+pub struct ProtocolFlags {
+    pub ipv4: bool,
+    pub ipv6: bool,
+}
+
+impl Default for ProtocolFlags {
+    fn default() -> Self {
+        Self {
+            ipv4: true,
+            ipv6: true,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateMetadata {
     pub version: String,

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -734,7 +734,10 @@ pub fn Browse() -> impl IntoView {
 
     let set_protocol_flags_action = Action::new_local(|flags: &ProtocolFlags| {
         let flags = flags.clone();
-        async move { update_protocol_flags(flags).await }
+        async move {
+            update_protocol_flags(flags).await;
+            invoke_no_args("browse_types").await;
+        }
     });
 
     Effect::watch(
@@ -745,7 +748,6 @@ pub fn Browse() -> impl IntoView {
                     ipv4: protocol_flags.0,
                     ipv6: protocol_flags.1,
                 });
-                spawn_local(invoke_no_args("browse_types"));
             }
         },
         false,

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -876,12 +876,9 @@ pub fn Browse() -> impl IntoView {
                         </MessageBarBody>
                     </MessageBar>
                 </Show>
-                <Flex
-                    gap=FlexGap::Small
-                    align=FlexAlign::Center
-                    justify=FlexJustify::Start>
-                    <Checkbox class=checkbox_class checked=ipv4checked label="IPv4"/>
-                    <Checkbox class=checkbox_class checked=ipv6checked label="IPv6"/>
+                <Flex gap=FlexGap::Small align=FlexAlign::Center justify=FlexJustify::Start>
+                    <Checkbox class=checkbox_class checked=ipv4checked label="IPv4" />
+                    <Checkbox class=checkbox_class checked=ipv6checked label="IPv6" />
                 </Flex>
                 <Flex gap=FlexGap::Small align=FlexAlign::Center justify=FlexJustify::Start>
                     <AutoCompleteServiceType

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -732,7 +732,7 @@ pub fn Browse() -> impl IntoView {
         async move { browse_many(vec![input]).await }
     });
 
-    let set_protcol_flags_action = Action::new_local(|flags: &ProtocolFlags| {
+    let set_protocol_flags_action = Action::new_local(|flags: &ProtocolFlags| {
         let flags = flags.clone();
         async move { update_protocol_flags(flags).await }
     });
@@ -741,7 +741,7 @@ pub fn Browse() -> impl IntoView {
         move || (ipv4checked.get(), ipv6checked.get()),
         move |protocol_flags, previous_protocol_flags, _| {
             if protocol_flags != previous_protocol_flags.unwrap_or(&(true, true)) {
-                set_protcol_flags_action.dispatch(ProtocolFlags {
+                set_protocol_flags_action.dispatch(ProtocolFlags {
                     ipv4: protocol_flags.0,
                     ipv6: protocol_flags.1,
                 });

--- a/styles.css
+++ b/styles.css
@@ -123,3 +123,8 @@ body {
 .resolved-service-details-dialog-scrollarea {
     max-height: 90vh;
 }
+
+.fake-disabled {
+    pointer-events: none;
+    opacity: 0.5;
+}


### PR DESCRIPTION
This has no influence on the resolved addresses, if IPv4 is disabled, IPv4 addresses may still be resolved using IPv6 multicast mDNS queries.

## Summary by Sourcery

Add support for enabling and disabling IPv4 and IPv6 protocols for service browsing

New Features:
- Introduce ability to toggle IPv4 and IPv6 protocols independently
- Add UI checkboxes to enable/disable IPv4 and IPv6 browsing

Enhancements:
- Implement backend support for managing protocol interface states
- Add frontend controls for protocol selection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added user controls to enable or disable IPv4 and IPv6 browsing protocols in the browsing interface.
  - Protocol flag settings now sync dynamically with the backend, allowing immediate updates and browsing refresh.
- **Bug Fixes**
  - Improved error handling when enabling or disabling network interfaces.
- **Style**
  - Introduced a new visual style to indicate when protocol selection checkboxes are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->