### PR TITLE
fix: upload sbom to release in workflow_call context

### DIFF
--- a/.github/workflows/publish-sbom-reusable.yml
+++ b/.github/workflows/publish-sbom-reusable.yml
@@ -23,9 +23,11 @@ jobs:
     steps:
       - name: 🏷️
         id: tag
+        env:
+          TAG_NAME: ${{ inputs.tagName }}
         run: |
-          if [ -n "${{ inputs.tagName }}" ]; then
-            echo "tag=${{ inputs.tagName }}" >> $GITHUB_OUTPUT
+          if [ -n "$TAG_NAME" ]; then
+            echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
           else
             echo "No tag provided" && exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,7 @@ jobs:
         build_android,
         build_desktop,
         build_void,
+        asset_checksums,
       ]
     if: (inputs.create-release && !inputs.dry-run)
     permissions:


### PR DESCRIPTION
Closes #1909 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release pipeline now publishes Software Bill of Materials (SBOM) artifacts and attaches them to releases for improved transparency of dependencies.
  * SBOM publishing runs as part of the release process and aggregates multiple SBOM files into the release assets.
  * Optional release tag can be specified when publishing SBOMs to target a specific release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->