### PR TITLE
chore: include dependencies in changelog

### DIFF
--- a/cliff-webkit2gtk.toml
+++ b/cliff-webkit2gtk.toml
@@ -20,6 +20,8 @@ body = """
         ### Fixed\n
     {% elif group == "Changed" -%}\
         ### Changed\n
+    {% elif group == "Dependencies" -%}\
+        ### Dependencies\n
     {% elif group == "Security" -%}\
         ### Security\n
     {% elif group == "Miscellaneous" -%}\
@@ -70,8 +72,7 @@ split_commits = false
 # regex for parsing and grouping commits
 commit_parsers = [
     { message = "^feat", group = "Added" },
-    { message = "^fix\\(deps\\): update", group = "Fixed" },
-    { message = "^fix\\(deps\\)", skip = true },
+    { message = "^fix\\(deps\\)", group = "Dependencies" },
     { message = "^fix\\(ci\\)", skip = true },
     { message = "^fix", group = "Fixed" },
     { message = "^doc", group = "Changed" },
@@ -81,10 +82,7 @@ commit_parsers = [
     { message = "^test", group = "Changed" },
     { message = "^ci", group = "Miscellaneous" },
     { message = "^build", group = "Miscellaneous" },
-    { message = "^chore\\(deps\\): update.*docker digest", skip = true },
-    { message = "^chore\\(deps\\): update", group = "Changed" },
-    { message = "^chore\\(deps\\): lock file maintenance", skip = true },
-    { message = "^chore\\(deps\\)", skip = true },
+    { message = "^chore\\(deps\\)", group = "Dependencies" },
     { message = "^chore\\(renovate", skip = true },
     { message = "^chore\\(arch-aur", skip = true },
     { message = "^chore\\(void", skip = true },

--- a/cliff.toml
+++ b/cliff.toml
@@ -20,6 +20,8 @@ body = """
         ### Fixed\n
     {% elif group == "Changed" -%}\
         ### Changed\n
+    {% elif group == "Dependencies" -%}\
+        ### Dependencies\n
     {% elif group == "Security" -%}\
         ### Security\n
     {% elif group == "Miscellaneous" -%}\
@@ -70,8 +72,7 @@ split_commits = false
 # regex for parsing and grouping commits
 commit_parsers = [
     { message = "^feat", group = "Added" },
-    { message = "^fix\\(deps\\): update", group = "Fixed" },
-    { message = "^fix\\(deps\\)", skip = true },
+    { message = "^fix\\(deps\\)", group = "Dependencies" },
     { message = "^fix\\(ci\\)", skip = true },
     { message = "^fix", group = "Fixed" },
     { message = "^doc", group = "Changed" },
@@ -81,10 +82,7 @@ commit_parsers = [
     { message = "^test", group = "Changed" },
     { message = "^ci", group = "Miscellaneous" },
     { message = "^build", group = "Miscellaneous" },
-    { message = "^chore\\(deps\\): update.*docker digest", skip = true },
-    { message = "^chore\\(deps\\): update", group = "Changed" },
-    { message = "^chore\\(deps\\): lock file maintenance", skip = true },
-    { message = "^chore\\(deps\\)", skip = true },
+    { message = "^chore\\(deps\\)", group = "Dependencies" },
     { message = "^chore\\(renovate", skip = true },
     { message = "^chore\\(arch-aur", skip = true },
     { message = "^chore\\(void", skip = true },

--- a/typos.toml
+++ b/typos.toml
@@ -9,3 +9,6 @@ extend-exclude = [
 
 [default]
 check-filename = true
+extend-ignore-re = [
+    "docker digest to \\b[0-9a-f]{7,}\\b",
+]


### PR DESCRIPTION
## Summary

Dependency commits are no longer skipped in the generated changelogs.

### Changes
- **cliff.toml** and **cliff-webkit2gtk.toml**: add a `### Dependencies` section and group all `fix(deps)` / `chore(deps)` commits there (including docker-digest and lock-file-maintenance commits that were previously skipped).
- **typos.toml**: ignore docker digest hashes in `extend-ignore-re`, which would otherwise be flagged as misspellings once the regenerated changelog includes those digest lines.

### Testing
- Verified both git-cliff configs render the `Dependencies` group correctly.
- `typos .` passes, and typos passes against the regenerated changelog content.

The changelog files themselves will be regenerated by the nightly `update-changelog` workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog generation to group dependency-related updates under a dedicated **Dependencies** section.
* **Chores**
  * Reduced false-positive typo warnings for Docker image digests in hexadecimal format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->