### PR TITLE
fix: use bash to get current release body step for windows

### DIFF
--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -106,6 +106,7 @@ jobs:
       - name: 📋 Get current release body
         if: inputs.tagName
         id: current-release
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ inputs.tagName }}


### PR DESCRIPTION
The `📋 Get current release body` step uses Bash syntax (`echo body