### PR TITLE
fix: Ensure resolved records are updated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3233,6 +3233,7 @@ name = "models"
 version = "0.17.0"
 dependencies = [
  "serde",
+ "serde_with",
  "thiserror 2.0.12",
 ]
 

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.210", features = ["derive"] }
+serde_with = "3"
 thiserror = "2.0.0"

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -38,7 +38,8 @@ pub struct ResolvedService {
     pub addresses: Vec<IpAddr>,
     pub subtype: Option<String>,
     pub txt: Vec<TxtRecord>,
-    pub updated_at_ms: u64,
+    #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
+    pub updated_at_ns: u64,
     pub dead: bool,
 }
 
@@ -54,9 +55,9 @@ impl ResolvedService {
             .to_string()
     }
 
-    pub fn die_at(&mut self, at_ms: u64) {
+    pub fn die_at(&mut self, at_ns: u64) {
         self.dead = true;
-        self.updated_at_ms = at_ms;
+        self.updated_at_ns = at_ns;
     }
     pub fn matches_query(&self, query: &str) -> bool {
         let query = query.to_lowercase();
@@ -79,13 +80,13 @@ impl ResolvedService {
     }
 }
 
-pub fn timestamp_millis() -> u64 {
+pub fn timestamp_nanos() -> u64 {
     let now = SystemTime::now();
     let since_epoch = now
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("To have a duration since unix epoch");
 
-    since_epoch.as_secs() * 1000 + u64::from(since_epoch.subsec_millis())
+    since_epoch.as_secs() * 1_000_000_000 + u64::from(since_epoch.subsec_nanos())
 }
 
 fn string_with_control_characters_escaped(input: String) -> String {
@@ -151,12 +152,14 @@ pub type ServiceTypeRemovedEventRes = ServiceTypeFoundEventRes;
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct ServiceRemovedEvent {
     pub instance_name: String,
-    pub at_ms: u64,
+    #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
+    pub at_ns: u64,
 }
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct ServiceRemovedEventRes {
     pub instance_name: String,
-    pub at_ms: u64,
+    #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
+    pub at_ns: u64,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -383,7 +386,7 @@ mod tests {
             addresses: addresses.clone(),
             subtype: subtype.clone(),
             txt: txt.clone(),
-            updated_at_ms,
+            updated_at_ns: updated_at_ms,
             dead,
         };
 
@@ -395,7 +398,7 @@ mod tests {
         assert_eq!(service.addresses, addresses);
         assert_eq!(service.subtype, subtype);
         assert_eq!(service.txt, txt);
-        assert_eq!(service.updated_at_ms, updated_at_ms);
+        assert_eq!(service.updated_at_ns, updated_at_ms);
         assert_eq!(service.dead, dead);
     }
 
@@ -410,7 +413,7 @@ mod tests {
             addresses: vec![IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))],
             subtype: None,
             txt: vec![],
-            updated_at_ms: 1620000000000,
+            updated_at_ns: 1620000000000,
             dead: false,
         };
 
@@ -421,7 +424,7 @@ mod tests {
 
         // Assert
         assert!(service.dead);
-        assert_eq!(service.updated_at_ms, new_updated_at_ms);
+        assert_eq!(service.updated_at_ns, new_updated_at_ms);
     }
 
     #[test]
@@ -435,7 +438,7 @@ mod tests {
             addresses: vec![IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))],
             subtype: None,
             txt: vec![],
-            updated_at_ms: 1620000000000,
+            updated_at_ns: 1620000000000,
             dead: true,
         };
 
@@ -446,7 +449,7 @@ mod tests {
 
         // Assert
         assert!(service.dead);
-        assert_eq!(service.updated_at_ms, new_updated_at_ms);
+        assert_eq!(service.updated_at_ns, new_updated_at_ms);
     }
 
     #[test]
@@ -460,7 +463,7 @@ mod tests {
             addresses: vec![IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))],
             subtype: None,
             txt: vec![],
-            updated_at_ms: 1620000000000,
+            updated_at_ns: 1620000000000,
             dead: false,
         };
 
@@ -469,7 +472,7 @@ mod tests {
 
         // Assert
         assert!(service.dead);
-        assert_eq!(service.updated_at_ms, 0);
+        assert_eq!(service.updated_at_ns, 0);
     }
     #[test]
     fn test_get_instance_name() {
@@ -482,7 +485,7 @@ mod tests {
             addresses: vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))],
             subtype: None,
             txt: vec![],
-            updated_at_ms: 0,
+            updated_at_ns: 0,
             dead: false,
         };
         assert_eq!(service.get_instance_name(), "My Service");
@@ -496,7 +499,7 @@ mod tests {
             addresses: vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))],
             subtype: None,
             txt: vec![],
-            updated_at_ms: 0,
+            updated_at_ns: 0,
             dead: false,
         };
         assert_eq!(service.get_instance_name(), "My.Complex.Service");
@@ -517,7 +520,7 @@ mod tests {
                 key: "key".to_string(),
                 val: Some("value".to_string()),
             }],
-            updated_at_ms: 0,
+            updated_at_ns: 0,
             dead: false,
         };
 
@@ -567,7 +570,7 @@ mod tests {
             addresses: vec![],
             subtype: None,
             txt: vec![],
-            updated_at_ms: 0,
+            updated_at_ns: 0,
             dead: true,
         };
 
@@ -591,7 +594,7 @@ mod tests {
                 key: "key".to_string(),
                 val: Some("val".to_string()),
             }],
-            updated_at_ms: 2349284,
+            updated_at_ns: 2349284,
             dead: false,
         };
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -72,7 +72,7 @@ fn from_service_info(info: &ServiceInfo) -> ResolvedService {
         addresses: sorted_addresses,
         subtype: info.get_subtype().clone(),
         txt: sorted_txt,
-        updated_at_ms: timestamp_millis(),
+        updated_at_ns: timestamp_nanos(),
         dead: false,
     }
 }
@@ -245,7 +245,7 @@ fn browse_many(service_types: Vec<String>, window: Window, state: State<ManagedS
                             "service-removed",
                             &ServiceRemovedEvent {
                                 instance_name,
-                                at_ms: timestamp_millis(),
+                                at_ns: timestamp_nanos(),
                             },
                         );
                     }


### PR DESCRIPTION
Increase precision of time-stamp to nanoseconds to ensure that consecutive fast updates of the resolved record are not missed to render.

## Summary by Sourcery

Increase timestamp precision to nanoseconds across the entire codebase to prevent rapid consecutive updates from being missed and ensure all resolved service records update correctly.

Bug Fixes:
- Ensure resolved service records are not skipped by replacing millisecond timestamps with higher-precision nanoseconds.

Enhancements:
- Rename all `updated_at_ms` and `at_ms` fields to `updated_at_ns` and `at_ns`, updating serialization annotations.
- Replace `timestamp_millis` with `timestamp_nanos` for nanosecond epoch calculations.
- Update UI logic to use nanosecond timestamps for sorting, rendering (using `from_timestamp_nanos`), key generation, and datetime formatting to microsecond precision.
- Adjust Tauri backend to emit and consume nanosecond timestamps for service events.

Build:
- Add `serde_with` dependency to support custom (de)serialization of nanosecond timestamps.

Tests:
- Update existing tests to reference `updated_at_ns` instead of `updated_at_ms`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased timestamp precision throughout the app from milliseconds to nanoseconds for service updates and removals.
- **Style**
	- Time displays now show microsecond precision for improved accuracy.
- **Chores**
	- Updated dependencies to support enhanced timestamp serialization and deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->