### PR TITLE
refactor: remove redundant android tauri config

### DIFF
--- a/.github/workflows/android-reusable.yml
+++ b/.github/workflows/android-reusable.yml
@@ -36,10 +36,10 @@ jobs:
         with:
           ref: ${{ inputs.tagName || github.ref }}
           fetch-depth: ${{ inputs.tagName && '0' || '1' }}
-      - name: 📝 Extract version from tauri.android.conf.json
+      - name: 📝 Extract version from tauri.conf.json
         id: get-version
         run: |
-          CURRENT_VERSION=$(jq -r '.version' src-tauri/tauri.android.conf.json)
+          CURRENT_VERSION=$(jq -r '.version' src-tauri/tauri.conf.json)
           echo "current-version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: 🛡️ Verify tag matches version in tauri config (publish only)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
               - 'src-tauri/capabilities/mobile.json'
               - 'src-tauri/icons/android/**'
               - 'src-tauri/tauri.android.conf.json'
+              - 'src-tauri/tauri.conf.json'
             aur:
               - '.github/workflows/aur-reusable.yml'
               - '.github/actions/latest-release-info/action.yml'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,6 @@ jobs:
 
             # Update Tauri config files
             jq --indent 4 ".version=\"$NEW_VERSION\"" src-tauri/tauri.conf.json > tauri.config.json.new && mv tauri.config.json.new src-tauri/tauri.conf.json
-            jq --indent 4 ".version=\"$NEW_VERSION\"" src-tauri/tauri.android.conf.json > tauri.android.config.json.new && mv tauri.android.config.json.new src-tauri/tauri.android.conf.json
             echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
             echo "Bumped version from $CURRENT_VERSION to $NEW_VERSION"
           fi

--- a/src-tauri/tauri.android.conf.json
+++ b/src-tauri/tauri.android.conf.json
@@ -1,22 +1,11 @@
 {
-    "build": {
-        "beforeDevCommand": "trunk --skip-version-check serve --log debug",
-        "beforeBuildCommand": "trunk --skip-version-check build",
-        "frontendDist": "../dist",
-        "devUrl": "http://localhost:1420"
-    },
     "bundle": {
-        "active": true,
         "android": {
             "debugApplicationIdSuffix": ".debug"
         }
     },
     "productName": "mDNS Browser",
-    "version": "1.12.0",
-    "identifier": "com.github.hrzlgnm.mdns-browser",
-    "plugins": {},
     "app": {
-        "withGlobalTauri": true,
         "windows": [
             {
                 "title": "mDNS-Browser",
@@ -26,9 +15,6 @@
                 "label": "main",
                 "visible": true
             }
-        ],
-        "security": {
-            "csp": null
-        }
+        ]
     }
 }


### PR DESCRIPTION
## Summary
- Removed redundant properties from `src-tauri/tauri.android.conf.json` that are already provided in `src-tauri/tauri.conf.json` (Tauri merges platform configs via JSON Merge Patch / RFC 7396): `build`, `bundle.active`, `version`, `identifier`, `plugins`, `app.withGlobalTauri`, `app.security.csp`.
- Kept android-specific overrides: `bundle.android.debugApplicationIdSuffix`, `productName` (`mDNS Browser` for the Android launcher label), `app.windows`.
- Updated `.github/workflows/android-reusable.yml` to read the version from `tauri.conf.json` instead of `tauri.android.conf.json`.
- Updated `.github/workflows/release.yml` to no longer write `version` into the android config during version bumps.
- Added `src-tauri/tauri.conf.json` to the `android` path-filter group in `.github/workflows/ci.yml`.

## Testing
- `actionlint .github/workflows/*.yml` passes.
- JSON config validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build and release processes to use the shared application configuration.
  * Improved change detection so relevant Android configuration updates trigger CI.
  * Simplified Android-specific configuration while retaining debug identification and product naming.
  * Removed redundant Android version updates during release preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->