### PR TITLE
chore(aur): Disable fail-fast option when publishing to `AUR`

### DIFF
--- a/.github/workflows/publish-arch-linux-aur.yml
+++ b/.github/workflows/publish-arch-linux-aur.yml
@@ -23,6 +23,7 @@ jobs:
     container:
       image: ghcr.io/hrzlgnm/mdns-browser-arch-aur-builder:v1@sha256:950538ed4abbf523f2fbc3fc034bf584cee1afb54fa6593f327e7d3662f30704
     strategy:
+      fail-fast: false
       matrix:
         package:
           - name: mdns-browser-bin


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve job execution handling during matrix builds.

---

**Note:** This release contains no user-facing changes. The update addresses internal infrastructure processes only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->