### PR TITLE
chore: update unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(deps)* Update hrzlgnm/actions action to v2.5.4 (#2329) ([#2329](https://github.com/hrzlgnm/mdns-browser/pull/2329))
 
+- *(deps)* Update release-drafter/release-drafter action to v7.7.0 (#2332) ([#2332](https://github.com/hrzlgnm/mdns-browser/pull/2332))
+
 ## [1.9.21] - 2026-07-26 [compare](https://github.com/hrzlgnm/mdns-browser/compare/mdns-browser-v1.9.20...mdns-browser-v1.9.21)
 
 ### Changed


### PR DESCRIPTION
Automated update of the `[Unreleased]` section in `CHANGELOG.md`.

This PR is created automatically on every push to `main`
by running `git-cliff` without a version tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the unreleased change log to record the latest maintenance update.
  * No user-facing features or behavior changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->