### PR TITLE
Revert "chore(ci): winget: Fix url generation after artifact name change"

### DIFF
--- a/.github/workflows/winget-publish-release.yml
+++ b/.github/workflows/winget-publish-release.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           VERSION=${{ steps.latest_release.outputs.result }}
           SHORT_VERSION=${VERSION#*-v}
-          URL=https://github.com/hrzlgnm/mdns-browser/releases/download/{VERSION}/mdns-browser_{SHORT_VERSION}_x64-setup_windows.exe
+          URL=https://github.com/hrzlgnm/mdns-browser/releases/download/{VERSION}/mdns-browser_{SHORT_VERSION}_x64-setup.exe
           FINAL_URL=$(echo $URL | sed "s/{VERSION}/$VERSION/g" | sed "s/{SHORT_VERSION}/${SHORT_VERSION}/g")
           echo "FINAL_URL=$FINAL_URL" >> $GITHUB_ENV
           echo "SHORT_VERSION=$SHORT_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
Reverts hrzlgnm/mdns-browser#1474
The name change of artifacts was fixed to use the previous names with an update of tauri-action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows installer file naming convention in the release workflow to simplify the filename pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->