### PR TITLE
chore(void): Install xtools for linting void packages

### DIFF
--- a/.github/docker/mdns-browser-void-package-builder/Dockerfile
+++ b/.github/docker/mdns-browser-void-package-builder/Dockerfile
@@ -13,6 +13,7 @@ RUN xbps-install -Syu xbps \
     jq \
     rustup \
     util-linux \
+    xtools \
     && xbps-remove -Ooy
 RUN rustup-init -y -q \
     && . $HOME/.cargo/env \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment dependencies to enhance package builder infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->