### PR TITLE
chore(winget): Bump komac to 2.13.0

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -32,7 +32,7 @@ jobs:
       - name: 🆙 winget package
         uses: michidk/run-komac@9b27eadc6e9235c252444a437d246c139da2f57f # v2.1.0
         with:
-          komac-version: "2.8.0"
+          komac-version: "2.13.0"
           args: "update hrzlgnm.mdns-browser --version $VERSION --urls $URL --submit --token=${{ secrets.WINGET_TOKEN }}"
 
   cleanup:
@@ -43,5 +43,5 @@ jobs:
       - name: 🧹
         uses: michidk/run-komac@9b27eadc6e9235c252444a437d246c139da2f57f # v2.1.0
         with:
-          komac-version: "2.8.0"
+          komac-version: "2.13.0"
           args: "cleanup --only-merged --token=${{ secrets.WINGET_TOKEN }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling version in CI/CD workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->