### PR TITLE
feat: add gh to ubuntu-package-builder image

### DIFF
--- a/.github/docker/mdns-browser-ubuntu-builder/Dockerfile
+++ b/.github/docker/mdns-browser-ubuntu-builder/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
     curl \
     file \
     git \
+    gh \
     jq \
     libayatana-appindicator3-dev \
     librsvg2-dev \


### PR DESCRIPTION
Adds GitHub CLI (gh) to the ubuntu-package-builder Docker image.