### PR TITLE
fix: Tweak layout on mobile so top controls are usable again

### DIFF
--- a/src/app/css.rs
+++ b/src/app/css.rs
@@ -10,7 +10,7 @@ pub fn get_class(is_desktop: &ReadSignal<bool>, base_class: &str) -> Signal<Stri
             } else {
                 "mobile-"
             };
-            format!("{}{} {}", prefix, &base_class, &base_class)
+            format!("{} {}{}", &base_class, prefix, &base_class)
         }
     })
 }

--- a/styles.css
+++ b/styles.css
@@ -59,11 +59,9 @@ body {
 
 /** mobile styles **/
 .mobile-outer-layout {
-.mobile-outer-layout {
     /** freaking front-camera holes in displays; account for safe area **/
     padding-top: calc(env(safe-area-inset-top, 0px) + 5px);
     border: 0;
-}
 }
 .mobile-metrics-layout {
     border: 0;

--- a/styles.css
+++ b/styles.css
@@ -60,7 +60,8 @@ body {
 
 /** mobile styles **/
 .mobile-outer-layout {
-    padding: 5px 2px 5px 2px;
+    /** freaking front-camera holes in displays, who came up with those? **/
+    padding-top: 15px;
     border: 0;
 }
 .mobile-metrics-layout {

--- a/styles.css
+++ b/styles.css
@@ -59,9 +59,11 @@ body {
 
 /** mobile styles **/
 .mobile-outer-layout {
-    /** freaking front-camera holes in displays, who came up with those? **/
-    padding-top: 15px;
+.mobile-outer-layout {
+    /** freaking front-camera holes in displays; account for safe area **/
+    padding-top: calc(env(safe-area-inset-top, 0px) + 5px);
     border: 0;
+}
 }
 .mobile-metrics-layout {
     border: 0;

--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,6 @@ body {
 .hidden {
     display: none;
 }
-
 .metrics-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -75,7 +74,7 @@ body {
 }
 .mobile-resolved-service-grid {
     grid-template-columns: repeat(auto-fill, minmax(480px, 1fr)) !important;
-    grid-gap: 8px 8px !important;
+    grid-gap: 8px !important;
 }
 .mobile-resolved-service-value-cell {
     width: 350px;
@@ -110,7 +109,7 @@ body {
 }
 .desktop-resolved-service-grid {
     grid-template-columns: repeat(auto-fill, minmax(520px, 1fr)) !important;
-    grid-gap: 10px 10px !important;
+    grid-gap: 10px !important;
 }
 .desktop-resolved-service-value-cell {
     width: 400px;

--- a/styles.css
+++ b/styles.css
@@ -46,6 +46,7 @@ body {
 }
 .resolved-service-details-dialog-scrollarea {
     max-height: 90vh;
+    overflow: auto;
 }
 .resolved-service-dead {
     color: var(--colorPaletteDarkOrangeForeground1);

--- a/styles.css
+++ b/styles.css
@@ -1,22 +1,72 @@
+/** common styles for all components **/
 body {
     margin: 0;
     padding: 0;
     border: 0;
 }
-
 .hidden {
     display: none;
 }
-.mobile-outer-layout {
-    border: 0;
+
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0px;
+}
+.metric-item {
+    border: var(--strokeWidthThin) solid var(--colorNeutralStroke2);
+    padding: 2px 5px 2px 5px;
+    min-width: 160px;
+}
+.resolved-service-card-title {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+    font-size: var(--fontSizeBase400);
+}
+.resolved-service-details-dialog-title {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+}
+.thaw-card-header__header {
+    justify-content: space-between;
+}
+.service-type-invalid > .thaw-input {
+    border: 2px groove var(--colorStatusDangerBorder1);
+}
+.service-type-valid > .thaw-input {
+    outline: 1px solid var(--colorTransparentStroke);
+}
+.resolved-service-details-dialog-body {
+    display: flex;
+    max-width: 90vw;
+}
+.resolved-service-details-dialog-scrollarea {
+    max-height: 90vh;
+}
+.resolved-service-dead {
+    color: var(--colorPaletteDarkOrangeForeground1);
+}
+.resolved-service-alive {
+    color: var(--colorBrandForeground1);
+}
+.theme-switcher {
+    cursor: pointer;
 }
 
+/** mobile styles **/
+.mobile-outer-layout {
+    padding: 5px 2px 5px 2px;
+    border: 0;
+}
 .mobile-metrics-layout {
     border: 0;
 }
-
 .mobile-browse-layout {
-    padding-top: 5px;
+    padding-top: 0px;
 }
 .mobile-resolved-service-card {
     width: 480px;
@@ -28,30 +78,31 @@ body {
 .mobile-resolved-service-value-cell {
     width: 350px;
 }
+.mobile-resolved-service-card-title {
+    max-width: 475px;
+}
+.mobile-resolved-service-details-dialog-title {
+    max-width: 480px;
+}
+.mobile-input > .thaw-input {
+    min-width: 180px;
+    max-width: 180px;
+}
+.mobile-input > .thaw-input__input {
+    min-width: 180px;
+    max-width: 180px;
+}
 
+/** desktop styles **/
 .desktop-outer-layout {
     padding: 10px;
 }
 .desktop-browse-layout {
     padding-top: 10px;
 }
-
 .desktop-metrics-layout {
     border: 0;
 }
-
-.metrics-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 0px;
-}
-
-.metric-item {
-    border: var(--strokeWidthThin) solid var(--colorNeutralStroke2);
-    padding: 2px 5px 2px 5px;
-    min-width: 160px;
-}
-
 .desktop-resolved-service-card {
     width: 520px;
 }
@@ -62,77 +113,12 @@ body {
 .desktop-resolved-service-value-cell {
     width: 400px;
 }
-
-.resolved-service-card-title {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: inline-block;
-    font-size: var(--fontSizeBase400);
-}
-
-.mobile-resolved-service-card-title {
-    max-width: 475px;
-}
-
 .desktop-resolved-service-card-title {
     max-width: 510px;
 }
-
-.mobile-input > .thaw-input {
-    min-width: 180px;
-    max-width: 180px;
-}
-.mobile-input > .thaw-input__input {
-    min-width: 180px;
-    max-width: 180px;
-}
-
 .desktop-input > .thaw-input__input {
     border: 0;
 }
-
-.thaw-card-header__header {
-    justify-content: space-between;
-}
-
-.service-type-invalid > .thaw-input {
-    border: 2px groove var(--colorStatusDangerBorder1);
-}
-.service-type-valid > .thaw-input {
-    outline: 1px solid var(--colorTransparentStroke);
-}
-
-.resolved-service-details-dialog-title {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: inline-block;
-}
 .desktop-resolved-service-details-dialog-title {
     max-width: 520px;
-}
-.mobile-resolved-service-details-dialog-title {
-    max-width: 480px;
-}
-
-.resolved-service-details-dialog-body {
-    display: flex;
-    max-width: 90vw;
-}
-
-.resolved-service-details-dialog-scrollarea {
-    max-height: 90vh;
-}
-
-.resolved-service-dead {
-    color: var(--colorPaletteDarkOrangeForeground1);
-}
-
-.resolved-service-alive {
-    color: var(--colorBrandForeground1);
-}
-
-.theme-switcher {
-    cursor: pointer;
 }


### PR DESCRIPTION
* Calculate the top layout offset using `safe-area-inset-top`, to account for full screen is being used if built for release mode and having a front-camera hole in that area.
* Refactor CSS-styles to separate sections for common, mobile- and desktop-specific styles.
* Cleanup deprecated `gap gap` definitions
* Refactor `get_class()` to return the base class as first in the list
* Also fixes theme switcher top offset
