### PR TITLE
fix: Enable the workaround for nvidia also when running in wayland

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -659,7 +659,7 @@ mod linux {
         // Check for Nvidia via glxinfo
         let nvidia_detected = check_nvidia_glxinfo()?;
         if nvidia_detected {
-            eprintln!("Note: nvidia|nouveau with X.Org|Wayland detected, disabling dmabuf renderer. Expect degraded renderer performance.");
+            eprintln!("Note: NVIDIA or Nouveau detected, disabling dmabuf renderer. Expect degraded renderer performance.");
             eprintln!("See https://github.com/hrzlgnm/mdns-browser/issues/947 for more details.");
         }
         Ok(nvidia_detected)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU detection to rely on direct driver checks for more accurate results.
  * Updated compatibility message to indicate "NVIDIA or Nouveau detected" (no platform-specific mentions).
  * Ensured the renderer-disable setting is applied reliably when forced or when NVIDIA/Nouveau is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->