### PR TITLE
fix: ensure url memo tracks reactive field changes

### DIFF
--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -449,11 +449,11 @@ fn ResolvedServiceItem(
     });
 
     let url = Memo::new(move |_| {
-        let _ = resolved_service.addresses().get();
-        let _ = resolved_service.txt().get();
-        let _ = resolved_service.service_type().get();
-        let _ = resolved_service.port().get();
-        get_open_url(&resolved_service.get())
+        resolved_service.addresses().track();
+        resolved_service.txt().track();
+        resolved_service.service_type().track();
+        resolved_service.port().track();
+        resolved_service.with(get_open_url)
     });
 
     let on_open_click = move |_| {

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -448,7 +448,13 @@ fn ResolvedServiceItem(
         async move { open_url(url.as_str()).await }
     });
 
-    let url = Memo::new(move |_| get_open_url(&resolved_service.get()));
+    let url = Memo::new(move |_| {
+        let _ = resolved_service.addresses().get();
+        let _ = resolved_service.txt().get();
+        let _ = resolved_service.service_type().get();
+        let _ = resolved_service.port().get();
+        get_open_url(&resolved_service.get())
+    });
 
     let on_open_click = move |_| {
         if let Some(url) = url.get() {


### PR DESCRIPTION
## Summary

- Add explicit field dependencies to the `url` memo in `ResolvedServiceItem` to ensure reactivity to changes in addresses, txt, service_type, and port fields
- This fixes an issue where IP address changes were not being detected reactively when using `Field<ResolvedService>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL tracking to properly update when service properties such as addresses, service type, and port information change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->