### PR TITLE
docs: Move sections about audiable builds and attestation to readme

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,6 +1,7 @@
 enhancement: ["feature/*", "feat/*"]
 ignore: ["bump/version*"]
 chore: ["chore/*"]
+performance: ["performance/*", "*blazingly-fast*"]
 refactor: ["refactor/*"]
 documentation: ["docs/*"]
 dependencies: ["renovate/*"]

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -43,12 +43,3 @@ header: |
 template: |
 
   $CHANGES
-
-footer: |
-
-  ## Auditable binaries since v0.8.x
-  The binaries built for desktop targets are now all build in auditable mode using [cargo-auditable](https://github.com/rust-secure-code/cargo-auditable?tab=readme-ov-file#cargo-auditable).
-  For information on how to audit the binaries see [Usage](https://github.com/rust-secure-code/cargo-auditable?tab=readme-ov-file#usage)
-
-  ## Attested build artifacts since v0.8.x
-  The build artifacts are now attested. Attestations information about the binaries is available [here](https://github.com/hrzlgnm/mdns-browser/attestations). For more information and details on how to verify those, see [Verifying artifact attestations with the GitHub CLI](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Screenshots from [v0.11.28](https://github.com/hrzlgnm/mdns-browser/releases/tag
     - [Attested build artifacts](#attested-build-artifacts)
     - [Privacy](#privacy)
     - [Acknowledgments](#acknowledgments)
-      <!--toc:end-->
+
+<!--toc:end-->
 
 ## Building
 
@@ -149,8 +150,8 @@ During installation, you will be prompted to accept a public key signed by `hrzl
 
 ## Auditable binaries
 
-The binaries built for desktop targets are now all build in auditable mode using [cargo-auditable](https://github.com/rust-secure-code/cargo-auditable?tab=readme-ov-file#cargo-auditable).
-For information on how to audit the binaries see [Usage](https://github.com/rust-secure-code/cargo-auditable?tab=readme-ov-file#usage)
+The binaries built for desktop targets are now all built in auditable mode using [cargo-auditable](https://github.com/rust-secure-code/cargo-auditable?tab=readme-ov-file#cargo-auditable).
+For information on how to audit the binaries, see [Usage](https://github.com/rust-secure-code/cargo-auditable?tab=readme-ov-file#usage)
 
 Since release v0.8.x
 

--- a/README.md
+++ b/README.md
@@ -36,16 +36,18 @@ Screenshots from [v0.11.28](https://github.com/hrzlgnm/mdns-browser/releases/tag
 <!--toc:start-->
 
 - [mDNS-Browser Overview](#mdns-browser)
-  - [How to Build](#building)
-  - [Command line options](#command-line-options)
-  - [Where to find the executables?](#where-to-find-the-executables)
-    - [GitHub Release](#github-releases)
-    - [Winget Installation](#winget-installation)
-    - [Arch Linux (AUR)](#arch-linux-aur)
-    - [Void Linux](#void-linux)
-  - [Privacy](#privacy)
-  - [Acknowledgments](#acknowledgments)
-  <!--toc:end-->
+    - [How to Build](#building)
+    - [Command line options](#command-line-options)
+    - [Where to find the executables?](#where-to-find-the-executables)
+        - [GitHub Release](#github-releases)
+        - [Winget Installation](#winget-installation)
+        - [Arch Linux (AUR)](#arch-linux-aur)
+        - [Void Linux](#void-linux)
+    - [Auditable binaries](#auditable-binaries)
+    - [Attested build artifacts](#attested-build-artifacts)
+    - [Privacy](#privacy)
+    - [Acknowledgments](#acknowledgments)
+      <!--toc:end-->
 
 ## Building
 
@@ -144,6 +146,19 @@ sudo xbps-install -S mdns-browser
 ```
 
 During installation, you will be prompted to accept a public key signed by `hrzlgnm@users.noreply.github.com`. The repository and package are signed with a key having the fingerprint: `64:6d:b9:23:3d:ad:9d:f1:b0:fe:64:8e:da:46:57:d3`.
+
+## Auditable binaries
+
+The binaries built for desktop targets are now all build in auditable mode using [cargo-auditable](https://github.com/rust-secure-code/cargo-auditable?tab=readme-ov-file#cargo-auditable).
+For information on how to audit the binaries see [Usage](https://github.com/rust-secure-code/cargo-auditable?tab=readme-ov-file#usage)
+
+Since release v0.8.x
+
+## Attested build artifacts
+
+The build artifacts are now attested. Attestations information about the binaries is available [here](https://github.com/hrzlgnm/mdns-browser/attestations). For more information and details on how to verify those, see [Verifying artifact attestations with the GitHub CLI](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli)
+
+Since release v0.8.x
 
 ## Privacy
 


### PR DESCRIPTION
Closes #1165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README with new sections on "Auditable binaries" and "Attested build artifacts," providing information and links related to binary auditability and artifact attestations.
- **Chores**
  - Added a new "performance" label category to the PR labeler configuration.
  - Removed the informational footer about auditable binaries and attested artifacts from the release drafter configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->