### PR TITLE
feat: Add Homebrew tap support

### DIFF
--- a/.github/workflows/homebrew-reusable.yml
+++ b/.github/workflows/homebrew-reusable.yml
@@ -1,0 +1,83 @@
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT-0
+
+name: Update Homebrew Tap
+
+on:
+  workflow_call:
+    inputs:
+      tagName:
+        required: true
+        type: string
+  workflow_dispatch:
+  release:
+    types: [released]
+
+jobs:
+  release-info:
+    permissions:
+      packages: read # needed to read release info from GitHub Packages
+    runs-on: ubuntu-slim
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tagName: ${{ steps.version.outputs.tagName }}
+    steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: 🏷️ Get version info
+        id: version
+        uses: ./.github/actions/latest-release-info
+
+  update-homebrew-tap:
+    needs: [release-info]
+    runs-on: ubuntu-latest
+    name: 🍺 Update Homebrew Tap
+    steps:
+      - name: 🔄 Checkout Tap Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: hrzlgnm/homebrew-tap
+          token: ${{ secrets.GH_ADMIN_TOKEN }}
+          path: homebrew-tap
+
+      - name: 📥 Download DMG Checksum
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tagName || needs.release-info.outputs.tagName }}
+        run: |
+          gh release download "$TAG" --pattern "*.dmg.sha256" --dir /tmp/dmg-checksum
+          CHECKSUM=$(grep "universal.dmg" /tmp/dmg-checksum/*.sha256 | cut -d' ' -f1)
+          echo "DMG_CHECKSUM=$CHECKSUM" >> "$GITHUB_ENV"
+
+      - name: 🔑 Configure SSH Signing
+        env:
+          SSH_SIGNING_KEY: ${{ secrets.SSH_SIGNING_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_SIGNING_KEY" > ~/.ssh/id_ed25519_signing
+          chmod 600 ~/.ssh/id_ed25519_signing
+          git config --global gpg.format ssh
+          git config --global user.signingKey ~/.ssh/id_ed25519_signing
+          git config --global user.name "hrzlgnm"
+          git config --global user.email "hrzlgnm@users.noreply.github.com"
+
+      - name: 🔄 Update Cask Version & SHA256
+        shell: bash
+        env:
+          NEW_VERSION: ${{ needs.release-info.outputs.version }}
+          CHECKSUM: ${{ env.DMG_CHECKSUM }}
+          CASK_PATH: homebrew-tap/Casks/mdns-browser.rb
+        run: |
+          sed -i "s/version \".*\"/version \"$NEW_VERSION\"/" "$CASK_PATH"
+          sed -i "s/sha256 \".*\"/sha256 \"$CHECKSUM\"/" "$CASK_PATH"
+
+      - name: 💾 Commit & Push to Tap
+        working-directory: homebrew-tap
+        run: |
+          git add Casks/mdns-browser.rb
+          git commit -S -m "Update mdns-browser to v${{ needs.release-info.outputs.version }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ During installation, you will be prompted to accept a public key signed by `hrzl
 
 ### Homebrew (macOS)
 
-Install via custom tap:
+To install on macOS using Homebrew, you can use the custom tap:
 
 ```console
 brew install --cask hrzlgnm/tap/mdns-browser

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Screenshots from [v0.11.28](https://github.com/hrzlgnm/mdns-browser/releases/tag
         - [Winget Installation](#winget-installation)
         - [Arch Linux (AUR)](#arch-linux-aur)
         - [Void Linux](#void-linux)
+        - [Homebrew (macOS)](#homebrew-macos)
     - [Auditable binaries](#auditable-binaries)
     - [Attested build artifacts](#attested-build-artifacts)
     - [Privacy](#privacy)
@@ -165,6 +166,21 @@ sudo xbps-install -S mdns-browser
 ```
 
 During installation, you will be prompted to accept a public key signed by `hrzlgnm@users.noreply.github.com`. The repository and package are signed with a key having the fingerprint: `64:6d:b9:23:3d:ad:9d:f1:b0:fe:64:8e:da:46:57:d3`.
+
+### Homebrew (macOS)
+
+Install via custom tap:
+
+```console
+brew install --cask hrzlgnm/tap/mdns-browser
+```
+
+Or add the tap first:
+
+```console
+brew tap hrzlgnm/tap
+brew install --cask mdns-browser
+```
 
 ## Auditable binaries
 


### PR DESCRIPTION
## Summary
- Add reusable workflow `homebrew-reusable.yml` for updating Homebrew tap on releases
- Update README.md with Homebrew installation instructions
- Follow winget/aur pattern: workflow triggers on published releases only

## Changes
- New file: `.github/workflows/homebrew-reusable.yml`
- Modified: `README.md` (added Homebrew section to TOC and installation docs)

## Testing
- All AGENTS.md checks passed:
  - `actionlint` - workflow validation passed
  - `cargo fmt -- --check` - formatting OK
  - `cargo clippy --workspace --tests -- -D warnings` - no warnings
  - `cargo nextest run --profile ci -p models -p mdns-browser` - 25 tests passed
  - `cargo --locked tauri build --no-bundle --no-sign` - release build successful
  - `cargo clippy --release --workspace --tests -- -D warnings` - no warnings

## Usage After Merge
Users can install via:
```bash
brew install --cask hrzlgnm/tap/mdns-browser
```

Tap repo created at: https://github.com/hrzlgnm/homebrew-tap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Homebrew installation support for macOS users.

* **Documentation**
  * Updated installation instructions to include Homebrew installation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->