### PR TITLE
chore(ci): Don't publish unused sha512 checksums

### DIFF
--- a/.github/workflows/release-checksums.yml
+++ b/.github/workflows/release-checksums.yml
@@ -35,7 +35,7 @@ jobs:
       - release_info
     strategy:
       matrix:
-        algorithm: [sha256, sha512]
+        algorithm: [sha256]
     steps:
       - name: download assets
         uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release checksum generation now uses SHA256 algorithm exclusively (previously supported both SHA256 and SHA512).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->