### PR TITLE
fix(release): replace release-downloader with gh release download in asset checksums

### DIFF
--- a/.github/workflows/asset-checksums-reusable.yml
+++ b/.github/workflows/asset-checksums-reusable.yml
@@ -47,11 +47,11 @@ jobs:
         algorithm: [sha256]
     steps:
       - name: 📥 assets
-        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
-        with:
-          repository: ${{ github.repository }}
-          tag: ${{ needs.tag.outputs.tag }}
-          fileName: "mdns?browser*"
+        shell: bash
+        env:
+          TAG_NAME: ${{ needs.tag.outputs.tag }}
+        run: |
+          gh release download "$TAG_NAME" -p "mdns?browser*" -D .
       - name: 🔢☑️
         shell: bash
         env:

--- a/.github/workflows/asset-checksums-reusable.yml
+++ b/.github/workflows/asset-checksums-reusable.yml
@@ -50,6 +50,8 @@ jobs:
         shell: bash
         env:
           TAG_NAME: ${{ needs.tag.outputs.tag }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release download "$TAG_NAME" -p "mdns?browser*" -D .
       - name: 🔢☑️


### PR DESCRIPTION
Replaces the unreliable robinraju/release-downloader action with `gh release download` in the asset-checksums reusable workflow, matching the same fix applied to the void workflow in #2380 and #2376. The release-downloader action was failing when trying to download release assets, causing the asset checksums job to fail later in the release chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and maintainability of release asset verification.
  * Updated asset retrieval processes to provide more consistent checksum validation during releases.
  * No changes to application functionality or the end-user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->