### PR TITLE
feat(webkit2gtk-nvidia-quirk): skip wayland workaround when egl-wayland2 is active

### DIFF
--- a/crates/webkit2gtk-nvidia-quirk/README.md
+++ b/crates/webkit2gtk-nvidia-quirk/README.md
@@ -5,6 +5,11 @@
 
 Session-aware workarounds for WebKitGTK rendering issues on Linux with NVIDIA driver.
 
+The Wayland workaround (disabling NVIDIA explicit sync) is only applied when the
+old EGLStreams-based `egl-wayland` library is in use. On systems with a NVIDIA
+driver 560 or newer and the dma-buf based `egl-wayland2` library, the workaround
+is skipped automatically, since it would degrade rendering performance.
+
 ## Quick Start
 
 ```rust,no_run

--- a/crates/webkit2gtk-nvidia-quirk/src/lib.rs
+++ b/crates/webkit2gtk-nvidia-quirk/src/lib.rs
@@ -29,6 +29,19 @@
 //! | X11 | Disable DMABUF renderer | `WEBKIT_DISABLE_DMABUF_RENDERER=1` |
 //! | Wayland | Disable NVIDIA explicit sync | `__NV_DISABLE_EXPLICIT_SYNC=1` |
 //!
+//! ## Wayland with egl-wayland2
+//!
+//! The Wayland workaround is only needed when the EGLStreams-based `egl-wayland`
+//! library is used. NVIDIA drivers 560 and newer ship the dma-buf based
+//! `egl-wayland2` library, which implements the Wayland explicit sync protocol
+//! correctly and is selected by the EGL loader with higher priority when both
+//! libraries are present. On such systems the workaround is skipped automatically,
+//! since disabling explicit sync there would degrade rendering performance.
+//!
+//! Users on older drivers or distributions that do not (yet) package
+//! `egl-wayland2` keep the old EGLStreams library and therefore still need the
+//! workaround, so it stays enabled for them.
+//!
 //! ## Detection Method
 //!
 //! The crate detects the NVIDIA driver by:
@@ -39,6 +52,15 @@
 //! more reliable detection mechanism with no external runtime dependencies.
 //!
 //! This specifically targets the proprietary NVIDIA driver, not the open-source nouveau driver.
+//!
+//! Whether `egl-wayland2` is used is detected by mirroring the EGL loader logic:
+//! the EGL external platform JSON manifests in `/etc/egl/egl_external_platform.d`
+//! and `/usr/share/egl/egl_external_platform.d` (or the directories/files given via
+//! `__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS`/`__EGL_EXTERNAL_PLATFORM_CONFIG_FILENAMES`)
+//! are checked in load order. If the first manifest referencing an NVIDIA Wayland
+//! library points at `libnvidia-egl-wayland2.so` and the loaded driver is version
+//! 560 or newer, `egl-wayland2` is considered active and the Wayland workaround is
+//! skipped. In all uncertain cases the workaround is still applied.
 //!
 //! ## Usage
 //!
@@ -182,6 +204,135 @@ fn nvidia_driver_loaded() -> bool {
     std::path::Path::new("/sys/module/nvidia").exists()
 }
 
+/// The NVIDIA Wayland EGL platform library referenced by an external platform manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WaylandLib {
+    /// The EGLStreams based `egl-wayland` library.
+    EglWayland,
+    /// The dma-buf based `egl-wayland2` library.
+    EglWayland2,
+}
+
+/// Classifies an external platform library path as either the old or the new
+/// NVIDIA Wayland library.
+fn classify_wayland_lib(library_path: &str) -> Option<WaylandLib> {
+    if library_path.contains("nvidia-egl-wayland2") {
+        Some(WaylandLib::EglWayland2)
+    } else if library_path.contains("nvidia-egl-wayland") {
+        Some(WaylandLib::EglWayland)
+    } else {
+        None
+    }
+}
+
+/// Extracts the `library_path` from an EGL external platform JSON manifest.
+fn library_path_from_manifest(content: &str) -> Option<&str> {
+    let key = "\"library_path\"";
+    let rest = &content[content.find(key)? + key.len()..];
+    let open = rest.find('"')?;
+    let value = &rest[open + 1..];
+    let close = value.find('"')?;
+    Some(&value[..close])
+}
+
+/// Reads an EGL external platform JSON manifest and classifies the NVIDIA
+/// Wayland library it references, if any.
+fn wayland_lib_from_manifest(path: &Path) -> Option<WaylandLib> {
+    let content = read_sysfs_file(path)?;
+    let library_path = library_path_from_manifest(&content)?;
+    classify_wayland_lib(library_path)
+}
+
+/// Returns the `.json` files of an EGL external platform config directory,
+/// sorted by filename as the EGL loader would try them.
+fn json_files_in_dir(dir: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = match std::fs::read_dir(dir) {
+        Ok(entries) => entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+            .collect(),
+        Err(_) => Vec::new(),
+    };
+    files.sort();
+    files
+}
+
+/// Returns the EGL external platform JSON config files in the order the EGL
+/// loader would try them, honoring the `__EGL_EXTERNAL_PLATFORM_CONFIG_FILENAMES`
+/// and `__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS` environment variables.
+fn egl_external_platform_config_files() -> Vec<PathBuf> {
+    if let Ok(files) = std::env::var("__EGL_EXTERNAL_PLATFORM_CONFIG_FILENAMES") {
+        return files.split(':').map(PathBuf::from).collect();
+    }
+    let dirs: Vec<PathBuf> = match std::env::var("__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS") {
+        Ok(dirs) => dirs.split(':').map(PathBuf::from).collect(),
+        Err(_) => vec![
+            PathBuf::from("/etc/egl/egl_external_platform.d"),
+            PathBuf::from("/usr/share/egl/egl_external_platform.d"),
+        ],
+    };
+    dirs.iter().flat_map(|dir| json_files_in_dir(dir)).collect()
+}
+
+/// Returns the NVIDIA Wayland EGL library the loader would select first, given
+/// the external platform JSON config files in load order.
+fn first_wayland_lib(configs: &[PathBuf]) -> Option<WaylandLib> {
+    configs
+        .iter()
+        .find_map(|config| wayland_lib_from_manifest(config))
+}
+
+/// Extracts the major version of a dotted NVIDIA driver version string, e.g.
+/// `610` from `610.43.03`.
+fn parse_driver_major(version: &str) -> Option<u64> {
+    let bytes = version.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_digit() {
+            let start = i;
+            while i < bytes.len() && bytes[i].is_ascii_digit() {
+                i += 1;
+            }
+            let major = bytes[start..i]
+                .iter()
+                .fold(0u64, |acc, b| acc * 10 + u64::from(b - b'0'));
+            if bytes.get(i) == Some(&b'.') && bytes.get(i + 1).is_some_and(|b| b.is_ascii_digit()) {
+                return Some(major);
+            }
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+/// Returns the loaded NVIDIA driver major version, if it can be determined.
+fn nvidia_driver_major() -> Option<u64> {
+    let version = read_sysfs_file(Path::new("/proc/driver/nvidia/version"))?;
+    parse_driver_major(&version)
+}
+
+/// Returns whether the dma-buf based `egl-wayland2` library is the one the EGL
+/// loader would use for the Wayland platform.
+///
+/// This is the case when the first external platform manifest in load order
+/// referencing an NVIDIA Wayland library points at `libnvidia-egl-wayland2.so`
+/// and the loaded NVIDIA driver is version 560 or newer (the version that added
+/// the driver interface `egl-wayland2` depends on). On older drivers the new
+/// library fails to initialize and the loader falls back to the old one.
+fn is_egl_wayland2_selected(configs: &[PathBuf], driver_major: Option<u64>) -> bool {
+    matches!(first_wayland_lib(configs), Some(WaylandLib::EglWayland2))
+        && driver_major.is_some_and(|major| major >= 560)
+}
+
+/// Reads the current system state and returns whether `egl-wayland2` is in use.
+fn egl_wayland2_active() -> bool {
+    let configs = egl_external_platform_config_files();
+    let driver_major = nvidia_driver_major();
+    is_egl_wayland2_selected(&configs, driver_major)
+}
+
 enum SessionType {
     Wayland,
     X11,
@@ -241,6 +392,7 @@ pub fn needs_workaround() -> WorkaroundKind {
         return WorkaroundKind::None;
     }
     match session {
+        SessionType::Wayland if egl_wayland2_active() => WorkaroundKind::None,
         SessionType::Wayland => WorkaroundKind::DisableNvExplicitSync,
         SessionType::X11 => WorkaroundKind::DisableWebkitDmabufRenderer,
         SessionType::Unknown => WorkaroundKind::None,
@@ -356,5 +508,188 @@ pub fn apply_workaround_with_options(options: ApplyWorkaroundOptions) {
             WorkaroundKind::DisableWebkitDmabufRenderer => set_webkit_disable_dmabuf_renderer(),
             WorkaroundKind::DisableNvExplicitSync => nv_disable_explicit_sync(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "webkit2gtk-nvidia-quirk-test-{}-{}",
+            name,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_manifest(dir: &Path, name: &str, library_path: &str) -> PathBuf {
+        let path = dir.join(name);
+        let content = format!(
+            "{{\n  \"file_format_version\": \"1.0.0\",\n  \"ICD\": {{\n    \"library_path\": \"{library_path}\"\n  }}\n}}\n"
+        );
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn test_classify_wayland_lib_wayland2() {
+        assert_eq!(
+            classify_wayland_lib("libnvidia-egl-wayland2.so.1"),
+            Some(WaylandLib::EglWayland2)
+        );
+        assert_eq!(
+            classify_wayland_lib("/usr/lib/libnvidia-egl-wayland2.so.1.0.1"),
+            Some(WaylandLib::EglWayland2)
+        );
+    }
+
+    #[test]
+    fn test_classify_wayland_lib_old() {
+        assert_eq!(
+            classify_wayland_lib("libnvidia-egl-wayland.so.1"),
+            Some(WaylandLib::EglWayland)
+        );
+        assert_eq!(
+            classify_wayland_lib("/usr/lib/libnvidia-egl-wayland.so.1.1.21"),
+            Some(WaylandLib::EglWayland)
+        );
+    }
+
+    #[test]
+    fn test_classify_wayland_lib_other() {
+        assert_eq!(classify_wayland_lib("libnvidia-egl-gbm.so.1"), None);
+        assert_eq!(classify_wayland_lib("libnvidia-egl-xcb.so.1"), None);
+    }
+
+    #[test]
+    fn test_library_path_from_manifest() {
+        let manifest = r#"{
+            "file_format_version": "1.0.0",
+            "ICD": {
+                "library_path": "libnvidia-egl-wayland2.so.1"
+            }
+        }"#;
+        assert_eq!(
+            library_path_from_manifest(manifest),
+            Some("libnvidia-egl-wayland2.so.1")
+        );
+        assert_eq!(library_path_from_manifest("no library path"), None);
+    }
+
+    #[test]
+    fn test_parse_driver_major() {
+        let nvr =
+            "NVRM version: NVIDIA UNIX Open Kernel Module for x86_64  610.43.03  Release Build";
+        assert_eq!(parse_driver_major(nvr), Some(610));
+        assert_eq!(
+            parse_driver_major("NVRM version: NVIDIA UNIX Open Kernel Module 560.35.03"),
+            Some(560)
+        );
+        assert_eq!(parse_driver_major("no version here"), None);
+        assert_eq!(parse_driver_major("x86_64"), None);
+    }
+
+    #[test]
+    fn test_json_files_in_dir_sorted() {
+        let dir = temp_dir("sorted");
+        write_manifest(&dir, "20_nvidia_xcb.json", "libnvidia-egl-xcb.so.1");
+        write_manifest(&dir, "10_nvidia_wayland.json", "libnvidia-egl-wayland.so.1");
+        write_manifest(
+            &dir,
+            "09_nvidia_wayland2.json",
+            "libnvidia-egl-wayland2.so.1",
+        );
+        write_manifest(&dir, "not-a-json.txt", "foo");
+        let files = json_files_in_dir(&dir);
+        let names: Vec<String> = files
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "09_nvidia_wayland2.json",
+                "10_nvidia_wayland.json",
+                "20_nvidia_xcb.json",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_is_egl_wayland2_selected_new_first() {
+        let dir = temp_dir("new_first");
+        let configs = vec![
+            write_manifest(
+                &dir,
+                "09_nvidia_wayland2.json",
+                "libnvidia-egl-wayland2.so.1",
+            ),
+            write_manifest(&dir, "10_nvidia_wayland.json", "libnvidia-egl-wayland.so.1"),
+        ];
+        assert!(is_egl_wayland2_selected(&configs, Some(610)));
+    }
+
+    #[test]
+    fn test_is_egl_wayland2_selected_only_new() {
+        let dir = temp_dir("only_new");
+        let configs = vec![write_manifest(
+            &dir,
+            "09_nvidia_wayland2.json",
+            "libnvidia-egl-wayland2.so.1",
+        )];
+        assert!(is_egl_wayland2_selected(&configs, Some(610)));
+    }
+
+    #[test]
+    fn test_is_egl_wayland2_selected_old_first() {
+        let dir = temp_dir("old_first");
+        let configs = vec![
+            write_manifest(&dir, "10_nvidia_wayland.json", "libnvidia-egl-wayland.so.1"),
+            write_manifest(
+                &dir,
+                "99_nvidia_wayland2.json",
+                "libnvidia-egl-wayland2.so.1",
+            ),
+        ];
+        assert!(!is_egl_wayland2_selected(&configs, Some(610)));
+    }
+
+    #[test]
+    fn test_is_egl_wayland2_selected_only_old() {
+        let dir = temp_dir("only_old");
+        let configs = vec![write_manifest(
+            &dir,
+            "10_nvidia_wayland.json",
+            "libnvidia-egl-wayland.so.1",
+        )];
+        assert!(!is_egl_wayland2_selected(&configs, Some(610)));
+    }
+
+    #[test]
+    fn test_is_egl_wayland2_selected_driver_too_old() {
+        let dir = temp_dir("driver_too_old");
+        let configs = vec![write_manifest(
+            &dir,
+            "09_nvidia_wayland2.json",
+            "libnvidia-egl-wayland2.so.1",
+        )];
+        assert!(!is_egl_wayland2_selected(&configs, Some(550)));
+        assert!(!is_egl_wayland2_selected(&configs, None));
+    }
+
+    #[test]
+    fn test_is_egl_wayland2_selected_no_wayland_lib() {
+        let dir = temp_dir("no_wayland_lib");
+        let configs = vec![write_manifest(
+            &dir,
+            "15_nvidia_gbm.json",
+            "libnvidia-egl-gbm.so.1",
+        )];
+        assert!(!is_egl_wayland2_selected(&configs, Some(610)));
+        assert!(!is_egl_wayland2_selected(&[], Some(610)));
     }
 }


### PR DESCRIPTION
## Summary

The Wayland explicit-sync workaround (`__NV_DISABLE_EXPLICIT_SYNC=1`) was previously applied on every NVIDIA + Wayland system. It is only needed with the old EGLStreams-based `egl-wayland` library, which triggers a Wayland protocol violation with WebKitGTK (upstream: WebKitGTK [bug #280210](https://bugs.webkit.org/show_bug.cgi?id=280210)).

NVIDIA drivers 560+ ship the dma-buf based `egl-wayland2` library, which the EGL loader selects with higher priority when both are present and which implements the Wayland explicit sync protocol correctly. On such systems the workaround is unnecessary and actually degrades rendering performance (implicit sync → reduced performance/out-of-order frames).

This change detects whether `egl-wayland2` is active and skips the Wayland workaround only then, keeping it enabled for users on older drivers or distros that don't package `egl-wayland2` yet.

## Changes

- `crates/webkit2gtk-nvidia-quirk/src/lib.rs`
  - Add detection that mirrors the EGL loader logic: inspects the external-platform JSON manifests in load order (`/etc/egl/egl_external_platform.d` + `/usr/share/egl/egl_external_platform.d`, honoring `__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS`/`_FILENAMES`).
  - `egl-wayland2` is considered active only when the first NVIDIA Wayland manifest points at `libnvidia-egl-wayland2.so` **and** the loaded driver (parsed from `/proc/driver/nvidia/version`) is ≥ 560.
  - `needs_workaround()` returns `None` for Wayland when `egl-wayland2` is active. All uncertain cases fall back to applying the workaround (safe default). X11 DMABUF path unchanged.
  - 12 unit tests for classification, manifest parsing, driver-version parsing, load-order, and driver gating.
- `crates/webkit2gtk-nvidia-quirk/README.md` — document the new behavior.

## Testing

- `cargo fmt -- --check`
- `cargo clippy --workspace --tests -- -D warnings`
- `cargo nextest run --profile ci --workspace` (37 tests pass)
- doc-tests, `actionlint`
- Live check on an NVIDIA 610.43.03 + `egl-wayland2 1.0.1` system confirming `egl_wayland2_active() == true` and the Wayland workaround is skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA Wayland compatibility by avoiding an unnecessary rendering workaround on driver 560+ systems using the newer dma-buf-based EGL platform.
  * Retained the workaround when platform or driver information is unavailable, helping preserve compatibility in uncertain configurations.

* **Documentation**
  * Clarified when the Wayland workaround is applied and when it is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->