### PR TITLE
chore: add GH_TOKEN to changelog generation steps in workflow

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -38,11 +38,15 @@ jobs:
 
       - name: 📝 Generate CHANGELOG.md
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 generate_changelog.py
 
       - name: 📝 Generate crate CHANGELOG.md
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 generate_changelog.py --crate webkit2gtk-nvidia-quirk \
             --crate-path crates/webkit2gtk-nvidia-quirk


### PR DESCRIPTION
Add `GH_TOKEN` env var to the changelog generation steps so the `gh` CLI can authenticate properly in GitHub Actions.