### PR TITLE
fix: only rerun failed jobs

### DIFF
--- a/.github/workflows/retry-failed-ci.yml
+++ b/.github/workflows/retry-failed-ci.yml
@@ -77,7 +77,7 @@ jobs:
             if gh api \
               --method POST \
               -f run_id="$RUN_ID" \
-              "repos/{owner}/{repo}/actions/runs/$RUN_ID/rerun"; then
+              "repos/{owner}/{repo}/actions/runs/$RUN_ID/rerun-failed-jobs"; then
               echo "  ✅ Successfully retried run #$RUN_NUMBER"
               RETRIED=$((RETRIED + 1))
             else


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failed CI recovery by retrying only the jobs that failed, rather than rerunning entire workflow runs.
  * Continued to avoid retrying failures that already have a newer run on the same branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->