### PR TITLE
fix(release): set releaseDraft: true and add releaseName in desktop workflow

### DIFF
--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -131,8 +131,9 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         with:
           tagName: ${{ inputs.tagName }}
+          releaseName: "mDNS-Browser v${{ steps.get-version.outputs.current-version }}"
           releaseBody: ${{ steps.current-release.outputs.body }}
-          releaseDraft: false
+          releaseDraft: true
           prerelease: false
           tauriScript: cargo --locked auditable tauri
           args: ${{ matrix.args }} --no-bundle
@@ -149,8 +150,9 @@ jobs:
         with:
           updaterJsonPreferNsis: true
           tagName: ${{ inputs.tagName }}
+          releaseName: "mDNS-Browser v${{ steps.get-version.outputs.current-version }}"
           releaseBody: ${{ steps.current-release.outputs.body }}
-          releaseDraft: false
+          releaseDraft: true
           prerelease: false
           tauriScript: cargo --locked auditable tauri
           args: ${{ matrix.args }}


### PR DESCRIPTION
Tauri Action v1.0.0 requires releaseName to create releases. With releaseDraft: false, the action looks for a published release but can't find the draft created by release-drafter (publish: false). Setting releaseDraft: true keeps the draft state consistent, and adding releaseName as fallback for release creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Desktop release builds now use versioned release names.
  * New releases are created as drafts for review before publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->