### PR TITLE
fix: Add deduplication of sorted addresses in from_resolved_service_detailed

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,6 +81,7 @@ fn from_resolved_service_detailed(resolved: &mdns_sd::ResolvedService) -> Resolv
         .map(convert_to_scoped_addr)
         .collect();
     sorted_addresses.sort();
+    sorted_addresses.dedup();
     let mut sorted_txt: Vec<TxtRecord> = resolved
         .txt_properties
         .iter()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address handling to ensure only unique addresses are displayed, preventing duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->