### PR TITLE
chore(winget): Always use latest version of `komac`

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -32,7 +32,6 @@ jobs:
       - name: 🆙 winget package
         uses: michidk/run-komac@9b27eadc6e9235c252444a437d246c139da2f57f # v2.1.0
         with:
-          komac-version: "2.13.0"
           args: "update hrzlgnm.mdns-browser --version $VERSION --urls $URL --submit --token=${{ secrets.WINGET_TOKEN }}"
 
   cleanup:
@@ -43,5 +42,4 @@ jobs:
       - name: 🧹
         uses: michidk/run-komac@9b27eadc6e9235c252444a437d246c139da2f57f # v2.1.0
         with:
-          komac-version: "2.13.0"
           args: "cleanup --only-merged --token=${{ secrets.WINGET_TOKEN }}"


### PR DESCRIPTION
Closes #1613 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to use the latest version of a dependency, removing explicit version pinning to allow dynamic updates.

---

**Note:** This release contains no user-facing changes; updates are limited to internal build and deployment infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->