### PR TITLE
feat: Enable full binary stripping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ opt-level = "z"
 panic = "abort"
 debug = true
 split-debuginfo = "packed"
-strip = "debuginfo"
+strip = true
 
 [dependencies]
 # crates


### PR DESCRIPTION
Symbols are not needed anymore after tauri-cli update with  #1848

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized how debug information is handled during release builds, improving build configuration efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->