### PR TITLE
feat: increase mDNS-Browser window width to 1615

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -58,7 +58,7 @@
             {
                 "title": "mDNS-Browser",
                 "url": "index.html",
-                "width": 1600,
+                "width": 1615,
                 "height": 900,
                 "label": "main",
                 "visible": false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the default window width of the mDNS-Browser from 1600 to 1615 pixels, offering a slightly wider viewport.
  * Improves content legibility and reduces truncation or horizontal scrolling in tight layouts.
  * Affects the initial/default window size (e.g., on first launch or after window settings reset).
  * No functional behavior changes; purely a minor UI sizing adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->