### PR TITLE
chore(ci): Handle enabling `sccache` correctly

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -4,13 +4,14 @@ inputs:
   enabled:
     description: Enable sccache usage
     required: true
+    type: boolean
 runs:
   using: "composite"
   steps:
-    - if: ${{ inputs.enabled }}
+    - if: inputs.enabled
       uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
-    - if: ${{ inputs.enabled }}
+    - if: inputs.enabled
       shell: bash
       run: |
         echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV


### PR DESCRIPTION
Otherwise sccache is also used in publish release workflows, where we don't want it to happen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions build configuration with explicit input type definitions to enhance validation and configuration management in action workflows.
  * Enhanced build environment setup with additional caching optimization configuration variables to improve build performance, efficiency, and consistency.
  * Refined action workflow conditional logic handling for better workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->