### PR TITLE
chore(ci): Move android specific steps after rust steps

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -41,18 +41,6 @@ jobs:
             exit 1
           fi
 
-      - name: ☕ Setup Java
-        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5
-        with:
-          distribution: "zulu"
-          java-version: "17"
-
-      - name: 🤖 Setup Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
-
-      - name: 🛠️ Install NDK
-        run: sdkmanager "ndk;27.0.11902837"
-
       - name: 🦀🚀
         uses: ./.github/actions/setup-rust-cache
         with:
@@ -65,6 +53,18 @@ jobs:
       - name: 🛠️🚀
         if: ${{ !inputs.publish }}
         uses: ./.github/actions/setup-sccache
+
+      - name: ☕ Setup Java
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5
+        with:
+          distribution: "zulu"
+          java-version: "17"
+
+      - name: 🤖 Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: 🛠️ Install NDK
+        run: sdkmanager "ndk;27.0.11902837"
 
       - name: 🔨 Build app bundle
         run: |


### PR DESCRIPTION
So java environment changes don't have an influence on the rust cache and installed tools hashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reordered Android build workflow steps for improved efficiency, with Java, Android SDK, and NDK setup now occurring after cache configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->