### PR TITLE
feat: add daily retry workflow for failed CI on PRs

### DIFF
--- a/.github/workflows/retry-failed-ci.yml
+++ b/.github/workflows/retry-failed-ci.yml
@@ -1,0 +1,87 @@
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT-0
+
+name: Retry Failed CI on PRs
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: retry-failed-ci
+  cancel-in-progress: false
+
+jobs:
+  retry-failed:
+    name: 🔄 Retry failed CI runs
+    runs-on: ubuntu-slim
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: 🔍 Find and retry failed CI runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          echo "Searching for failed CI workflow runs on PRs from the last 24 hours..."
+
+          # Calculate timestamp 24 hours ago in ISO 8601 format
+          SINCE=$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
+                  date -u -v-24H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
+                  date -u '+%Y-%m-%dT%H:%M:%SZ')
+          echo "Looking for runs since: $SINCE"
+
+          # Fetch failed CI workflow runs from pull_request events in the last 24h
+          FAILED_RUNS=$(gh api \
+            --method GET \
+            -f workflow=ci.yml \
+            -f status=failure \
+            -f event=pull_request \
+            -f created=">=$SINCE" \
+            -q '.workflow_runs[] | "\(.id) \(.head_branch) \(.run_number) \(.created_at)"' \
+            "repos/{owner}/{repo}/actions/workflows/ci.yml/runs" 2>/dev/null || true)
+
+          if [ -z "$FAILED_RUNS" ]; then
+            echo "No failed CI runs found in the last 24 hours. Nothing to retry."
+            exit 0
+          fi
+
+          RETRIED=0
+          SKIPPED=0
+
+          while IFS=' ' read -r RUN_ID HEAD_BRANCH RUN_NUMBER _CREATED_AT; do
+            [ -z "$RUN_ID" ] && continue
+
+            # Check if this run was already retried by looking for a re-run
+            # created after this failed run on the same head branch
+            EXISTING_RERUN=$(gh api \
+              --method GET \
+              -f head="$HEAD_BRANCH" \
+              -f status=completed \
+              -q ".workflow_runs[] | select(.head_branch == \"$HEAD_BRANCH\" and .run_number > $RUN_NUMBER) | .id" \
+              "repos/{owner}/{repo}/actions/workflows/ci.yml/runs" 2>/dev/null | head -1 || true)
+
+            if [ -n "$EXISTING_RERUN" ]; then
+              echo "Skipping run #$RUN_NUMBER on branch $HEAD_BRANCH — already has a newer run ($EXISTING_RERUN)"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            echo "Retrying CI run #$RUN_NUMBER on branch $HEAD_BRANCH (run_id=$RUN_ID)..."
+
+            gh api \
+              --method POST \
+              -f run_id="$RUN_ID" \
+              "repos/{owner}/{repo}/actions/runs/$RUN_ID/rerun" 2>/dev/null && \
+              echo "  ✅ Successfully retried run #$RUN_NUMBER" && \
+              RETRIED=$((RETRIED + 1)) || \
+              echo "  ⚠️ Failed to retry run #$RUN_NUMBER (may lack permissions or run is too old)"
+
+          done <<< "$FAILED_RUNS"
+
+          echo ""
+          echo "Summary: retried=$RETRIED skipped=$SKIPPED"

--- a/.github/workflows/retry-failed-ci.yml
+++ b/.github/workflows/retry-failed-ci.yml
@@ -59,6 +59,7 @@ jobs:
 
             # Check if this run was already retried by looking for a re-run
             # created after this failed run on the same head branch
