### PR TITLE
feat: Add enable_devtools CLI argument to enable devtools at startup

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ log = { workspace = true }
 mdns-sd = { version = "0.13.0", features = ["async", "log"] }
 serde = { workspace = true }
 serde_json = "1.0.128"
-tauri = { version = "2.0.0", features = [] }
+tauri = { version = "2.0.0", features = ["devtools"] }
 tauri-plugin-clipboard-manager = "2.0.0"
 tauri-plugin-log = { version = "2.0.0", features = ["colored"] }
 tauri-plugin-opener = "2.2.0"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -591,6 +591,13 @@ struct Args {
     )]
     log_level: foreign_crate::LevelFilter,
     #[arg(
+        short = 'D',
+        long,
+        default_value_t = false,
+        help = "Enable devtools at startup"
+    )]
+    enable_devtools: bool,
+    #[arg(
         short = 'f',
         long,
         default_value_t = false,
@@ -787,7 +794,7 @@ pub fn run() {
                 .build(),
         )
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .setup(|app| {
+        .setup(move |app| {
             let splashscreen_window = app
                 .get_webview_window("splashscreen")
                 .expect("Splashscreen window to exist");
@@ -799,8 +806,9 @@ pub fn run() {
                 tokio::time::sleep(SPLASH_SCREEN_DURATION).await;
                 splashscreen_window.close().expect("To close");
                 main_window.show().expect("To show");
-                #[cfg(debug_assertions)]
-                main_window.open_devtools();
+                if args.enable_devtools {
+                    main_window.open_devtools();
+                }
             });
             Ok(())
         })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line option to enable developer tools at startup.

- **Chores**
  - Updated internal dependencies to support the new developer tools feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->