### PR TITLE
refactor: Ensure we are not browsing after a frontend reload

### DIFF
--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -639,6 +639,11 @@ async fn update_protocol_flags(flags: ProtocolFlags) {
 /// ```
 #[component]
 pub fn Browse() -> impl IntoView {
+    // Stop browsing when the component is mounted,
+    // so after a reload of the frontend we don't have
+    // queriers active
+    spawn_local(stop_browse());
+
     let (can_browse, set_can_browse) = signal(false);
     let (service_types, set_service_types) = signal(ServiceTypes::new());
     let ipv4checked = RwSignal::new(true);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where ongoing browsing queries could persist after reloading the frontend, ensuring they are now properly stopped when the browse page loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->