### PR TITLE
fix: handle disposal gracefully in ResolvedServiceItem component

### DIFF
--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -422,6 +422,12 @@ fn ResolvedRow(
 }
 
 /// Component that shows a resolved service reactivly as a card
+///
+/// This component uses `try_get()` for all accesses to `resolved_service` fields
+/// to gracefully handle disposal. When the quick filter changes, the parent
+/// `filtered` store replaces its items which disposes the old `Field<ResolvedService>`
+/// wrappers. Without `try_get()`, accessing disposed fields would panic with
+/// "you tried to access a reactive value which was already been disposed".
 #[component]
 fn ResolvedServiceItem(
     #[prop(into)] resolved_service: Field<ResolvedService>,

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -453,7 +453,7 @@ fn ResolvedServiceItem(
         resolved_service.txt().track();
         resolved_service.service_type().track();
         resolved_service.port().track();
-        resolved_service.with(get_open_url)
+        resolved_service.try_get().and_then(|rs| get_open_url(&rs))
     });
 
     let on_open_click = move |_| {
@@ -462,42 +462,59 @@ fn ResolvedServiceItem(
         }
     };
 
-    let updated_at =
-        Memo::new(move |_| to_local_timestamp(resolved_service.updated_at_micros().get()));
+    let updated_at = Memo::new(move |_| {
+        resolved_service
+            .try_get()
+            .map_or_else(String::new, |rs| to_local_timestamp(rs.updated_at_micros))
+    });
 
     let addrs = Memo::new(move |_| {
         resolved_service
-            .addresses()
-            .get()
-            .iter()
-            .map(|a| a.to_string())
-            .collect::<Vec<_>>()
+            .try_get()
+            .map(|rs| {
+                rs.addresses
+                    .iter()
+                    .map(|a| a.to_string())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
     });
 
     let addrs_for_copy = Memo::new(move |_| {
         resolved_service
-            .addresses()
-            .get()
-            .iter()
-            .map(|a| a.to_ip_string())
-            .collect::<Vec<_>>()
+            .try_get()
+            .map(|rs| {
+                rs.addresses
+                    .iter()
+                    .map(|a| a.to_ip_string())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
     });
 
     let txts = Memo::new(move |_| {
         resolved_service
-            .txt()
-            .get()
-            .iter()
-            .map(|t| t.to_string())
-            .collect::<Vec<_>>()
+            .try_get()
+            .map(|rs| rs.txt.iter().map(|t| t.to_string()).collect::<Vec<_>>())
+            .unwrap_or_default()
     });
 
-    let subtype = Memo::new(move |_| match resolved_service.subtype().get() {
-        None => vec![],
-        Some(s) => vec![s.to_owned()],
+    let subtype = Memo::new(move |_| {
+        resolved_service
+            .try_get()
+            .map(|rs| match &rs.subtype {
+                None => vec![],
+                Some(s) => vec![s.to_owned()],
+            })
+            .unwrap_or_default()
     });
 
-    let title = Signal::derive(move || resolved_service.get().get_instance_name());
+    let title = Memo::new(move |_| {
+        resolved_service
+            .try_get()
+            .map(|rs| rs.get_instance_name())
+            .unwrap_or_default()
+    });
     let show_details = RwSignal::new(false);
     let first_address = Memo::new(move |_| {
         addrs
@@ -508,38 +525,52 @@ fn ResolvedServiceItem(
     });
     let first_address_for_copy = Memo::new(move |_| {
         resolved_service
-            .addresses()
-            .get()
-            .first()
-            .map(|a| a.to_ip_string())
+            .try_get()
+            .and_then(|rs| rs.addresses.first().map(|a| a.to_ip_string()))
             .unwrap_or_default()
     });
 
     let first_address_display = Memo::new(move |_| {
-        let additional_addrs = resolved_service.addresses().get().len() - 1;
-        if additional_addrs > 0 {
-            format!("{} (+{})", first_address.get(), additional_addrs)
-        } else {
-            first_address.get()
-        }
+        resolved_service.try_get().map_or_else(String::new, |rs| {
+            let additional_addrs = rs.addresses.len().saturating_sub(1);
+            let first = first_address.get();
+            if additional_addrs > 0 {
+                format!("{} (+{})", first, additional_addrs)
+            } else {
+                first
+            }
+        })
     });
 
     let is_desktop = IsDesktopInjection::expect_context();
     let card_class = get_class(&is_desktop, "resolved-service-card");
     let value_cell_class = get_class(&is_desktop, "resolved-service-value-cell");
     let dead = resolved_service.dead();
-    // Avoid disposed-scope panics: read via try_get() default to dead when unavailable
     let dead = {
         let dead_signal = dead;
         Memo::new(move |_| dead_signal.try_get().unwrap_or(true))
     };
-    let port = Memo::new(move |_| resolved_service.port().get().to_string());
+    let port = Memo::new(move |_| {
+        resolved_service
+            .try_get()
+            .map(|rs| rs.port.to_string())
+            .unwrap_or_default()
+    });
     let hostname = resolved_service.hostname();
-    let hostname_display = Memo::new(move |_| drop_trailing_dot(&hostname.get()));
+    let hostname_display = Memo::new(move |_| {
+        hostname
+            .try_get()
+            .map(|h| drop_trailing_dot(h.as_str()))
+            .unwrap_or_default()
+    });
     let instance_fullname = resolved_service.instance_fullname();
     let service_type = resolved_service.service_type();
-    let service_type_display =
-        Memo::new(move |_| drop_local_and_trailing_dot(service_type.get().as_str()));
+    let service_type_display = Memo::new(move |_| {
+        service_type
+            .try_get()
+            .map(|s| drop_local_and_trailing_dot(s.as_str()))
+            .unwrap_or_default()
+    });
     let dead_or_alive_icon_class = Memo::new(move |_| {
         if dead.get() {
             "resolved-service-dead".to_string()

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -454,17 +454,19 @@ fn ResolvedServiceItem(
         async move { open_url(url.as_str()).await }
     });
 
-    let url = Memo::new(move |_| {
-        resolved_service.addresses().track();
-        resolved_service.txt().track();
-        resolved_service.service_type().track();
-        resolved_service.port().track();
-        resolved_service.try_get().and_then(|rs| get_open_url(&rs))
+    let url: Memo<Option<String>> = Memo::new(move |_| {
+        resolved_service.try_get().and_then(|rs| {
+            resolved_service.addresses().track();
+            resolved_service.txt().track();
+            resolved_service.service_type().track();
+            resolved_service.port().track();
+            get_open_url(&rs)
+        })
     });
 
     let on_open_click = move |_| {
-        if let Some(url) = url.get() {
-            open_action.dispatch(url.clone());
+        if let Some(url_to_open) = url.get() {
+            open_action.dispatch(url_to_open);
         }
     };
 
@@ -478,6 +480,7 @@ fn ResolvedServiceItem(
         resolved_service
             .try_get()
             .map(|rs| {
+                resolved_service.addresses().track();
                 rs.addresses
                     .iter()
                     .map(|a| a.to_string())
@@ -490,6 +493,7 @@ fn ResolvedServiceItem(
         resolved_service
             .try_get()
             .map(|rs| {
+                resolved_service.addresses().track();
                 rs.addresses
                     .iter()
                     .map(|a| a.to_ip_string())
@@ -501,16 +505,22 @@ fn ResolvedServiceItem(
     let txts = Memo::new(move |_| {
         resolved_service
             .try_get()
-            .map(|rs| rs.txt.iter().map(|t| t.to_string()).collect::<Vec<_>>())
+            .map(|rs| {
+                resolved_service.txt().track();
+                rs.txt.iter().map(|t| t.to_string()).collect::<Vec<_>>()
+            })
             .unwrap_or_default()
     });
 
     let subtype = Memo::new(move |_| {
         resolved_service
             .try_get()
-            .map(|rs| match &rs.subtype {
-                None => vec![],
-                Some(s) => vec![s.to_owned()],
+            .map(|rs| {
+                resolved_service.track();
+                match &rs.subtype {
+                    None => vec![],
+                    Some(s) => vec![s.to_owned()],
+                }
             })
             .unwrap_or_default()
     });
@@ -518,7 +528,11 @@ fn ResolvedServiceItem(
     let title = Memo::new(move |_| {
         resolved_service
             .try_get()
-            .map(|rs| rs.get_instance_name())
+            .map(|rs| {
+                resolved_service.instance_fullname().track();
+                resolved_service.service_type().track();
+                rs.get_instance_name()
+            })
             .unwrap_or_default()
     });
     let show_details = RwSignal::new(false);
@@ -532,12 +546,16 @@ fn ResolvedServiceItem(
     let first_address_for_copy = Memo::new(move |_| {
         resolved_service
             .try_get()
-            .and_then(|rs| rs.addresses.first().map(|a| a.to_ip_string()))
+            .and_then(|rs| {
+                resolved_service.addresses().track();
+                rs.addresses.first().map(|a| a.to_ip_string())
+            })
             .unwrap_or_default()
     });
 
     let first_address_display = Memo::new(move |_| {
         resolved_service.try_get().map_or_else(String::new, |rs| {
+            resolved_service.addresses().track();
             let additional_addrs = rs.addresses.len().saturating_sub(1);
             let first = first_address.get();
             if additional_addrs > 0 {
@@ -559,7 +577,10 @@ fn ResolvedServiceItem(
     let port = Memo::new(move |_| {
         resolved_service
             .try_get()
-            .map(|rs| rs.port.to_string())
+            .map(|rs| {
+                resolved_service.port().track();
+                rs.port.to_string()
+            })
             .unwrap_or_default()
     });
     let hostname = resolved_service.hostname();

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -455,7 +455,13 @@ fn ResolvedServiceItem(
     });
 
     let url: Memo<Option<String>> = Memo::new(move |_| {
-        resolved_service.try_get().and_then(|rs| get_open_url(&rs))
+        resolved_service.try_get().and_then(|rs| {
+            resolved_service.addresses().track();
+            resolved_service.txt().track();
+            resolved_service.service_type().track();
+            resolved_service.port().track();
+            get_open_url(&rs)
+        })
     });
 
     let on_open_click = move |_| {

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 hrzlgnm
+// Copyright 2026 hrzlgnm
 // SPDX-License-Identifier: MIT-0
 
 use chrono::{DateTime, Local};
@@ -455,13 +455,7 @@ fn ResolvedServiceItem(
     });
 
     let url: Memo<Option<String>> = Memo::new(move |_| {
-        resolved_service.try_get().and_then(|rs| {
-            resolved_service.addresses().track();
-            resolved_service.txt().track();
-            resolved_service.service_type().track();
-            resolved_service.port().track();
-            get_open_url(&rs)
-        })
+        resolved_service.try_get().and_then(|rs| get_open_url(&rs))
     });
 
     let on_open_click = move |_| {


### PR DESCRIPTION
## Summary

- Fixed panic when typing in the quick filter input by handling disposal gracefully in the `ResolvedServiceItem` component
- When the quick filter changes, the filtered store replaces its items which disposes the old `Field<ResolvedService>` wrappers
- Previously, the component would panic when trying to access disposed reactive values
- Now all accesses to `resolved_service` fields use `try_get()` to gracefully handle disposal, returning default/empty values when the field is no longer available

## Changes

- Updated all Memos in `ResolvedServiceItem` that access `resolved_service` fields to use `try_get()` instead of direct access
- Fields now return sensible defaults (empty strings, empty vectors) when the field is disposed
- The `url` Memo specifically uses `and_then()` to preserve Option<String> behavior while 
handling disposal


Closes #2114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable service information in the browse interface
  * Fixed potential arithmetic error in address count calculation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