+            # shellcheck disable=SC2016
             EXISTING_RERUN=$(gh api \
               --method GET \
               -f head="$HEAD_BRANCH" \

--- a/.github/workflows/retry-failed-ci.yml
+++ b/.github/workflows/retry-failed-ci.yml
@@ -43,7 +43,7 @@ jobs:
             -f event=pull_request \
             -f created=">=$SINCE" \
             -q '.workflow_runs[] | "\(.id) \(.head_branch) \(.run_number) \(.created_at)"' \
-            "repos/{owner}/{repo}/actions/workflows/ci.yml/runs" 2>/dev/null || true)
+            "repos/{owner}/{repo}/actions/workflows/ci.yml/runs")
 
           if [ -z "$FAILED_RUNS" ]; then
             echo "No failed CI runs found in the last 24 hours. Nothing to retry."
@@ -52,6 +52,7 @@ jobs:
 
           RETRIED=0
           SKIPPED=0
+          FAILED=0
 
           while IFS=' ' read -r RUN_ID HEAD_BRANCH RUN_NUMBER _CREATED_AT; do
             [ -z "$RUN_ID" ] && continue
@@ -61,9 +62,10 @@ jobs:
             EXISTING_RERUN=$(gh api \
               --method GET \
               -f head="$HEAD_BRANCH" \
-              -f status=completed \
-              -q ".workflow_runs[] | select(.head_branch == \"$HEAD_BRANCH\" and .run_number > $RUN_NUMBER) | .id" \
-              "repos/{owner}/{repo}/actions/workflows/ci.yml/runs" 2>/dev/null | head -1 || true)
+              -q '.workflow_runs[] | select(.head_branch == $branch and .run_number > $num) | .id' \
+              --raw-field "branch=$HEAD_BRANCH" \
+              --raw-field "num=$RUN_NUMBER" \
+              "repos/{owner}/{repo}/actions/workflows/ci.yml/runs" | head -1 || true)
 
             if [ -n "$EXISTING_RERUN" ]; then
               echo "Skipping run #$RUN_NUMBER on branch $HEAD_BRANCH — already has a newer run ($EXISTING_RERUN)"
@@ -73,15 +75,18 @@ jobs:
 
             echo "Retrying CI run #$RUN_NUMBER on branch $HEAD_BRANCH (run_id=$RUN_ID)..."
 
-            gh api \
+            if gh api \
               --method POST \
               -f run_id="$RUN_ID" \
-              "repos/{owner}/{repo}/actions/runs/$RUN_ID/rerun" 2>/dev/null && \
-              echo "  ✅ Successfully retried run #$RUN_NUMBER" && \
-              RETRIED=$((RETRIED + 1)) || \
-              echo "  ⚠️ Failed to retry run #$RUN_NUMBER (may lack permissions or run is too old)"
+              "repos/{owner}/{repo}/actions/runs/$RUN_ID/rerun"; then
+              echo "  ✅ Successfully retried run #$RUN_NUMBER"
+              RETRIED=$((RETRIED + 1))
+            else
+              echo "  ❌ Failed to retry run #$RUN_NUMBER"
+              FAILED=$((FAILED + 1))
+            fi
 
           done <<< "$FAILED_RUNS"
 
           echo ""
-          echo "Summary: retried=$RETRIED skipped=$SKIPPED"
+          echo "Summary: retried=$RETRIED skipped=$SKIPPED failed=$FAILED"


### PR DESCRIPTION
Adds a scheduled GitHub Actions workflow that runs daily at 06:00 UTC to automatically retry failed CI workflow runs on pull requests.

**What it does:**
- Queries for CI workflow runs from PRs that failed in the last 24 hours
- Skips runs that already have a newer run on the same branch (prevents retrying a retry)
- Re-runs eligible failures via the GitHub API

**Safeguards:**
- Max 1 retry per failed run
- Concurrency group prevents parallel executions
- Uses `GITHUB_TOKEN` (no extra secrets needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a scheduled daily process to detect and retry eligible failed continuous integration checks.
  * Added manual triggering for on-demand retries.
  * Avoided retrying runs when a newer check run for the same branch is already available.
  * Added end-of-run reporting with totals for retried, skipped, and unsuccessful retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->