### PR TITLE
chore: Remove debug logs for received events

### DIFF
--- a/src/app/listen.rs
+++ b/src/app/listen.rs
@@ -54,7 +54,6 @@ pub(crate) async fn listen_events<T, F, S, Fut>(
     subscriber().await;
 
     while let Some(event) = events.next().await {
-        log::debug!("Received event {}: {:#?}", event_name, event.payload);
         process_event(event.payload);
     }
 }
@@ -156,13 +155,11 @@ pub(crate) async fn listen_add_remove<A, R, FA, FR, S, Fut>(
         select! {
             added = added_fused.next() => {
                 if let Some(added) = added {
-                    log::debug!("Received event '{}': {:#?}", added_event_name, added.payload);
                     process_added(added.payload);
                 }
             },
             removed = removed_fused.next() => {
                 if let Some(removed) = removed {
-                    log::debug!("Received event '{}': {:#?}", removed_event_name, removed.payload);
                     process_removed(removed.payload);
                 }
             },


### PR DESCRIPTION
Removed debug logging for received events in listen.rs.
Closes #1920 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug logging statements from event handling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->