### PR TITLE
chore(ci): Enable sccache when running clippy

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -64,6 +64,11 @@ jobs:
           components: clippy
           targets: ${{ matrix.os == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin,wasm32-unknown-unknown' || 'wasm32-unknown-unknown' }}
 
+      - name: 🛠️🚀
+        uses: ./.github/actions/setup-sccache
+        with:
+          enabled: true
+
       - name: 📎 Run clippy and fail if any warnings
         shell: bash
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow by enabling build caching for improved compilation performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->