### PR TITLE
fix: preserve release notes from release-drafter when tauri-action uploads artifacts

### DIFF
--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -103,6 +103,18 @@ jobs:
           Remove-Item -path certificate -include tempCert.txt
           Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -Force -AsPlainText)
 
+      - name: 📋 Get current release body
+        if: inputs.tagName
+        id: current-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo "body<<BODYEOF"
+            gh release view "${{ inputs.tagName }}" --json body --jq '.body'
+            echo "BODYEOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: 🔨 Build plain executables using tauri action (publish artifacts on release)
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
         if: ${{ !contains(matrix.os, 'macos') }}
@@ -113,6 +125,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         with:
           tagName: ${{ inputs.tagName }}
+          releaseBody: ${{ steps.current-release.outputs.body }}
           releaseDraft: false
           prerelease: false
           tauriScript: cargo --locked auditable tauri
@@ -130,6 +143,7 @@ jobs:
         with:
           updaterJsonPreferNsis: true
           tagName: ${{ inputs.tagName }}
+          releaseBody: ${{ steps.current-release.outputs.body }}
           releaseDraft: false
           prerelease: false
           tauriScript: cargo --locked auditable tauri

--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -108,10 +108,11 @@ jobs:
         id: current-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tagName }}
         run: |
           {
             echo "body<<BODYEOF"
-            gh release view "${{ inputs.tagName }}" --json body --jq '.body'
+            gh release view "$TAG_NAME" --json body --jq '.body'
             echo "BODYEOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,14 @@ When changing any GitHub Actions workflows (.github/workflows/*.yml) or actions 
 
 3. **Re-run actionlint** to ensure all issues are resolved
 
+4. **Pass `github` context values (inputs, secrets, env) through the `env` block** instead of interpolating them directly in `run` scripts. Direct interpolation (`${{ inputs.foo }}` inside a `run:` block) creates a template-injection risk. Use an `env:` mapping and reference as a shell variable instead:
+   ```yaml
+   - name: Example
+     env:
+       MY_VAR: ${{ inputs.foo }}
+     run: gh command "$MY_VAR"
+   ```
+
 This ensures your workflow changes follow GitHub Actions best practices and will execute correctly.
 
 ## Common Pitfalls to Avoid

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ When changing any GitHub Actions workflows (.github/workflows/*.yml) or actions 
 
 3. **Re-run actionlint** to ensure all issues are resolved
 
-4. **Pass `github` context values (inputs, secrets, env) through the `env` block** instead of interpolating them directly in `run` scripts. Direct interpolation (`${{ inputs.foo }}` inside a `run:` block) creates a template-injection risk. Use an `env:` mapping and reference as a shell variable instead:
+4. **Pass GitHub Actions context values (`inputs`, `secrets`, `env`) through the `env` block** instead of interpolating them directly in `run` scripts. Direct interpolation (e.g., `${{ inputs.foo }}` inside a `run:` block) creates a template-injection risk. Use an `env:` mapping and reference as a shell variable instead:
    ```yaml
    - name: Example
      env:


### PR DESCRIPTION
tauri-action@v1.0.0 overwrites the release body with an empty string when it updates an existing release to upload artifacts. This change fetches the current release body before the build steps and passes it back as `releaseBody` input to both tauri-action invocations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publishing now reuses the existing release notes when a release tag is provided.
  * Tauri publish actions now include the current release content automatically for both app builds and bundles.
* **Documentation**
  * Updated workflow/action guidance to ensure GitHub Actions context values are passed via `env:` to reduce template-injection risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->