### PR TITLE
chore: Increase release optimization to level 'z' and retain debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,11 @@ edition = "2021"
 
 [profile.release]
 codegen-units = 1
-debug = true
 lto = true
-opt-level = "s"
+opt-level = "z"
 panic = "abort"
+debug = true
+split-debuginfo = "packed"
 strip = "debuginfo"
 
 [dependencies]


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release build to use a more aggressive optimization level.
  * Enabled debug information in release builds and configured packed split debug info for improved debugging support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Optimization Level Testing Results

This PR changes the release optimization settings. Here are the binary size results for different optimization levels (keeping all other release profile settings unchanged):

| opt-level | Binary Size | Description |
|-----------|-------------|-------------|
| 0 | 47M | No optimization (largest) |
| 1 | 16M | Basic optimization |
| 2 | 16M | Moderate optimization |
| 3 | 16M | Full optimization |
| "s" | 11M | Optimize for size |
| "z" | 11M | Optimize for size aggressively (best) |

**Key Findings:**
- opt-level 0 produces the largest binary (47M) - no optimization
- opt-level 1, 2, 3 all produce the same size (16M) - basic to full optimization
- opt-level "s" and "z" both produce the smallest binaries (11M) - size optimization
- opt-level "z" provides the best binary size reduction at 11M
- The jump from opt-level 0 to 1 provides the most significant size reduction (47M → 16M)

This configuration change optimizes the binary for minimal size while maintaining the existing LTO, codegen-units, and panic settings.