### PR TITLE
chore: make all dependencies workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,18 @@ resolver = "2"
 chrono = "0.4"
 reactive_stores = "0.3"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_with = "3"
 log = "0.4"
 thiserror = "2.0"
 tokio = { version = "1.45", features = ["time"] }
 os-release = "0.1.0"
+mdns-sd = "0.18"
+tauri = { version = "2.0", features = ["devtools"] }
+tauri-plugin-clipboard-manager = "2.2"
+tauri-plugin-log = { version = "2.4", features = ["colored"] }
+tauri-plugin-opener = "2.2"
+tauri-plugin-updater = "2.0"
+pnet = "0.35"
+ipconfig = "0.3"
+clap = { version = "4.5", features = ["derive"] }

--- a/crates/models/Cargo.toml
+++ b/crates/models/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 reactive_stores = { workspace = true }
 serde = { workspace = true }
-serde_with = "3"
+serde_with = { workspace = true }
 thiserror = { workspace = true }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,21 +9,21 @@ edition = "2021"
 tauri-build = { version = "2.2", features = [] }
 
 [target.'cfg(not(any(target_os="android",target_os="ios")))'.dependencies]
-clap = { version = "4.5", features = ["derive"] }
-tauri-plugin-updater = "2.0"
+clap = { workspace = true }
+tauri-plugin-updater = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true }
 
 [dependencies]
 # crates
 log = { workspace = true }
-mdns-sd = "0.18"
+mdns-sd = { workspace = true }
 serde = { workspace = true }
-serde_json = "1.0"
-tauri = { version = "2.0", features = ["devtools"] }
-tauri-plugin-clipboard-manager = "2.2"
-tauri-plugin-log = { version = "2.4", features = ["colored"] }
-tauri-plugin-opener = "2.2"
+serde_json = { workspace = true }
+tauri = { workspace = true }
+tauri-plugin-clipboard-manager = { workspace = true }
+tauri-plugin-log = { workspace = true }
+tauri-plugin-opener = { workspace = true }
 tokio = { workspace = true }
 
 # local
@@ -32,10 +32,10 @@ shared_constants = { path = "../crates/shared_constants" }
 
 # platform-specific dependencies
 [target.'cfg(not(windows))'.dependencies]
-pnet = "0.35"
+pnet = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-ipconfig = "0.3"
+ipconfig = { workspace = true }
 
 [target.'cfg(target_os="linux")'.dependencies]
 os-release.workspace = true


### PR DESCRIPTION
## Summary
- Moved all external dependencies from src-tauri/Cargo.toml to workspace dependencies in root Cargo.toml
- Also converted serde_with in crates/models/Cargo.toml to workspace dependency
- Closes #1907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependency management and workspace configuration for improved build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->