### PR TITLE
refactor: Centralize protocol flag management in a ProtocolFlags component

### DIFF
--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -174,7 +174,7 @@ pub struct CanBrowseChangedEventRes {
     pub can_browse: bool,
 }
 
-#[derive(Deserialize, Serialize, Clone, Eq, PartialEq, Debug)]
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq, Debug, Store)]
 pub struct ProtocolFlags {
     pub ipv4: bool,
     pub ipv6: bool,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,5 +7,6 @@ mod is_desktop;
 mod listen;
 pub mod main;
 mod metrics;
+mod protocol_flags;
 mod theme_switcher;
 mod values_table;

--- a/src/app/protocol_flags.rs
+++ b/src/app/protocol_flags.rs
@@ -1,0 +1,66 @@
+use leptos::prelude::*;
+use reactive_stores::Store;
+use serde::{Deserialize, Serialize};
+
+use models::{ProtocolFlags, ProtocolFlagsStoreFields};
+use tauri_sys::core::invoke;
+use thaw::{Checkbox, Flex, FlexAlign, FlexGap, FlexJustify};
+
+use crate::app::invoke::invoke_no_args;
+
+async fn get_protocol_flags(store: Store<ProtocolFlags>) {
+    let flags = invoke::<ProtocolFlags>("get_protocol_flags", &()).await;
+    log::debug!("get_protocol_flags: {:?}", flags);
+    store.ipv4().set(flags.ipv4);
+    store.ipv6().set(flags.ipv6);
+}
+
+#[derive(Serialize, Deserialize)]
+struct ProtocolFlagsArgs {
+    flags: ProtocolFlags,
+}
+
+async fn update_protocol_flags(flags: ProtocolFlags) {
+    let _: () = invoke("set_protocol_flags", &ProtocolFlagsArgs { flags }).await;
+}
+
+#[component]
+pub fn ProtocolFlags(#[prop(optional, into)] disabled: Signal<bool>) -> impl IntoView {
+    let protocol_flags = Store::new(ProtocolFlags::default());
+    LocalResource::new(move || get_protocol_flags(protocol_flags));
+
+    let set_protocol_flags_action = Action::new_local(|flags: &ProtocolFlags| {
+        let flags = flags.clone();
+        async move {
+            update_protocol_flags(flags).await;
+            invoke_no_args("browse_types").await;
+        }
+    });
+
+    let checkbox_class = Memo::new(move |_| {
+        if disabled.get() {
+            // TODO: pass on the disabled flag to checkbox when supported instead
+            "fake-disabled".to_string()
+        } else {
+            "".to_string()
+        }
+    });
+
+    Effect::watch(
+        move || protocol_flags.get(),
+        move |protocol_flags, _, _| {
+            set_protocol_flags_action.dispatch(protocol_flags.clone());
+        },
+        false,
+    );
+
+    let ipv4checked = protocol_flags.ipv4();
+    let ipv6checked = protocol_flags.ipv6();
+
+    view! {
+        <Flex gap=FlexGap::Small align=FlexAlign::Center justify=FlexJustify::Start>
+            <Checkbox class=checkbox_class checked=ipv4checked label="IPv4" />
+            <Checkbox class=checkbox_class checked=ipv6checked label="IPv6" />
+        </Flex>
+    }
+}


### PR DESCRIPTION
Closes #1133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a unified Protocol Flags component for managing IPv4 and IPv6 settings, offering a streamlined interface with checkboxes and backend synchronization.
- **Refactor**
	- Simplified the browsing interface by replacing individual IPv4 and IPv6 toggles with the new Protocol Flags component.
- **Chores**
	- Added a new module for protocol flag management to improve code organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->