### PR TITLE
feat: add --no-nvidia-workaround CLI option to disable all NVIDIA workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Options:
   -f, --log-to-file                 Enable logging to file
   -d, --disable-dmabuf-renderer     Disable dmabuf renderer (Linux only), useful when having rendering issues
       --disable-nv-explicit-sync    Disable NVIDIA explicit sync (Linux only)
+      --no-nvidia-workaround         Disable all NVIDIA workarounds (Linux only)
   -h, --help                        Print help
   -V, --version                     Print version
 
@@ -101,6 +102,13 @@ This option has been added with release [v0.12.0](https://github.com/hrzlgnm/mdn
 
 This option disables NVIDIA explicit sync, useful for testing or debugging rendering issues on non-NVIDIA systems.
 This option has been added with release [v1.8.0](https://github.com/hrzlgnm/mdns-browser/releases/tag/mdns-browser-v1.8.0)
+
+### no-nvidia-workaround (Linux only)
+
+This option disables all NVIDIA workarounds entirely, including automatic detection.
+Useful for testing whether rendering issues are caused by the workarounds or to completely disable them.
+
+This option takes precedence over both `--disable-dmabuf-renderer` and `--disable-nv-explicit-sync`.
 
 ## Where to find the executables?
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Options:
   -f, --log-to-file                 Enable logging to file
   -d, --disable-dmabuf-renderer     Disable dmabuf renderer (Linux only), useful when having rendering issues
       --disable-nv-explicit-sync    Disable NVIDIA explicit sync (Linux only)
-      --no-nvidia-workaround         Disable all NVIDIA workarounds (Linux only)
+      --no-nvidia-workaround        Disable all NVIDIA workarounds entirely (Linux only)
   -h, --help                        Print help
   -V, --version                     Print version
 

--- a/docs/mdns-browser.1
+++ b/docs/mdns-browser.1
@@ -23,6 +23,9 @@ Disable dmabuf renderer (Linux only), useful when having rendering issues
 .BI \-\-disable\-nv\-explicit\-sync
 Disable NVIDIA explicit sync even if NVIDIA is not detected (Linux only)
 .TP
+.BI \-\-no\-nvidia\-workaround
+Disable all NVIDIA workarounds entirely (Linux only)
+.TP
 .BI \-h , \-\-help
 Print help
 .TP

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -792,6 +792,13 @@ struct Args {
         help = "Disable NVIDIA explicit sync even if NVIDIA is not detected"
     )]
     disable_nv_explicit_sync: bool,
+    #[cfg(target_os = "linux")]
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Disable all NVIDIA workarounds entirely"
+    )]
+    no_nvidia_workaround: bool,
 }
 
 #[cfg(desktop)]
@@ -948,10 +955,12 @@ pub fn run() {
 
     #[cfg(target_os = "linux")]
     {
-        let options = ApplyWorkaroundOptions::default()
-            .force_disable_dmabuf(args.disable_dmabuf_renderer)
-            .force_disable_nv_explicit_sync(args.disable_nv_explicit_sync);
-        apply_workaround_with_options(options);
+        if !args.no_nvidia_workaround {
+            let options = ApplyWorkaroundOptions::default()
+                .force_disable_dmabuf(args.disable_dmabuf_renderer)
+                .force_disable_nv_explicit_sync(args.disable_nv_explicit_sync);
+            apply_workaround_with_options(options);
+        }
     }
 
     let mut log_targets = vec![


### PR DESCRIPTION
## Summary
- Add `--no-nvidia-workaround` CLI option (Linux only) to disable all NVIDIA WebKitGTK workarounds entirely
- Useful for testing whether rendering issues are caused by the workarounds or to completely disable them
- Takes precedence over both `--disable-dmabuf-renderer` and `--disable-nv-explicit-sync`

Closes #2117

## Changes
- `src-tauri/src/lib.rs`: Add CLI flag and conditional workaround application
- `README.md`: Document new option
- `docs/mdns-browser.1`: Update manpage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-nvidia-workaround` CLI flag (Linux only) to disable all NVIDIA workarounds entirely, with higher precedence over related rendering options.

* **Documentation**
  * Updated README and manual page documentation for the new CLI flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->