### PR TITLE
fix: Ensure details dialog close button is visible with long titles

### DIFF
--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -11,9 +11,9 @@ use tauri_sys::core::invoke;
 use thaw::{
     AutoComplete, AutoCompleteOption, AutoCompleteRef, AutoCompleteSize, Badge, BadgeAppearance,
     BadgeColor, BadgeSize, Button, ButtonAppearance, ButtonSize, Card, CardHeader, CardPreview,
-    ComponentRef, Dialog, DialogBody, DialogSurface, DialogTitle, Flex, FlexAlign, FlexGap,
-    FlexJustify, Grid, GridItem, Icon, Input, Layout, MessageBar, MessageBarBody, MessageBarIntent,
-    MessageBarTitle, Scrollbar, Select, Table, TableBody, TableCell, TableRow, Text, TextTag,
+    ComponentRef, Dialog, DialogBody, DialogSurface, Flex, FlexAlign, FlexGap, FlexJustify, Grid,
+    GridItem, Icon, Input, Layout, MessageBar, MessageBarBody, MessageBarIntent, MessageBarTitle,
+    Scrollbar, Select, Table, TableBody, TableCell, TableRow, Text, TextTag,
 };
 
 use super::{
@@ -572,11 +572,9 @@ fn ResolvedServiceItem(
                                                             icon=icondata::MdiCircle
                                                             class=dead_or_alive_icon_class
                                                         />
-                                                        <DialogTitle>
-                                                            <Text class="resolved-service-details-dialog-title">
-                                                                {move || title.get()}
-                                                            </Text>
-                                                        </DialogTitle>
+                                                        <Text class="resolved-service-details-dialog-title">
+                                                            {move || title.get()}
+                                                        </Text>
                                                         <Button
                                                             size=ButtonSize::Small
                                                             appearance=ButtonAppearance::Subtle

--- a/styles.css
+++ b/styles.css
@@ -25,6 +25,7 @@ body {
     font-size: var(--fontSizeBase400);
 }
 .resolved-service-details-dialog-title {
+    max-width: 75vw;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Closes #1338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the Resolved Service Details dialog title presentation for better readability. Titles now have a max-width and will truncate with an ellipsis to prevent overflow, especially on smaller screens. No changes to dialog behavior.

* **Refactor**
  * Simplified how the dialog title is rendered internally to reduce complexity while preserving the existing look and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->