### PR TITLE
chore: update unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(deps)* Update mozilla-actions/sccache-action action to v0.0.11 (#2331) ([#2331](https://github.com/hrzlgnm/mdns-browser/pull/2331))
 
+- *(deps)* Update rust crate clap to v4.6.5 (#2335) ([#2335](https://github.com/hrzlgnm/mdns-browser/pull/2335))
+
 ## [1.9.21] - 2026-07-26 [compare](https://github.com/hrzlgnm/mdns-browser/compare/mdns-browser-v1.9.20...mdns-browser-v1.9.21)
 
 ### Changed


### PR DESCRIPTION
Automated update of the `[Unreleased]` section in `CHANGELOG.md`.

This PR is created automatically on every push to `main`
by running `git-cliff` without a version tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Unreleased changelog entry documenting the update to Rust `clap` version 4.6.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->