### PR TITLE
fix(release): replace draft input with publish in release-drafter config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,7 @@ jobs:
         if: ${{ !inputs.dry-run && needs.bump_version.outputs.version != '' }}
         uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         with:
-          draft: true
+          publish: false
           latest: false
           name: "mDNS-Browser v${{ needs.bump_version.outputs.version }}"
           tag: mdns-browser-v${{ needs.bump_version.outputs.version }}


### PR DESCRIPTION
release-drafter@v7 removed the `draft` input. Replaced `draft: true` with `publish: false` (inverted logic) in the release notes step. Fixes the 'Unexpected input(s) draft' error.