### PR TITLE
feat(release): use immutable releases with draft workflow (#2354)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,7 +4,7 @@
 change-template: "- $TITLE @$AUTHOR #$NUMBER"
 sort-direction: ascending
 
-name-template: "mDNS-Browser Release v$RESOLVED_VERSION"
+name-template: "mDNS-Browser v$RESOLVED_VERSION"
 tag-template: "mdns-browser-v$RESOLVED_VERSION"
 tag-prefix: mdns-browser-v
 

--- a/.github/workflows/android-reusable.yml
+++ b/.github/workflows/android-reusable.yml
@@ -131,15 +131,18 @@ jobs:
 
       - name: 🚀 Publish (publish only)
         if: inputs.tagName
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        with:
-          name: mDNS-Browser Release v${{ steps.get-version.outputs.current-version }}
-          tag_name: ${{ inputs.tagName }}
-          append_body: true
-          make_latest: false
-          generate_release_notes: false
-          files: |
-            src-tauri/gen/android/app/build/outputs/apk/universal/release/mdns-browser_${{ steps.get-version.outputs.current-version }}.apk
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tagName }}
+          APK_FILE: src-tauri/gen/android/app/build/outputs/apk/universal/release/mdns-browser_${{ steps.get-version.outputs.current-version }}.apk
+        run: |
+          if [[ -n "$APK_FILE" && -f "$APK_FILE" ]]; then
+            gh release upload "$TAG_NAME" "$APK_FILE" --clobber
+          else
+            echo "No release assets to upload for this platform"
+            exit 1
+          fi
 
       - name: 🛡️ Attest build provenance (publish only)
         if: inputs.tagName

--- a/.github/workflows/asset-checksums-reusable.yml
+++ b/.github/workflows/asset-checksums-reusable.yml
@@ -14,6 +14,9 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: write # Needed to upload checksums and publish release assets
+
 jobs:
   tag:
     name: Tag
@@ -78,17 +81,26 @@ jobs:
       - tag
       - generate_checksums
     steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
       - name: 📥 artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
 
       - name: 📰🔢☑️
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ needs.tag.outputs.tag }}
-          append_body: true
-          make_latest: false
-          generate_release_notes: false
-          files: |
-            **/*.sha*
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.tag.outputs.tag }}
+        run: |
+          CHECKSUMS=()
+          while IFS= read -r -d '' file; do
+            CHECKSUMS+=("$file")
+          done < <(find . -type f -name '*.sha*' -not -path './.git/*' -print0)
+          if [ "${#CHECKSUMS[@]}" -eq 0 ]; then
+            echo "No checksum files to upload"
+            exit 1
+          fi
+          gh release upload "$TAG_NAME" "${CHECKSUMS[@]}" --clobber

--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -230,13 +230,27 @@ jobs:
 
       - name: 📤 Publish debug symbols to release
         if: inputs.tagName
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        with:
-          tag_name: ${{ inputs.tagName }}
-          files: |
-            ${{ steps.debug-symbols.outputs.paths }}
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tagName }}
+          VERSION: ${{ steps.get-version.outputs.current-version }}
+        run: |
+          ASSETS=()
+          for file in \
+            "target/release/mdns-browser-$VERSION-debug-symbols-windows.zip" \
+            "target/release/mdns-browser-$VERSION-debug-symbols-linux.tar.gz" \
+            "target/x86_64-apple-darwin/release/deps/mdns-browser-$VERSION-debug-symbols-macos-x86_64.tar.gz" \
+            "target/aarch64-apple-darwin/release/deps/mdns-browser-$VERSION-debug-symbols-macos-aarch64.tar.gz"; do
+            if [[ -n "$file" && -f "$file" ]]; then
+              ASSETS+=("$file")
+            fi
+          done
+          if [ "${#ASSETS[@]}" -eq 0 ]; then
+            echo "No release assets to upload for this platform"
+            exit 1
+          fi
+          gh release upload "$TAG_NAME" "${ASSETS[@]}" --clobber
 
       - name: 🛡️ Attest build provenance (publish release only)
         if: inputs.tagName

--- a/.github/workflows/publish-sbom-reusable.yml
+++ b/.github/workflows/publish-sbom-reusable.yml
@@ -10,6 +10,9 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: write # Needed to upload SBOMs to release
+
 jobs:
   tag:
     name: Tag
@@ -34,6 +37,11 @@ jobs:
     needs:
       - tag
     steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
       - name: 📥 SBOM artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -42,13 +50,17 @@ jobs:
           merge-multiple: true
 
       - name: 📰📜
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ needs.tag.outputs.tag }}
-          append_body: true
-          make_latest: false
-          generate_release_notes: false
-          files: |
-            sboms/*
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.tag.outputs.tag }}
+        run: |
+          SBOMS=()
+          while IFS= read -r -d '' file; do
+            SBOMS+=("$file")
+          done < <(find sboms -type f -name '*.spdx.json' -print0)
+          if [ "${#SBOMS[@]}" -eq 0 ]; then
+            echo "No SBOM files to upload"
+            exit 1
+          fi
+          gh release upload "$TAG_NAME" "${SBOMS[@]}" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,6 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       tagName: mdns-browser-v${{ steps.version.outputs.version}}
     env:
-      GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
       RULESET: repos/${{github.repository}}/rulesets/${{ secrets.RULESET_ID }}
     steps:
       - name: 🔄 Checkout
@@ -121,6 +120,8 @@ jobs:
           git config --global user.email "hrzlgnm@users.noreply.github.com"
 
       - name: ⏳ Temporary disable ruleset enforcement
+        env:
+          GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
         if: (!inputs.dry-run)
         run: |
           gh api \
@@ -155,6 +156,8 @@ jobs:
           git push --follow-tags
 
       - name: 👮 Re-enable enforcement of rules
+        env:
+          GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
         if: (always() && !inputs.dry-run)
         run: |
           gh api \
@@ -173,8 +176,6 @@ jobs:
       contents: write # to create, update, and manage releases and drafts
     runs-on: ubuntu-slim
     name: 📝 Draft a new release
-    env:
-      GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
     steps:
       - name: 🔄 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           git add -A
           git commit -S -m "Bump version to ${{ steps.version.outputs.version }}"
-          git tag -s -a mdns-browser-v${{ steps.version.outputs.version }} -m "mDNS-Browser Release v${{ steps.version.outputs.version }}"
+          git tag -s -a mdns-browser-v${{ steps.version.outputs.version }} -m "mDNS-Browser v${{ steps.version.outputs.version }}"
           git push --follow-tags
 
       - name: 👮 Re-enable enforcement of rules
@@ -172,20 +172,28 @@ jobs:
     permissions:
       contents: write # to create, update, and manage releases and drafts
     runs-on: ubuntu-slim
-    name: 🚀 Create Pre-release
+    name: 📝 Draft a new release
+    env:
+      GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
     steps:
       - name: 🔄 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      - name: 🗒️ Create pre-release
+      - name: 🧹 Delete pre-existing draft releases
+        if: ${{ !inputs.dry-run && needs.bump_version.outputs.version != '' }}
+        uses: hugo19941994/delete-draft-releases@3f19a25abf2ce87850c2268938f98f14e4d3d1f1 # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🗒️ Generate release notes with release-drafter
+        if: ${{ !inputs.dry-run && needs.bump_version.outputs.version != '' }}
         uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         with:
+          draft: true
           latest: false
-          name: "mDNS-Browser Release v${{ needs.bump_version.outputs.version }}"
-          prerelease: true
-          publish: true
+          name: "mDNS-Browser v${{ needs.bump_version.outputs.version }}"
           tag: mdns-browser-v${{ needs.bump_version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/source-checksums-reusable.yml
+++ b/.github/workflows/source-checksums-reusable.yml
@@ -14,6 +14,9 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: write # Needed to upload checksums and publish release assets
+
 jobs:
   tag:
     name: Tag
@@ -67,17 +70,26 @@ jobs:
       - tag
       - generate_checksums
     steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
       - name: 📥 artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
 
       - name: 📰🔢☑️
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ needs.tag.outputs.tag }}
-          append_body: true
-          make_latest: false
-          generate_release_notes: false
-          files: |
-            **/*.sha*
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.tag.outputs.tag }}
+        run: |
+          CHECKSUMS=()
+          while IFS= read -r -d '' file; do
+            CHECKSUMS+=("$file")
+          done < <(find . -type f -name '*.sha*' -not -path './.git/*' -print0)
+          if [ "${#CHECKSUMS[@]}" -eq 0 ]; then
+            echo "No checksum files to upload"
+            exit 1
+          fi
+          gh release upload "$TAG_NAME" "${CHECKSUMS[@]}" --clobber

