### PR TITLE
refactor: Remove redundant event structs and unify event type definitions

### DIFF
--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -131,13 +131,8 @@ fn byte_array_hexlified(byte_array: &[u8]) -> String {
         .join("")
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct MetricsEvent {
-    pub metrics: HashMap<String, i64>,
-}
-
 #[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug)]
-pub struct MetricsEventRes {
+pub struct MetricsChangedEvent {
     pub metrics: HashMap<String, i64>,
 }
 
@@ -147,21 +142,11 @@ pub struct ServiceResolvedEvent {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct ServiceResolvedEventRes {
-    pub service: ResolvedService,
-}
-
-#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct ServiceTypeFoundEvent {
     pub service_type: String,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct ServiceTypeFoundEventRes {
-    pub service_type: String,
-}
 pub type ServiceTypeRemovedEvent = ServiceTypeFoundEvent;
-pub type ServiceTypeRemovedEventRes = ServiceTypeFoundEventRes;
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct ServiceRemovedEvent {
@@ -169,20 +154,14 @@ pub struct ServiceRemovedEvent {
     #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
     pub at_micros: u64,
 }
-#[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct ServiceRemovedEventRes {
-    pub instance_name: String,
-    #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
-    pub at_micros: u64,
-}
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct ThemeChangedEventRes {
+pub struct ThemeChangedEvent {
     pub theme: String,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct CanBrowseChangedEventRes {
+pub struct CanBrowseChangedEvent {
     pub can_browse: bool,
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -310,7 +310,7 @@ async fn poll_can_browse(window: Window) {
     emit_event(
         &window,
         "can-browse-changed",
-        &CanBrowseChangedEventRes {
+        &CanBrowseChangedEvent {
             can_browse: current,
         },
     );
@@ -322,7 +322,7 @@ async fn poll_can_browse(window: Window) {
             emit_event(
                 &window,
                 "can-browse-changed",
-                &CanBrowseChangedEventRes {
+                &CanBrowseChangedEvent {
                     can_browse: current,
                 },
             );
@@ -342,7 +342,7 @@ fn subscribe_can_browse(window: Window, state: State<ManagedState>) {
         emit_event(
             &window,
             "can-browse-changed",
-            &CanBrowseChangedEventRes {
+            &CanBrowseChangedEvent {
                 can_browse: has_mdns_capable_interfaces(),
             },
         );
@@ -375,7 +375,7 @@ fn subscribe_metrics(window: Window, state: State<ManagedState>) {
                             emit_event(
                                 &window,
                                 "metrics-changed",
-                                &MetricsEvent {
+                                &MetricsChangedEvent {
                                     metrics: metrics.clone(),
                                 },
                             );

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -52,7 +52,7 @@ async fn listen_to_service_type_events(writer: WriteSignal<ServiceTypes>) {
     listen_add_remove(
         browse_types,
         "service-type-found",
-        move |event: ServiceTypeFoundEventRes| {
+        move |event: ServiceTypeFoundEvent| {
             let mut set = HashSet::new();
             writer.update(|sts| {
                 sts.push(event.service_type);
@@ -61,7 +61,7 @@ async fn listen_to_service_type_events(writer: WriteSignal<ServiceTypes>) {
             });
         },
         "service-type-removed",
-        move |event: ServiceTypeRemovedEventRes| {
+        move |event: ServiceTypeRemovedEvent| {
             writer.update(|evts| {
                 evts.retain(|st| st != &event.service_type);
             });
@@ -75,7 +75,7 @@ async fn listen_to_service_type_events(writer: WriteSignal<ServiceTypes>) {
 /// Updates the provided signal whenever a "can_browse" event is received,
 /// reflecting whether browsing is currently allowed.
 async fn listen_to_can_browse_events(writer: WriteSignal<bool>) {
-    listen_to_named_event("can_browse", move |event: CanBrowseChangedEventRes| {
+    listen_to_named_event("can_browse", move |event: CanBrowseChangedEvent| {
         writer.update(|evt| *evt = event.can_browse);
     })
     .await;
@@ -118,7 +118,7 @@ async fn listen_for_resolve_events(store: Store<Resolved>) {
     listen_add_remove(
         async || {},
         "service-resolved",
-        move |event: ServiceResolvedEventRes| {
+        move |event: ServiceResolvedEvent| {
             store
                 .services()
                 .iter_unkeyed()
@@ -136,7 +136,7 @@ async fn listen_for_resolve_events(store: Store<Resolved>) {
             apply_sort_kind(store, &store.sort_by().get_untracked());
         },
         "service-removed",
-        move |event: ServiceRemovedEventRes| {
+        move |event: ServiceRemovedEvent| {
             if let Some(rs) = store.services().iter_unkeyed().find(|rs| {
                 let rs = rs.read_untracked();
                 rs.instance_fullname == event.instance_name && !rs.dead

--- a/src/app/metrics.rs
+++ b/src/app/metrics.rs
@@ -1,5 +1,5 @@
 use leptos::prelude::*;
-use models::MetricsEventRes;
+use models::MetricsChangedEvent;
 use thaw::{
     Accordion, AccordionHeader, AccordionItem, Badge, BadgeAppearance, BadgeColor, BadgeSize,
     Layout, Text, TextTag,
@@ -13,7 +13,7 @@ use super::listen::listen_to_named_event;
 /// sorts them by metric name, and updates the given reactive signal accordingly. The signal is
 /// updated whenever new metrics are received.
 async fn listen_to_metrics_event(event_writer: RwSignal<Vec<(String, i64)>>) {
-    listen_to_named_event("metrics", move |event: MetricsEventRes| {
+    listen_to_named_event("metrics", move |event: MetricsChangedEvent| {
         event_writer.update(|evts| {
             *evts = event.metrics.into_iter().collect::<Vec<_>>();
             evts.sort_by(|a, b| a.0.cmp(&b.0));

--- a/src/app/theme_switcher.rs
+++ b/src/app/theme_switcher.rs
@@ -1,5 +1,5 @@
 use leptos::prelude::*;
-use models::ThemeChangedEventRes;
+use models::ThemeChangedEvent;
 use tauri_sys::core::invoke;
 use thaw::{Icon, Theme};
 
@@ -24,7 +24,7 @@ pub fn ThemeSwitcher(theme: RwSignal<Theme>) -> impl IntoView {
         listen_events(
             async || {},
             "theme-changed",
-            move |event: ThemeChangedEventRes| {
+            move |event: ThemeChangedEvent| {
                 theme.update(|v| *v = Theme::from(event.theme));
             },
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified event handling by consolidating and renaming event types, removing redundant response wrapper types. Event payloads now use unified names without the "Res" suffix.
- **Style**
  - Updated type annotations and imports throughout the app to match the new event type names. 

No changes to event names, app behavior, or user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->