### PR TITLE
fix: specify repo for gh release download in homebrew workflow

### DIFF
--- a/.github/workflows/homebrew-reusable.yml
+++ b/.github/workflows/homebrew-reusable.yml
@@ -45,7 +45,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.release-info.outputs.tagName }}
         run: |
-          gh release download "$TAG" --pattern "*.dmg.sha256" --dir /tmp/dmg-checksum
+          gh release download "$TAG" --repo hrzlgnm/mdns-browser --pattern "*.dmg.sha256" --dir /tmp/dmg-checksum
           CHECKSUM=$(grep "universal.dmg" /tmp/dmg-checksum/*.sha256 | cut -d' ' -f1)
           if [ -z "$CHECKSUM" ]; then
             echo "Error: No checksum found for universal.dmg in release $TAG"


### PR DESCRIPTION
## Summary
- Fix `gh release download` failing with "not a git repository" error
- Add `--repo hrzlgnm/mdns-browser` to specify correct repository context
- The step runs after checking out homebrew-tap repo, so git context is wrong

## Changes
- Modified: `.github/workflows/homebrew-reusable.yml` (line 48)

## Root Cause
After checking out `hrzlgnm/homebrew-tap` to `homebrew-tap/` directory, the `gh release download` command tries to determine repo from git context, which points to the tap repo instead of the main repo.

## Fix
Explicitly specify `--repo hrzlgnm/mdns-browser` so `gh` knows which repository contains the release artifacts.

## Testing
- `actionlint` validation passed
- Follows pattern used in other workflow steps that reference the main repo