### PR TITLE
feat: enumerate_mdns_incapable_interfaces: skip loopback on Linux/Windows

### DIFF
--- a/.github/workflows/desktop-tauri.yml
+++ b/.github/workflows/desktop-tauri.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: ✅ Run tests
         run: |
-          cargo --locked test --package=models
+          cargo --locked test --package=models --package=mdns-browser
 
       - name: 🔑 Import windows signing certificate
         if: contains(matrix.os, 'windows')

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -371,7 +371,7 @@ mod tests {
     #[test]
     fn test_loopback_not_included_in_mdns_incapable_interfaces() {
         let result = enumerate_mdns_incapable_interfaces();
-        println!("{result:?}");
+        println!("Enumerated {result:?}");
         let loopback_names: std::collections::HashSet<String> = ipconfig::get_adapters()
             .map(|adapters| {
                 adapters


### PR DESCRIPTION
Closes #1316 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented loopback interfaces from being classified as mDNS-incapable on Linux and Windows, improving discovery accuracy and avoiding false warnings or misrouting.

* **Tests**
  * Added platform-specific tests verifying loopback interfaces are excluded from mDNS-incapable results to ensure consistent behavior across OSes.

* **Chores**
  * CI: expanded test step to run tests for multiple workspace crates (models and mdns-browser).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->