### PR TITLE
fix(release): use gh release download for source tarball checksum in void workflow

### DIFF
--- a/.github/workflows/void-reusable.yml
+++ b/.github/workflows/void-reusable.yml
@@ -59,9 +59,14 @@ jobs:
 
       - name: 🔢 Get Source Tarball Checksum
         id: get-checksum
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          URL="https://github.com/hrzlgnm/mdns-browser/releases/download/mdns-browser-v${{ steps.get-version.outputs.version }}/mdns-browser-v${{ steps.get-version.outputs.version }}.tar.gz.sha256"
-          SHA256SUM=$(curl -LfsS "$URL" | cut -d ' ' -f1)
+          VERSION="${{ steps.get-version.outputs.version }}"
+          TAG="mdns-browser-v${VERSION}"
+          FILENAME="${TAG}.tar.gz.sha256"
+          gh release download "$TAG" --pattern "$FILENAME" --output "$RUNNER_TEMP/$FILENAME"
+          SHA256SUM=$(cut -d ' ' -f1 "$RUNNER_TEMP/$FILENAME")
           echo "checksum=$SHA256SUM" >> "$GITHUB_OUTPUT"
 
       - name: 🌀  Generate template

--- a/.github/workflows/void-reusable.yml
+++ b/.github/workflows/void-reusable.yml
@@ -60,13 +60,20 @@ jobs:
       - name: 🔢 Get Source Tarball Checksum
         id: get-checksum
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.get-version.outputs.version }}"
           TAG="mdns-browser-v${VERSION}"
           FILENAME="${TAG}.tar.gz.sha256"
-          gh release download "$TAG" --pattern "$FILENAME" --output "$RUNNER_TEMP/$FILENAME"
-          SHA256SUM=$(cut -d ' ' -f1 "$RUNNER_TEMP/$FILENAME")
+          ASSET_URL=$(curl -sSL \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "${GITHUB_API_URL}/repos/${{ github.repository }}/releases/tags/$TAG" \
+            | jq -r ".assets[] | select(.name == \"$FILENAME\") | .url")
+          SHA256SUM=$(curl -sSL \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/octet-stream" \
+            "$ASSET_URL" | cut -d ' ' -f1)
           echo "checksum=$SHA256SUM" >> "$GITHUB_OUTPUT"
 
       - name: 🌀  Generate template


### PR DESCRIPTION
Draft releases don't have publicly accessible download URLs. The void workflow uses curl to fetch the checksum from the release download URL, which returns 404 for draft releases. Using gh release download with authentication fixes this since gh is already used in the same workflow.