### PR TITLE
chore: update copyright years to 2026

### DIFF
--- a/.github/workflows/void-reusable.yml
+++ b/.github/workflows/void-reusable.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 hrzlgnm
+# Copyright 2025-2026 hrzlgnm
 # SPDX-License-Identifier: MIT-0
 
 name: Void Linux XBPS Package

--- a/packaging/aur/generate-mdns-browser.sh
+++ b/packaging/aur/generate-mdns-browser.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2024-2025 hrzlgnm
+# Copyright 2024-2026 hrzlgnm
 # SPDX-License-Identifier: MIT-0
 
 version=$1

--- a/packaging/void/generate-template.sh
+++ b/packaging/void/generate-template.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 hrzlgnm
+# Copyright 2025-2026 hrzlgnm
 # SPDX-License-Identifier: MIT-0
 
 version=$1


### PR DESCRIPTION
## Summary
- Updated copyright years in file headers to include 2026
- Updated .github/workflows/void-reusable.yml, packaging/aur/generate-mdns-browser.sh, and packaging/void/generate-template.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright years in build workflow and packaging configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->