### PR TITLE
chore(ci): Fix conditional `sccache`

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,22 +1,12 @@
 name: Setup sccache
 description: Sets up sccache
-inputs:
-  enabled:
-    description: Enable sccache usage
-    required: true
-    type: boolean
+
 runs:
   using: "composite"
   steps:
+    - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
     - shell: bash
-      run: |
-        echo "🔍Setting up sccache is enabled: ${{ inputs.enabled }}"
-
-    - if: inputs.enabled == 'true'
-      uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-
-    - if: inputs.enabled == 'true'
-      shell: bash
       run: |
         echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
         echo "RUSTC_WRAPPER=${SCCACHE_PATH}" >> $GITHUB_ENV

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -63,9 +63,8 @@ jobs:
         uses: ./.github/actions/setup-tauri
 
       - name: 🛠️🚀
+        if: ${{ !inputs.publish }}
         uses: ./.github/actions/setup-sccache
-        with:
-          enabled: ${{ !inputs.publish }}
 
       - name: 🔨 Build app bundle
         run: |

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -66,8 +66,6 @@ jobs:
 
       - name: 🛠️🚀
         uses: ./.github/actions/setup-sccache
-        with:
-          enabled: true
 
       - name: 📎 Run clippy and fail if any warnings
         shell: bash

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: 🛠️🚀
         uses: ./.github/actions/setup-sccache
-        with:
-          enabled: true
 
       - name: ✅ Run tests
         shell: bash

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -66,9 +66,8 @@ jobs:
         uses: ./.github/actions/setup-tauri
 
       - name: 🛠️🚀
+        if: ${{ inputs.tagName == '' }}
         uses: ./.github/actions/setup-sccache
-        with:
-          enabled: ${{ inputs.tagName == '' }}
 
       - name: 🔑 Import windows signing certificate (windows only)
         if: contains(matrix.os, 'windows')


### PR DESCRIPTION
Composite action steps don't support `if:` conditions and are always run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified CI workflow logic around the build cache setup, consolidating and standardizing execution conditions across workflows to make build behavior more consistent and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->