### PR TITLE
chore(ci): Use ubuntu builder docker image for lint steps

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -21,6 +21,15 @@ jobs:
           components: rustfmt, clippy
           targets: wasm32-unknown-unknown
 
+      - name: 📦 Rust cache
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            shared_constants -> ./target
+            models -> ./target
+            src-tauri -> ./target
+
       - name: 📝 Check spelling using typos-action
         uses: crate-ci/typos@80c8a4945eec0f6d464eaf9e65ed98ef085283d1 # v1.38.1
 


### PR DESCRIPTION
Closes #1471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the continuous integration lint workflow to use containerized builds and implement Rust-specific caching on the main branch, improving build performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->