### PR TITLE
fix: Make display of table row button texts reactive

### DIFF
--- a/src/app/clipboard.rs
+++ b/src/app/clipboard.rs
@@ -63,7 +63,7 @@ pub fn CopyToClipBoardButton(
             appearance=ButtonAppearance::Subtle
             size=size
         >
-            {button_text.get()}
+            {move || button_text.get()}
         </Button>
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the Copy to Clipboard button so its label now updates automatically when its text changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->