### PR TITLE
chore(aur): Disable signing when building the bundle artifacts

### DIFF
--- a/aur-template/generate-mdns-browser.sh
+++ b/aur-template/generate-mdns-browser.sh
@@ -38,8 +38,7 @@ build() {
     export CFLAGS="\${CFLAGS//-flto=auto//}"
     # build the normal binary without bundling first
     cargo --locked --frozen auditable tauri build --no-bundle
-    # to get the artifacts for packaging, but ignore errors due to missing signing keys
-    cargo --locked --frozen auditable tauri build -b deb || true
+    cargo --locked --frozen auditable tauri build -b deb --no-sign
 }
 check() {
     cd "\$srcdir/\$_builddir" || exit 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Enhanced the Debian package build process to enforce stricter error detection and explicit signing verification during packaging. Removed previous error suppression behavior to ensure build failures are properly reported when issues occur.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->