### PR TITLE
chore(ci): disable sccache for windows

### DIFF
--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -87,7 +87,7 @@ jobs:
         uses: ./.github/actions/setup-tauri
 
       - name: 🛠️🚀
-        if: (!inputs.tagName)
+        if: (!inputs.tagName && runner.os != 'Windows')
         uses: ./.github/actions/setup-sccache
 
       - name: 🔑 Import windows signing certificate (windows only)

--- a/.github/workflows/lint-reusable.yml
+++ b/.github/workflows/lint-reusable.yml
@@ -76,6 +76,7 @@ jobs:
           targets: ${{ matrix.os == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin,wasm32-unknown-unknown' || 'wasm32-unknown-unknown' }}
 
       - name: 🛠️🚀
+        if: runner.os != 'Windows'
         uses: ./.github/actions/setup-sccache
 
       - name: 📎 Run clippy and fail if any warnings

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -43,6 +43,7 @@ jobs:
           locked: true
 
       - name: 🛠️🚀
+        if: runner.os != 'Windows'
         uses: ./.github/actions/setup-sccache
 
       - name: ✅ Run tests with nextest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build, lint, and test workflow compatibility by avoiding cache setup on Windows runners.
  * Non-publish Android builds continue to use caching on supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->