### PR TITLE
chore: update unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move changelog comparison links inline with version sections (#2320) ([#2320](https://github.com/hrzlgnm/mdns-browser/pull/2320))
 
+- *(deps)* Update hrzlgnm/actions action to v2.4.0 (#2322) ([#2322](https://github.com/hrzlgnm/mdns-browser/pull/2322))
+
 ## [1.9.20] - 2026-07-26 [compare](https://github.com/hrzlgnm/mdns-browser/compare/mdns-browser-v1.9.19...mdns-browser-v1.9.20)
 
 ### Added


### PR DESCRIPTION
Automated update of the `[Unreleased]` section in `CHANGELOG.md`.

This PR is created automatically on every push to `main`
by running `git-cliff` without a version tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying automation action to version 2.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->