### PR TITLE
docs: add shell: bash instruction to workflow guidelines in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,17 @@ When changing any GitHub Actions workflows (.github/workflows/*.yml) or actions 
    - Follow GitHub Actions best practices
    - Validate workflow structure
 
-3. **Re-run actionlint** to ensure all issues are resolved
+3. **Always specify `shell: bash` on steps using bash-specific syntax** (heredocs `<<`, `$GITHUB_OUTPUT`, etc.) when the workflow runs on Windows. The default shell on Windows runners is PowerShell, which doesn't support bash heredoc syntax. Add `shell: bash` explicitly:
+   ```yaml
+   - name: Step using bash syntax
+     shell: bash
+     run: |
+       {
+         echo "body<<BODYEOF"
+         some_command
+         echo "BODYEOF"
+       } >> "$GITHUB_OUTPUT"
+   ```
 
 4. **Pass GitHub Actions context values (`inputs`, `secrets`, `env`) through the `env` block** instead of interpolating them directly in `run` scripts. Direct interpolation (e.g., `${{ inputs.foo }}` inside a `run:` block) creates a template-injection risk. Use an `env:` mapping and reference as a shell variable instead:
    ```yaml
@@ -240,6 +250,8 @@ When changing any GitHub Actions workflows (.github/workflows/*.yml) or actions 
    ```
 
 This ensures your workflow changes follow GitHub Actions best practices and will execute correctly.
+
+5. **Re-run actionlint** after making changes to ensure all issues are resolved.
 
 ## Common Pitfalls to Avoid
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ When changing any GitHub Actions workflows (.github/workflows/*.yml) or actions 
    - Follow GitHub Actions best practices
    - Validate workflow structure
 
-3. **Always specify `shell: bash` on steps using bash-specific syntax** (heredocs `<<`, `$GITHUB_OUTPUT`, etc.) when the workflow runs on Windows. The default shell on Windows runners is PowerShell, which doesn't support bash heredoc syntax. Add `shell: bash` explicitly:
+3. **Always specify `shell: bash` on steps using bash-specific syntax** (such as group redirection `{ ... } >> "$GITHUB_OUTPUT"`, bash heredocs, etc.) when the workflow runs on Windows. The default shell on Windows runners is PowerShell, which doesn't support bash syntax. Add `shell: bash` explicitly:
    ```yaml
    - name: Step using bash syntax
      shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,9 +249,9 @@ When changing any GitHub Actions workflows (.github/workflows/*.yml) or actions 
      run: gh command "$MY_VAR"
    ```
 
-This ensures your workflow changes follow GitHub Actions best practices and will execute correctly.
-
 5. **Re-run actionlint** after making changes to ensure all issues are resolved.
+
+This ensures your workflow changes follow GitHub Actions best practices and will execute correctly.
 
 ## Common Pitfalls to Avoid
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for editing workflow automation to clarify a required shell setting for Windows-compatible steps that use bash-style syntax.
  * Added an extra validation step to re-run workflow checks after making changes, helping catch issues before merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->