### PR TITLE
fix: resolve variable shadowing and replace Memo with Signal::derive

### DIFF
--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -453,7 +453,9 @@ fn ResolvedServiceItem(
     let verifying = RwSignal::new(false);
     let on_verify_click = move |_| {
         verifying.set(true);
-        if let Some(instance_fullname) = rs.with(|s| s.as_ref().map(|r| r.instance_fullname.clone())) {
+        if let Some(instance_fullname) =
+            rs.with(|s| s.as_ref().map(|r| r.instance_fullname.clone()))
+        {
             verify_action.dispatch(instance_fullname);
         }
         set_timeout(

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -453,8 +453,8 @@ fn ResolvedServiceItem(
     let verifying = RwSignal::new(false);
     let on_verify_click = move |_| {
         verifying.set(true);
-        if let Some(rs) = rs.get() {
-            verify_action.dispatch(rs.instance_fullname.clone());
+        if let Some(resolved) = rs.get() {
+            verify_action.dispatch(resolved.instance_fullname.clone());
         }
         set_timeout(
             move || {
@@ -693,7 +693,7 @@ fn ResolvedServiceItem(
                                             size=ButtonSize::Small
                                             appearance=ButtonAppearance::Primary
                                             on_click=on_open_click
-                                            disabled=Memo::new(move |_| { url.get().is_none() })
+                                            disabled=Signal::derive(move || url.get().is_none())
                                             icon=icondata::MdiOpenInNew
                                         >
                                             "Open"

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -693,7 +693,7 @@ fn ResolvedServiceItem(
                                             size=ButtonSize::Small
                                             appearance=ButtonAppearance::Primary
                                             on_click=on_open_click
-                                            disabled=Signal::derive(move || url.get().is_none())
+                                            disabled=Signal::derive(move || url.with(|u| u.is_none()))
                                             icon=icondata::MdiOpenInNew
                                         >
                                             "Open"

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -453,8 +453,8 @@ fn ResolvedServiceItem(
     let verifying = RwSignal::new(false);
     let on_verify_click = move |_| {
         verifying.set(true);
-        if let Some(resolved) = rs.get() {
-            verify_action.dispatch(resolved.instance_fullname.clone());
+        if let Some(instance_fullname) = rs.with(|s| s.as_ref().map(|r| r.instance_fullname.clone())) {
+            verify_action.dispatch(instance_fullname);
         }
         set_timeout(
             move || {


### PR DESCRIPTION
## Summary
- Rename inner `rs` variable in `on_verify_click` closure to `resolved` to avoid shadowing outer memo
- Replace unused `Memo::new` with lightweight `Signal::derive` for disabled signal on Open button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed verify button to correctly reference instance names.

* **Refactor**
  * Improved reactive state management for the Open button's disabled state, ensuring more efficient updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->