### PR TITLE
chore: update unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add GH_TOKEN to changelog generation steps in workflow (#2310) ([#2310](https://github.com/hrzlgnm/mdns-browser/pull/2310))
 
+- Include changelog in packaging configurations (#2314) ([#2314](https://github.com/hrzlgnm/mdns-browser/pull/2314))
+
 ## [1.9.18] - 2026-07-17
 
 ### Changed


### PR DESCRIPTION
Automated update of the `[Unreleased]` section in `CHANGELOG.md`.

This PR is created automatically on every push to `main`
by running `git-cliff` without a version tag.