### PR TITLE
chore(void): Attest build provenance when publishing only

### DIFF
--- a/.github/workflows/void.yml
+++ b/.github/workflows/void.yml
@@ -72,6 +72,7 @@ jobs:
           xbps-rindex --privkey private.pem --sign-pkg hostdir/binpkgs/*.xbps
 
       - name: 🛡️ Attest build provenance (publish release only)
+        if: inputs.tagName
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
           subject-path: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build provenance attestation now only executes when a release tag is provided, preventing unnecessary attestation attempts during standard builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->