### PR TITLE
chore(ci): run changelog update on a nightly schedule

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -4,9 +4,9 @@
 name: "📝 Update Changelog"
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: write # Needed to push to the update branch
@@ -68,7 +68,7 @@ jobs:
               --title "chore: update unreleased changelog" \
               --body "Automated update of the \`[Unreleased]\` section in \`CHANGELOG.md\`.
 
-          This PR is created automatically on every push to \`main\`
+          This PR is created automatically on a nightly schedule
           by running \`git-cliff\` without a version tag." \
               --label ignore
           fi


### PR DESCRIPTION
Summary:
- Change the `update-changelog` workflow trigger from `push` to `main` to a nightly `schedule` cron (00:00 UTC) plus `workflow_dispatch` for manual runs.
- Update the auto-generated PR body text to match the new trigger.

Testing:
- `actionlint .github/workflows/update-changelog.yml` passes.