### PR TITLE
chore(void): install gh in void package builder

### DIFF
--- a/.github/docker/mdns-browser-void-package-builder/Dockerfile
+++ b/.github/docker/mdns-browser-void-package-builder/Dockerfile
@@ -13,6 +13,7 @@ RUN xbps-install -Syu xbps \
     curl \
     findutils \
     git \
+    github-cli \
     jq \
     rustup \
     util-linux \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub CLI to the Docker image’s build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->