### PR TITLE
chore: update unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] [compare](https://github.com/hrzlgnm/mdns-browser/compare/mdns-browser-v1.12.0...HEAD)
+
+### Changed
+
+- Update agent instructions (#2362) ([#2362](https://github.com/hrzlgnm/mdns-browser/pull/2362))
+
+- Tweak tauri config (#2361) ([#2361](https://github.com/hrzlgnm/mdns-browser/pull/2361))
+
 ## [1.12.0] - 2026-08-01 [compare](https://github.com/hrzlgnm/mdns-browser/compare/mdns-browser-v1.10.0...mdns-browser-v1.12.0)
 
 ### Added


### PR DESCRIPTION
Automated update of the `[Unreleased]` section in `CHANGELOG.md`.

This PR is created automatically on a nightly schedule
by running `git-cliff` without a version tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an **Unreleased** changelog section documenting updates to agent guidance and application configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->