### PR TITLE
chore: consolidate winget jobs to install komac only once

### DIFF
--- a/.github/workflows/winget-reusable.yml
+++ b/.github/workflows/winget-reusable.yml
@@ -48,11 +48,8 @@ jobs:
         with:
           args: "update hrzlgnm.mdns-browser --version $VERSION --urls $URL --submit --token=$WINGET_TOKEN"
 
-  cleanup:
-    name: 🧹 branches
-    runs-on: ubuntu-latest
-    steps:
       - name: 🧹 Cleanup merged branches
+        if: always()
         env:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
         uses: michidk/run-komac@9b27eadc6e9235c252444a437d246c139da2f57f # v2.1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of cleanup operations in the package publishing workflow to ensure they execute consistently regardless of other step outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->