### PR TITLE
Revert "fix(aur): Add workaround for `--no-sign` not working as expected"

### DIFF
--- a/aur-template/generate-mdns-browser.sh
+++ b/aur-template/generate-mdns-browser.sh
@@ -2,7 +2,6 @@
 # Copyright 2024-2025 hrzlgnm
 # SPDX-License-Identifier: MIT-0
 
-
 version=$1
 sha256sum=$2
 


### PR DESCRIPTION
Reverts hrzlgnm/mdns-browser#1687
Is not needed anymore as the issue has been fixed upstream, and tauri-cli updated respectively with #1688 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build process simplified to a single, strict build step; failures are no longer suppressed.
  * Removed previous workaround and related explanatory comments about ignored build errors.
  * Improved reliability and clearer reporting when packaging fails, so build issues are now surfaced promptly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->