### PR TITLE
fix:  Refine UI layout for service status

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["hrzlgnm"]
 edition = "2021"
 
 [build-dependencies]
-tauri-build = { version = "2.2.0" }
+tauri-build = { version = "2.2.0", features = [] }
 
 [target.'cfg(not(any(target_os="android",target_os="ios")))'.dependencies]
 clap = { version = "4.5.19", features = ["derive"] }

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -506,8 +506,14 @@ fn ResolvedServiceItem(#[prop(into)] resolved_service: Field<ResolvedService>) -
         <GridItem>
             <Card class=card_class>
                 <CardHeader>
-                    <Flex justify=FlexJustify::SpaceBetween align=FlexAlign::Stretch>
-                        <Icon icon=icondata::MdiCircle class=dead_or_alive_icon_class />
+                    <Flex
+                        justify=FlexJustify::FlexStart
+                        align=FlexAlign::Stretch
+                        gap=FlexGap::Size(0)
+                    >
+                        <Flex vertical=true justify=FlexJustify::SpaceAround gap=FlexGap::Size(0)>
+                            <Icon icon=icondata::MdiCircle class=dead_or_alive_icon_class />
+                        </Flex>
                         <CopyToClipBoardButton
                             class=get_class(&is_desktop, "resolved-service-card-title")
                             size=ButtonSize::Large
@@ -554,7 +560,21 @@ fn ResolvedServiceItem(#[prop(into)] resolved_service: Field<ResolvedService>) -
                                                         <DialogTitle class=get_class(
                                                             &is_desktop,
                                                             "resolved-service-details-dialog-title",
-                                                        )>{title}</DialogTitle>
+                                                        )>
+                                                            <Flex justify=FlexJustify::FlexStart gap=FlexGap::Small>
+                                                                <Flex
+                                                                    vertical=true
+                                                                    justify=FlexJustify::SpaceAround
+                                                                    gap=FlexGap::Size(0)
+                                                                >
+                                                                    <Icon
+                                                                        icon=icondata::MdiCircle
+                                                                        class=dead_or_alive_icon_class
+                                                                    />
+                                                                </Flex>
+                                                                {move || title.get()}
+                                                            </Flex>
+                                                        </DialogTitle>
                                                         <ValuesTable values=subtype title="subtype".to_string() />
                                                         <ValuesTable values=addrs title="IPs".to_string() />
                                                         <ValuesTable values=txts title="txt".to_string() />

--- a/styles.css
+++ b/styles.css
@@ -125,12 +125,10 @@ body {
 }
 
 .resolved-service-dead {
-    margin-top: 5px;
     color: var(--colorStatusDangerForeground1);
 }
 
 .resolved-service-alive {
-    margin-top: 5px;
     color: var(--colorBrandForeground1);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved alignment and spacing of status icons and titles in service cards and dialogs for a more consistent appearance.
  - Updated styles for service status indicators by removing unnecessary top margin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->