### PR TITLE
chore(deb): install the copyright to the correct location

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
         "linux": {
             "deb": {
                 "files": {
-                    "/usr/share/licenses/mdns-browser/LICENSE": "../LICENSE",
+                    "/usr/share/doc/mdns-browser/copyright": "../LICENSE",
                     "/usr/share/doc/mdns-browser/changelog": "../CHANGELOG.md",
                     "/usr/share/man/man1/mdns-browser.1": "../docs/mdns-browser.1"
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Linux Debian package to place the license information in the correct documentation location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->