### PR TITLE
chore(ci): update NDK version to 29

### DIFF
--- a/.github/workflows/android-reusable.yml
+++ b/.github/workflows/android-reusable.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: 🤖 Setup Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
+        with:
+          cmdline-tools-version: 15859902
 
       - name: 🛠️ Install NDK
         run: sdkmanager "ndk;29.0.14206865"

--- a/.github/workflows/android-reusable.yml
+++ b/.github/workflows/android-reusable.yml
@@ -86,7 +86,7 @@ jobs:
           cmdline-tools-version: 15859902
 
       - name: 🛠️ Install NDK
-        run: sdkmanager "ndk;$NDK_VERSION"
+        run: android sdk "ndk;$NDK_VERSION"
 
       - name: 🔨 Build app bundle
         run: |

--- a/.github/workflows/android-reusable.yml
+++ b/.github/workflows/android-reusable.yml
@@ -81,7 +81,7 @@ jobs:
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
 
       - name: 🛠️ Install NDK
-        run: sdkmanager "ndk;27.0.11902837"
+        run: sdkmanager "ndk;29.0.14206865"
 
       - name: 🔨 Build app bundle
         run: |

--- a/.github/workflows/android-reusable.yml
+++ b/.github/workflows/android-reusable.yml
@@ -3,6 +3,9 @@
 
 name: "Reusable android workflow"
 
+env:
+  NDK_VERSION: 29.0.14206865
+
 on:
   workflow_call:
     inputs:
@@ -83,7 +86,7 @@ jobs:
           cmdline-tools-version: 15859902
 
       - name: 🛠️ Install NDK
-        run: sdkmanager "ndk;29.0.14206865"
+        run: sdkmanager "ndk;$NDK_VERSION"
 
       - name: 🔨 Build app bundle
         run: |
@@ -91,7 +94,7 @@ jobs:
           cp -a src-tauri/icons/android/mipmap-* src-tauri/gen/android/app/src/main/res/
           cargo --locked auditable tauri android build
         env:
-          NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/27.0.11902837
+          NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
           RUSTFLAGS: "-D warnings"
 
       - name: 🔑 Extract android signing key

--- a/.github/workflows/android-reusable.yml
+++ b/.github/workflows/android-reusable.yml
@@ -86,7 +86,7 @@ jobs:
           cmdline-tools-version: 15859902
 
       - name: 🛠️ Install NDK
-        run: android sdk "ndk;$NDK_VERSION"
+        run: android sdk install "ndk;$NDK_VERSION"
 
       - name: 🔨 Build app bundle
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Android build environment with pinned SDK command-line tools and a newer NDK version.
  * Improved consistency and reproducibility for Android builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->