--- a/.github/workflows/void-reusable.yml
+++ b/.github/workflows/void-reusable.yml
@@ -108,16 +108,23 @@ jobs:
 
       - name: 🚀 Publish
         if: inputs.tagName
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          name: mDNS-Browser Release v${{ steps.get-version.outputs.version }}
-          tag_name: ${{ inputs.tagName }}
-          append_body: true
-          make_latest: false
-          generate_release_notes: false
-          files: |
-            /github/home/void-packages/hostdir/binpkgs/mdns-browser-${{ steps.get-version.outputs.version }}_1.x86_64.xbps
-            /github/home/void-packages/hostdir/binpkgs/mdns-browser-${{ steps.get-version.outputs.version }}_1.x86_64.xbps.sig2
-            /github/home/void-packages/hostdir/binpkgs/x86_64-repodata
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tagName }}
+          VERSION: ${{ steps.get-version.outputs.version }}
+        run: |
+          ASSETS=()
+          for file in \
+            "/github/home/void-packages/hostdir/binpkgs/mdns-browser-${VERSION}_1.x86_64.xbps" \
+            "/github/home/void-packages/hostdir/binpkgs/mdns-browser-${VERSION}_1.x86_64.xbps.sig2" \
+            "/github/home/void-packages/hostdir/binpkgs/x86_64-repodata"; do
+            if [ -n "$file" ] && [ -f "$file" ]; then
+              ASSETS+=("$file")
+            fi
+          done
+          if [ "${#ASSETS[@]}" -eq 0 ]; then
+            echo "No release assets to upload for this platform"
+            exit 1
+          fi
+          gh release upload "$TAG_NAME" "${ASSETS[@]}" --clobber


### PR DESCRIPTION
Ports the same changes from mdns-tui-browser commits 98070af and 5ff2860 to mdns-browser.

- Creates a draft release instead of a prerelease (user publishes manually)
- Uses `hugo19941994/delete-draft-releases` to clean up stale drafts before drafting
- Replaces `softprops/action-gh-release` with `gh release upload --clobber` for asset uploads
- Removes 'Release' from release name and tag message
- Checkout before download-artifact in checksum/SBOM workflows to prevent file loss
- Fails if no release assets to upload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Management**
  - Release names now use the streamlined format `mDNS-Browser v<version>`.
  - Prereleases are prepared as drafts for review before publication.
  - Release notes are generated when version information is available.

- **Bug Fixes**
  - Improved publication of Android, desktop, checksum, SBOM, and package assets.
  - Missing release assets now trigger clear failures instead of incomplete uploads.
  - Existing assets can be safely replaced during publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->