### PR TITLE
fix: skip service subtypes in service type enumeration

### DIFF
--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -225,7 +225,7 @@ pub enum MdnsError {
     #[error("The service type label is not well formed")]
     InvalidService,
     #[error("The service sub type label is not well formed")]
-    InvalidSubtype,
+    InvalidSubType,
     #[error("The service sub label is invalid, expected `_sub`")]
     InvalidSublabel,
     #[error("The protocol is invalid, expected `_tcp` or `_udp`")]
@@ -239,13 +239,13 @@ pub enum MdnsError {
 #[derive(PartialEq, Eq, Debug)]
 pub enum MdnsLabelType {
     ServiceType,
-    Subtype,
+    SubType,
 }
 
 fn check_mdns_label(label: &str, is_subtype: bool) -> Result<MdnsLabelType, MdnsError> {
     let valid_dns_chars = |c: char| c.is_ascii_alphanumeric() || c == '-' || c == '_';
     let error = if is_subtype {
-        MdnsError::InvalidSubtype
+        MdnsError::InvalidSubType
     } else {
         MdnsError::InvalidService
     };
@@ -281,7 +281,7 @@ fn check_mdns_label(label: &str, is_subtype: bool) -> Result<MdnsLabelType, Mdns
     }
 
     if is_subtype {
-        Ok(MdnsLabelType::Subtype)
+        Ok(MdnsLabelType::SubType)
     } else {
         Ok(MdnsLabelType::ServiceType)
     }
@@ -690,7 +690,7 @@ mod tests {
         );
         assert_eq!(
             check_service_type_fully_qualified("_myprinter._sub._http._tcp.local."),
-            Ok(MdnsLabelType::Subtype)
+            Ok(MdnsLabelType::SubType)
         );
     }
 
@@ -742,11 +742,11 @@ mod tests {
         ); // Invalid service name format
         assert_eq!(
             check_service_type_fully_qualified("_-printer._sub._http._tcp.local."),
-            Err(MdnsError::InvalidSubtype)
+            Err(MdnsError::InvalidSubType)
         ); // Invalid subtype name format
         assert_eq!(
             check_service_type_fully_qualified("_printer-._sub._http._tcp.local."),
-            Err(MdnsError::InvalidSubtype)
+            Err(MdnsError::InvalidSubType)
         ); // Invalid subtype name format
         assert_eq!(
             check_service_type_fully_qualified("_printer._pub._http._tcp.local."),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -155,7 +155,7 @@ fn browse_types(window: Window, state: State<ManagedState>) -> Result<(), String
                                 },
                             );
                         }
-                        Ok(MdnsLabelType::Subtype) => {
+                        Ok(MdnsLabelType::SubType) => {
                             log::debug!(
                                 "Ignoring subtype `{full_name}` found during service type browsing"
                             );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Browsing now emits events only for actual service types, ignoring subtypes to prevent misleading results.

* **Refactor**
  * Validation now returns explicit type information so discovery results are handled more precisely.

* **Tests**
  * Updated tests to cover both service type and subtype scenarios, ensuring accurate behavior across valid inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->