### PR TITLE
feat: Restructure details dialog: split header, add close button

### DIFF
--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -579,7 +579,7 @@ fn ResolvedServiceItem(
                                                         </DialogTitle>
                                                         <Button
                                                             size=ButtonSize::Small
-                                                            appearance=ButtonAppearance::Primary
+                                                            appearance=ButtonAppearance::Subtle
                                                             on_click=move |_| show_details.set(false)
                                                             icon=icondata::MdiClose
                                                         />


### PR DESCRIPTION
Closes #1333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a close button to the item details dialog for quick dismissal.

* **Style**
  * Redesigned the dialog header with balanced alignment and a separate icon, title, and dismiss control.
  * Scrolling now applies only to the content area for smoother navigation.
  * Details (Subtype, IPs, TXT) preserved and presented in a clearer vertical layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->