### PR TITLE
chore: only specify up to minor version in dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,7 +19,7 @@
     ],
     prConcurrentLimit: 0,
     lockFileMaintenance: {
-        enabled: false,
+        enabled: true,
         schedule: ["on the first day of the month"],
     },
     customManagers: [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,18 @@ debug = true
 [dependencies]
 # crates
 chrono = { workspace = true }
-console_error_panic_hook = "0.1.7"
-console_log = "1.0.0"
-futures = "0.3.30"
-icondata = "0.5.0"
-icondata_core = "0.1.0"
-js-sys = "0.3.70"
+console_error_panic_hook = "0.1"
+console_log = "1.0"
+futures = "0.3"
+icondata = "0.5"
+icondata_core = "0.1"
+js-sys = "0.3"
 leptos = { version = "0.8", features = ["csr"] }
 log = { workspace = true }
 reactive_stores = { workspace = true }
 serde = { workspace = true }
-serde-wasm-bindgen = "0.6.5"
-strsim = "0.11.1"
+serde-wasm-bindgen = "0.6"
+strsim = "0.11"
 thaw = { version = "0.5.0-beta", features = ["csr"] }
 thaw_utils = "0.2.0-beta"
 # git
@@ -42,9 +42,9 @@ models = { path = "./models" }
 members = ["models", "shared_constants", "src-tauri"]
 
 [workspace.dependencies]
-chrono = "0.4.38"
-reactive_stores = "0.2.2"
-serde = { version = "1.0.219", features = ["derive"] }
-log = "0.4.27"
-thiserror = "2.0.12"
-tokio = { version = "1.45.0", features = ["time"] }
+chrono = "0.4"
+reactive_stores = "0.2"
+serde = { version = "1.0", features = ["derive"] }
+log = "0.4"
+thiserror = "2.0"
+tokio = { version = "1.45", features = ["time"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,13 +17,13 @@ chrono = { workspace = true }
 [dependencies]
 # crates
 log = { workspace = true }
-mdns-sd = { version = "0.13.0", features = ["async", "log"] }
+mdns-sd = { version = "0.13", features = ["async", "log"] }
 serde = { workspace = true }
-serde_json = "1.0.128"
-tauri = { version = "2.0.0", features = ["devtools"] }
-tauri-plugin-clipboard-manager = "2.0.0"
-tauri-plugin-log = { version = "2.0.0", features = ["colored"] }
-tauri-plugin-opener = "2.2.0"
+serde_json = "1.0"
+tauri = { version = "2.0", features = ["devtools"] }
+tauri-plugin-clipboard-manager = "2.2"
+tauri-plugin-log = { version = "2.4", features = ["colored"] }
+tauri-plugin-opener = "2.2"
 tokio = { workspace = true }
 
 # local
@@ -32,13 +32,13 @@ shared_constants = { path = "../shared_constants" }
 
 # platform-specific dependencies
 [target.'cfg(not(windows))'.dependencies]
-pnet = "0.35.0"
+pnet = "0.35"
 
 [target.'cfg(windows)'.dependencies]
-ipconfig = "0.3.2"
+ipconfig = "0.3"
 
 [target.'cfg(target_os="linux")'.dependencies]
-regex = "1.11.1"
+regex = "1.11"
 
 [lib]
 name = "mdns_browser_lib"


### PR DESCRIPTION
enable lock file maintenance again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enabled automatic monthly lock file maintenance for dependencies.
	- Generalized dependency version specifications for improved flexibility and easier updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->