### PR TITLE
chore: Switch mdns-sd to crates.io 0.14 in src-tauri/Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3212,7 +3212,8 @@ dependencies = [
 [[package]]
 name = "mdns-sd"
 version = "0.14.0"
-source = "git+https://github.com/keepsimple1/mdns-sd?branch=main#a229ab9290ad8235252e528f880a03f9ff2aac1d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b96116f4d4cc3272cd64d5d69079249e32bb05a2d020dd81572c2103392e162"
 dependencies = [
  "fastrand",
  "flume",
@@ -3427,7 +3428,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -7041,7 +7042,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,10 +17,7 @@ chrono = { workspace = true }
 [dependencies]
 # crates
 log = { workspace = true }
-mdns-sd = { git = "https://github.com/keepsimple1/mdns-sd", branch = "main", features = [
-    "async",
-    "log",
-] }
+mdns-sd = "0.14"
 serde = { workspace = true }
 serde_json = "1.0"
 tauri = { version = "2.0", features = ["devtools"] }


### PR DESCRIPTION
Closes #1253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the network discovery dependency from a Git-based source to a stable, versioned crates.io release to improve build reliability and dependency management.
  * Removed the previous custom feature specification for that dependency.
  * No user-visible functional changes expected; this simplifies maintenance, improves reproducible builds, and reduces dependency-related build flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->