### PR TITLE
chore: use github-actions bot for automated commits

### DIFF
--- a/.github/workflows/homebrew-reusable.yml
+++ b/.github/workflows/homebrew-reusable.yml
@@ -53,7 +53,7 @@ jobs:
           fi
           echo "DMG_CHECKSUM=$CHECKSUM" >> "$GITHUB_ENV"
 
-      - name: 🔑 Configure SSH Signing
+      - name: 🔑 Set up SSH signing key
         env:
           SSH_SIGNING_KEY: ${{ secrets.SSH_SIGNING_KEY }}
         run: |
@@ -62,8 +62,8 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519_signing
           git config --global gpg.format ssh
           git config --global user.signingKey ~/.ssh/id_ed25519_signing
-          git config --global user.name "hrzlgnm"
-          git config --global user.email "hrzlgnm@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: 🔄 Update Cask Version & SHA256
         shell: bash

--- a/.github/workflows/publish-webkit2gtk-nvidia-quirk.yml
+++ b/.github/workflows/publish-webkit2gtk-nvidia-quirk.yml
@@ -114,8 +114,8 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519_signing
           git config --global gpg.format ssh
           git config --global user.signingKey ~/.ssh/id_ed25519_signing
-          git config --global user.name "hrzlgnm"
-          git config --global user.email "hrzlgnm@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: ⏳ Temporary disable ruleset enforcement
         if: (!inputs.dry-run)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,8 +118,8 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519_signing
           git config --global gpg.format ssh
           git config --global user.signingKey ~/.ssh/id_ed25519_signing
-          git config --global user.name "hrzlgnm"
-          git config --global user.email "hrzlgnm@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: ⏳ Temporary disable ruleset enforcement
         if: (!inputs.dry-run)

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -38,15 +38,15 @@ jobs:
           git-cliff --output CHANGELOG.md
           git-cliff --config cliff-webkit2gtk.toml --output crates/webkit2gtk-nvidia-quirk/CHANGELOG.md
 
-      - name: ⚙️ Set up SSH signing key
+      - name: 🔑 Set up SSH signing key
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_SIGNING_KEY }}" > ~/.ssh/id_ed25519_signing
           chmod 600 ~/.ssh/id_ed25519_signing
           git config --global gpg.format ssh
           git config --global user.signingKey ~/.ssh/id_ed25519_signing
-          git config --global user.name "hrzlgnm"
-          git config --global user.email "hrzlgnm@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: 🔁 Create or update Pull Request
         env:


### PR DESCRIPTION
Automated commits from release/packaging workflows now use the `github-actions[bot]` identity instead of the personal `hrzlgnm` user.

Changes:
- Set `user.name`/`user.email` to `github-actions[bot]`/`41898282+github-actions[bot]@users.noreply.github.com` in:
  - `update-changelog.yml`
  - `release.yml`
  - `publish-webkit2gtk-nvidia-quirk.yml`
  - `homebrew-reusable.yml`
- Unified the SSH signing step name to `🔑 Set up SSH signing key`
- Commits remain signed (SSH) via `SSH_SIGNING_KEY`; no signing changes.

Testing: `actionlint .github/workflows/*.yml` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated release, publishing, changelog, and package update commits now use the standard GitHub Actions identity.
  * Updated commit signing setup labels for clearer workflow reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->