### PR TITLE
chore: Add cargo badge for webkit2gtk-nvidia-quirk

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![AUR Version](https://img.shields.io/aur/version/mdns-browser-bin)](https://aur.archlinux.org/packages/mdns-browser-bin)
 [![License: MIT](https://img.shields.io/github/license/hrzlgnm/mdns-browser)](https://github.com/hrzlgnm/mdns-browser/blob/main/LICENSE)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/hrzlgnm/mdns-browser/ci.yml)](https://github.com/hrzlgnm/mdns-browser/actions)
+[![Cargo webkit2gtk-nvidia-quirk](https://img.shields.io/crates/v/webkit2gtk-nvidia-quirk.svg)](https://crates.io/crates/webkit2gtk-nvidia-quirk)
 
 # mDNS-Browser
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a crates.io version badge to the README for quick access to the latest package information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->