### PR TITLE
chore: update unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Ignore update changelog PRs in release-drafter (#2316) ([#2316](https://github.com/hrzlgnm/mdns-browser/pull/2316))
+
 ## [1.9.20] - 2026-07-26
 
 ### Added


### PR DESCRIPTION
Automated update of the `[Unreleased]` section in `CHANGELOG.md`.

This PR is created automatically on every push to `main`
by running `git-cliff` without a version tag.