### PR TITLE
chore: update unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Replace generate_changelog.py with git-cliff
+- Replace generate_changelog.py with git-cliff (#2311) ([#2311](https://github.com/hrzlgnm/mdns-browser/pull/2311))
+
+- Add workflow to keep Unreleased changelog sections up to date (#2312) ([#2312](https://github.com/hrzlgnm/mdns-browser/pull/2312))
 
 ### Changed
 
@@ -38,8 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(deps)* Update actions/setup-python action to v7 (#2309) ([#2309](https://github.com/hrzlgnm/mdns-browser/pull/2309))
 
 - Add GH_TOKEN to changelog generation steps in workflow (#2310) ([#2310](https://github.com/hrzlgnm/mdns-browser/pull/2310))
-
-- Add typo corrections to git-cliff postprocessors
 
 ## [1.9.18] - 2026-07-17
 

--- a/crates/webkit2gtk-nvidia-quirk/CHANGELOG.md
+++ b/crates/webkit2gtk-nvidia-quirk/CHANGELOG.md
@@ -9,13 +9,11 @@ This changelog is auto-generated from commits that modify this crate.
 
 ### Added
 
-- Replace generate_changelog.py with git-cliff
+- Replace generate_changelog.py with git-cliff (#2311) ([#2311](https://github.com/hrzlgnm/mdns-browser/pull/2311))
 
 ### Changed
 
 - Add CHANGELOG.md with automated maintenance (#2308) ([#2308](https://github.com/hrzlgnm/mdns-browser/pull/2308))
-
-- Add typo corrections to git-cliff postprocessors
 
 ## [1.3.0] - 2026-04-08
 


### PR DESCRIPTION
Automated update of the `[Unreleased]` section in `CHANGELOG.md`.

This PR is created automatically on every push to `main`
by running `git-cliff` without a version tag.