### PR TITLE
chore: ignore update changelog PRs in release-drafter

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -70,7 +70,7 @@ jobs:
 
           This PR is created automatically on every push to \`main\`
           by running \`git-cliff\` without a version tag." \
-              --label chore
+              --label ignore
           fi
 
           gh pr merge "$BRANCH" --auto --squash


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated changelog update pull requests are now labeled `ignore` instead of `chore`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->