### PR TITLE
feat: add selectable network interfaces

### DIFF
--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -187,14 +187,18 @@ fn byte_array_hexlified(byte_array: &[u8]) -> String {
         .join("")
 }
 
+/// A network interface that can be selected for mDNS browsing.
 #[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug, Store)]
+#[serde(rename_all = "camelCase")]
 pub struct NetworkInterface {
     pub name: String,
     pub addresses: Vec<String>,
     pub enabled: bool,
 }
 
+/// Event emitted when the set of mDNS-capable network interfaces changes.
 #[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct InterfacesChangedEvent {
     pub interfaces: Vec<NetworkInterface>,
 }

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -187,6 +187,18 @@ fn byte_array_hexlified(byte_array: &[u8]) -> String {
         .join("")
 }
 
+#[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug, Store)]
+pub struct NetworkInterface {
+    pub name: String,
+    pub addresses: Vec<String>,
+    pub enabled: bool,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug)]
+pub struct InterfacesChangedEvent {
+    pub interfaces: Vec<NetworkInterface>,
+}
+
 #[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug)]
 pub struct MetricsChangedEvent {
     pub metrics: HashMap<String, i64>,

--- a/crates/shared_constants/src/lib.rs
+++ b/crates/shared_constants/src/lib.rs
@@ -6,6 +6,7 @@ pub const MDNS_SD_META_SERVICE: &str = "_services._dns-sd._udp.local.";
 pub const MDNS_SD_IP_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 pub const METRICS_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 pub const INTERFACES_CAN_BROWSE_CHECK_INTERVAL: Duration = Duration::from_millis(500);
+pub const INTERFACES_LIST_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
 pub const AUTO_COMPLETE_AUTO_FOCUS_DELAY: Duration = Duration::from_secs(5);
 pub const SHOW_NO_UPDATE_DURATION: Duration = Duration::from_secs(3);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,9 +5,13 @@
 use clap::builder::TypedValueParser as _;
 #[cfg(desktop)]
 use clap::Parser;
+#[cfg(windows)]
+use ipconfig::IfType;
 use mdns_sd::{IfKind, ServiceDaemon, ServiceEvent};
 use models::check_service_type_fully_qualified;
 use models::*;
+#[cfg(not(windows))]
+use pnet::datalink;
 use shared_constants::{
     INTERFACES_CAN_BROWSE_CHECK_INTERVAL, INTERFACES_LIST_CHECK_INTERVAL,
     MDNS_SD_IP_CHECK_INTERVAL, MDNS_SD_META_SERVICE, METRICS_CHECK_INTERVAL, VERIFY_TIMEOUT,
@@ -435,7 +439,6 @@ fn is_mdns_capable_pnet(interface: &pnet::datalink::NetworkInterface) -> bool {
 
 #[cfg(not(windows))]
 fn enumerate_mdns_incapable_interfaces() -> Vec<IfKind> {
-    use pnet::datalink;
     let interfaces = datalink::interfaces();
     interfaces
         .iter()
@@ -452,7 +455,6 @@ fn enumerate_mdns_incapable_interfaces() -> Vec<IfKind> {
 
 #[cfg(not(windows))]
 fn enumerate_mdns_capable_interfaces() -> Vec<NetworkInterface> {
-    use pnet::datalink;
     let mut interfaces: Vec<NetworkInterface> = datalink::interfaces()
         .iter()
         .filter(|interface| {
@@ -543,8 +545,6 @@ fn is_mdns_capable_ipconfig(adapter: &ipconfig::Adapter) -> bool {
 
 #[cfg(windows)]
 fn enumerate_mdns_incapable_interfaces() -> Vec<IfKind> {
-    use ipconfig::IfType;
-
     if let Ok(adapters) = ipconfig::get_adapters() {
         adapters
             .iter()
@@ -571,31 +571,33 @@ fn enumerate_mdns_incapable_interfaces() -> Vec<IfKind> {
 
 #[cfg(windows)]
 fn enumerate_mdns_capable_interfaces() -> Vec<NetworkInterface> {
-    use ipconfig::IfType;
-    let mut interfaces: Vec<NetworkInterface> = ipconfig::get_adapters()
-        .map(|adapters| {
-            adapters
-                .iter()
-                .filter(|adapter| {
-                    // The loopback adapter is offered as a selection even though it is not
-                    // multicast capable, as it allows browsing mDNS services that are only
-                    // advertised on loopback.
-                    is_mdns_capable_ipconfig(adapter)
-                        || (adapter.if_type() == IfType::SoftwareLoopback
-                            && !adapter.ip_addresses().is_empty())
-                })
-                .map(|adapter| NetworkInterface {
-                    name: adapter.friendly_name().to_string(),
-                    addresses: adapter
-                        .ip_addresses()
-                        .iter()
-                        .map(|ip| ip.to_string())
-                        .collect(),
-                    enabled: true,
-                })
-                .collect()
+    let adapters = match ipconfig::get_adapters() {
+        Ok(adapters) => adapters,
+        Err(err) => {
+            log::error!("Failed to get network adapters: {err:?}");
+            return vec![];
+        }
+    };
+    let mut interfaces: Vec<NetworkInterface> = adapters
+        .iter()
+        .filter(|adapter| {
+            // The loopback adapter is offered as a selection even though it is not
+            // multicast capable, as it allows browsing mDNS services that are only
+            // advertised on loopback.
+            is_mdns_capable_ipconfig(adapter)
+                || (adapter.if_type() == IfType::SoftwareLoopback
+                    && !adapter.ip_addresses().is_empty())
         })
-        .unwrap_or_default();
+        .map(|adapter| NetworkInterface {
+            name: adapter.friendly_name().to_string(),
+            addresses: adapter
+                .ip_addresses()
+                .iter()
+                .map(|ip| ip.to_string())
+                .collect(),
+            enabled: true,
+        })
+        .collect();
     interfaces.sort_by(|a, b| a.name.cmp(&b.name));
     interfaces
 }
@@ -662,7 +664,6 @@ mod tests {
 
 #[cfg(not(windows))]
 fn has_mdns_capable_interfaces() -> bool {
-    use pnet::datalink;
     datalink::interfaces().iter().any(|interface| {
         is_mdns_capable_pnet(interface) || (interface.is_loopback() && !interface.ips.is_empty())
     })
@@ -707,6 +708,11 @@ async fn poll_can_browse(window: Window) {
     }
 }
 
+/// Subscribes to updates of the mDNS browsing capability.
+///
+/// Starts a background task that polls whether mDNS-capable interfaces are available at regular
+/// intervals, or emits the current state immediately if a subscription is already active. Emits
+/// `"can-browse-changed"` events to the Tauri window.
 #[tauri::command]
 fn subscribe_can_browse(window: Window, state: State<ManagedState>) {
     if state
@@ -750,20 +756,26 @@ async fn poll_interfaces(window: Window, disabled_interfaces: Arc<Mutex<HashSet<
     }
 }
 
+/// Subscribes to periodic updates of the available mDNS network interfaces.
+///
+/// Starts a background task that polls the system for mDNS-capable network interfaces at regular
+/// intervals, or emits the current list immediately if a subscription is already active. Emits
+/// `"interfaces-changed"` events to the Tauri window.
 #[tauri::command]
-fn subscribe_interfaces(window: Window, state: State<ManagedState>) {
+fn subscribe_interfaces(window: Window, state: State<ManagedState>) -> Result<(), String> {
     if state
         .interfaces_subscribed
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         .is_ok()
     {
         tauri::async_runtime::spawn(poll_interfaces(window, state.disabled_interfaces.clone()));
+        Ok(())
     } else {
         let disabled = match state.disabled_interfaces.lock() {
             Ok(disabled) => disabled.clone(),
             Err(err) => {
                 log::error!("Failed to lock disabled interfaces: {err:?}");
-                return;
+                return Err(format!("Failed to lock disabled interfaces: {err:?}"));
             }
         };
         let interfaces =
@@ -773,6 +785,7 @@ fn subscribe_interfaces(window: Window, state: State<ManagedState>) {
             "interfaces-changed",
             &InterfacesChangedEvent { interfaces },
         );
+        Ok(())
     }
 }
 
@@ -897,8 +910,6 @@ fn set_interface_enabled_flags(
 
 #[tauri::command]
 fn set_protocol_flags(state: State<ManagedState>, flags: ProtocolFlags) -> Result<(), String> {
-    state.ipv4_enabled.store(flags.ipv4, Ordering::SeqCst);
-    state.ipv6_enabled.store(flags.ipv6, Ordering::SeqCst);
     let disabled_interfaces = state
         .disabled_interfaces
         .lock()
@@ -908,7 +919,15 @@ fn set_protocol_flags(state: State<ManagedState>, flags: ProtocolFlags) -> Resul
         .daemon
         .lock()
         .map_err(|e| format!("Failed to lock daemon: {e:?}"))?;
-    apply_interface_selections(&daemon, &disabled_interfaces, flags.ipv4, flags.ipv6)
+    if let Err(err) =
+        apply_interface_selections(&daemon, &disabled_interfaces, flags.ipv4, flags.ipv6)
+    {
+        log::error!("Failed to apply interface selections: {err}");
+        return Err(err);
+    }
+    state.ipv4_enabled.store(flags.ipv4, Ordering::SeqCst);
+    state.ipv6_enabled.store(flags.ipv6, Ordering::SeqCst);
+    Ok(())
 }
 
 #[tauri::command]
@@ -930,9 +949,6 @@ fn set_interfaces(state: State<ManagedState>, enabled: Vec<String>) -> Result<()
     if *disabled_interfaces == new_disabled {
         return Ok(());
     }
-    *disabled_interfaces = new_disabled;
-    let disabled = disabled_interfaces.clone();
-    drop(disabled_interfaces);
 
     let daemon = state
         .daemon
@@ -940,7 +956,13 @@ fn set_interfaces(state: State<ManagedState>, enabled: Vec<String>) -> Result<()
         .map_err(|e| format!("Failed to lock daemon: {e:?}"))?;
     let ipv4_enabled = state.ipv4_enabled.load(Ordering::SeqCst);
     let ipv6_enabled = state.ipv6_enabled.load(Ordering::SeqCst);
-    apply_interface_selections(&daemon, &disabled, ipv4_enabled, ipv6_enabled)
+    if let Err(err) = apply_interface_selections(&daemon, &new_disabled, ipv4_enabled, ipv6_enabled)
+    {
+        log::error!("Failed to apply interface selections: {err}");
+        return Err(err);
+    }
+    *disabled_interfaces = new_disabled;
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -455,7 +455,12 @@ fn enumerate_mdns_capable_interfaces() -> Vec<NetworkInterface> {
     use pnet::datalink;
     let mut interfaces: Vec<NetworkInterface> = datalink::interfaces()
         .iter()
-        .filter(|interface| is_mdns_capable_pnet(interface))
+        .filter(|interface| {
+            // The loopback interface is offered as a selection even though it is not multicast
+            // capable, as it allows browsing mDNS services that are only advertised on loopback.
+            is_mdns_capable_pnet(interface)
+                || (interface.is_loopback() && !interface.ips.is_empty())
+        })
         .map(|interface| NetworkInterface {
             name: interface.name.clone(),
             addresses: interface.ips.iter().map(|ip| ip.ip().to_string()).collect(),
@@ -499,26 +504,26 @@ mod tests {
     }
 
     #[test]
-    fn test_loopback_not_included_in_mdns_capable_interfaces() {
+    fn test_loopback_included_in_mdns_capable_interfaces() {
         let result = enumerate_mdns_capable_interfaces();
         // Gather actual loopback interface names on this system.
         let loopback_names: std::collections::HashSet<String> = {
             datalink::interfaces()
                 .into_iter()
-                .filter(|iface| iface.is_loopback())
+                .filter(|iface| iface.is_loopback() && !iface.ips.is_empty())
                 .map(|iface| iface.name)
                 .collect()
         };
         assert!(
             !loopback_names.is_empty(),
-            "No loopback interfaces detected on this host; test cannot validate exclusion"
+            "No loopback interfaces detected on this host; test cannot validate inclusion"
         );
         let any_loopback_found = result
             .iter()
             .any(|interface| loopback_names.contains(&interface.name));
         assert!(
-            !any_loopback_found,
-            "Loopback interfaces {:?} should not be included in mdns-capable interfaces",
+            any_loopback_found,
+            "Loopback interfaces {:?} should be included in mdns-capable interfaces",
             loopback_names
         );
     }
@@ -566,11 +571,19 @@ fn enumerate_mdns_incapable_interfaces() -> Vec<IfKind> {
 
 #[cfg(windows)]
 fn enumerate_mdns_capable_interfaces() -> Vec<NetworkInterface> {
+    use ipconfig::IfType;
     let mut interfaces: Vec<NetworkInterface> = ipconfig::get_adapters()
         .map(|adapters| {
             adapters
                 .iter()
-                .filter(|adapter| is_mdns_capable_ipconfig(adapter))
+                .filter(|adapter| {
+                    // The loopback adapter is offered as a selection even though it is not
+                    // multicast capable, as it allows browsing mDNS services that are only
+                    // advertised on loopback.
+                    is_mdns_capable_ipconfig(adapter)
+                        || (adapter.if_type() == IfType::SoftwareLoopback
+                            && !adapter.ip_addresses().is_empty())
+                })
                 .map(|adapter| NetworkInterface {
                     name: adapter.friendly_name().to_string(),
                     addresses: adapter
@@ -621,7 +634,7 @@ mod tests {
     }
 
     #[test]
-    fn test_loopback_not_included_in_mdns_capable_interfaces() {
+    fn test_loopback_included_in_mdns_capable_interfaces() {
         let result = enumerate_mdns_capable_interfaces();
         let loopback_names: std::collections::HashSet<String> = ipconfig::get_adapters()
             .map(|adapters| {
@@ -634,14 +647,14 @@ mod tests {
             .unwrap_or_default();
         assert!(
             !loopback_names.is_empty(),
-            "No loopback interfaces detected on this host; test cannot validate exclusion"
+            "No loopback interfaces detected on this host; test cannot validate inclusion"
         );
         let loopback_present = result
             .iter()
             .any(|interface| loopback_names.contains(&interface.name));
         assert!(
-            !loopback_present,
-            "Software loopback adapters {:?} should not be included in mdns-capable interfaces",
+            loopback_present,
+            "Software loopback adapters {:?} should be included in mdns-capable interfaces",
             loopback_names
         );
     }
@@ -650,21 +663,19 @@ mod tests {
 #[cfg(not(windows))]
 fn has_mdns_capable_interfaces() -> bool {
     use pnet::datalink;
-    let interfaces = datalink::interfaces();
-    interfaces.iter().any(|interface| {
-        !interface.ips.is_empty()
-            && !interface.is_loopback()
-            && !interface.is_point_to_point()
-            && interface.is_multicast()
-            && interface.is_broadcast()
-            && interface.is_running()
+    datalink::interfaces().iter().any(|interface| {
+        is_mdns_capable_pnet(interface) || (interface.is_loopback() && !interface.ips.is_empty())
     })
 }
 
 #[cfg(windows)]
 fn has_mdns_capable_interfaces() -> bool {
     if let Ok(adapters) = ipconfig::get_adapters() {
-        adapters.iter().any(is_mdns_capable_ipconfig)
+        adapters.iter().any(|adapter| {
+            is_mdns_capable_ipconfig(adapter)
+                || (adapter.if_type() == ipconfig::IfType::SoftwareLoopback
+                    && !adapter.ip_addresses().is_empty())
+        })
     } else {
         log::warn!("Unable to determine whether we have mDNS capable network adapters, assuming no network is present");
         false

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,8 +9,8 @@ use mdns_sd::{IfKind, ServiceDaemon, ServiceEvent};
 use models::check_service_type_fully_qualified;
 use models::*;
 use shared_constants::{
-    INTERFACES_CAN_BROWSE_CHECK_INTERVAL, MDNS_SD_IP_CHECK_INTERVAL, MDNS_SD_META_SERVICE,
-    METRICS_CHECK_INTERVAL, VERIFY_TIMEOUT,
+    INTERFACES_CAN_BROWSE_CHECK_INTERVAL, INTERFACES_LIST_CHECK_INTERVAL,
+    MDNS_SD_IP_CHECK_INTERVAL, MDNS_SD_META_SERVICE, METRICS_CHECK_INTERVAL, VERIFY_TIMEOUT,
 };
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
@@ -33,8 +33,10 @@ struct ManagedState {
     queriers: Arc<Mutex<HashSet<String>>>,
     metrics_subscribed: AtomicBool,
     can_browse_subscribed: AtomicBool,
+    interfaces_subscribed: AtomicBool,
     ipv4_enabled: AtomicBool,
     ipv6_enabled: AtomicBool,
+    disabled_interfaces: Arc<Mutex<HashSet<String>>>,
     #[cfg(desktop)]
     dev_tools_enabled: bool,
 }
@@ -47,8 +49,10 @@ impl ManagedState {
             queriers: Arc::new(Mutex::new(HashSet::new())),
             metrics_subscribed: AtomicBool::new(false),
             can_browse_subscribed: AtomicBool::new(false),
+            interfaces_subscribed: AtomicBool::new(false),
             ipv4_enabled: AtomicBool::new(true),
             ipv6_enabled: AtomicBool::new(true),
+            disabled_interfaces: Arc::new(Mutex::new(HashSet::new())),
             dev_tools_enabled: dev_tools_requested,
         }
     }
@@ -60,8 +64,10 @@ impl ManagedState {
             queriers: Arc::new(Mutex::new(HashSet::new())),
             metrics_subscribed: AtomicBool::new(false),
             can_browse_subscribed: AtomicBool::new(false),
+            interfaces_subscribed: AtomicBool::new(false),
             ipv4_enabled: AtomicBool::new(true),
             ipv6_enabled: AtomicBool::new(true),
+            disabled_interfaces: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 }
@@ -157,6 +163,52 @@ mod convert_to_scoped_addr_tests {
         let result = convert_to_scoped_addr(&scoped_ip);
 
         assert_eq!(result.addr, IpAddr::V6(ipv6_addr));
+    }
+}
+
+#[cfg(test)]
+mod interface_selection_tests {
+    use super::*;
+
+    fn sample_interfaces() -> Vec<NetworkInterface> {
+        vec![
+            NetworkInterface {
+                name: "en0".to_string(),
+                addresses: vec!["192.168.1.1".to_string()],
+                enabled: true,
+            },
+            NetworkInterface {
+                name: "en1".to_string(),
+                addresses: vec![],
+                enabled: true,
+            },
+        ]
+    }
+
+    #[test]
+    fn test_set_interface_enabled_flags_keeps_all_enabled_when_nothing_disabled() {
+        let result = set_interface_enabled_flags(sample_interfaces(), &HashSet::new());
+        assert!(result.iter().all(|interface| interface.enabled));
+    }
+
+    #[test]
+    fn test_set_interface_enabled_flags_disables_matching_interfaces() {
+        let disabled = HashSet::from(["en0".to_string()]);
+        let result = set_interface_enabled_flags(sample_interfaces(), &disabled);
+        assert!(
+            !result
+                .iter()
+                .find(|interface| interface.name == "en0")
+                .expect("To contain en0")
+                .enabled
+        );
+        assert!(
+            result
+                .iter()
+                .find(|interface| interface.name == "en1")
+                .expect("To contain en1")
+                .enabled
+        );
     }
 }
 
@@ -365,33 +417,53 @@ fn browse_many(service_types: Vec<String>, window: Window, state: State<ManagedS
 }
 
 #[cfg(not(windows))]
+/// Checks whether a network interface is capable of mDNS discovery.
+///
+/// mDNS capable interfaces must have at least one IP address, must not be loopback or point to
+/// point, must be running and support multicast and broadcast. On Android there are some `rmnet`
+/// (remote network virtual) interfaces for cellular modems without a broadcast capability like
+/// ethernet or wifi interfaces, and sometimes a `dummy0` interface without multicast capability,
+/// both of which are therefore considered incapable.
+fn is_mdns_capable_pnet(interface: &pnet::datalink::NetworkInterface) -> bool {
+    !interface.ips.is_empty()
+        && !interface.is_loopback()
+        && !interface.is_point_to_point()
+        && interface.is_multicast()
+        && interface.is_broadcast()
+        && interface.is_running()
+}
+
+#[cfg(not(windows))]
 fn enumerate_mdns_incapable_interfaces() -> Vec<IfKind> {
     use pnet::datalink;
     let interfaces = datalink::interfaces();
     interfaces
         .iter()
-        .filter_map(|interface| {
-            // Skip loopback and point to point outright as those are disabled by
-            // default.
-            if interface.is_loopback() || interface.is_point_to_point() {
-                return None;
-            }
-            // On android there are some `rmnet` = remote network virtual interfaces which are
-            // cellular modem data interfaces. Those do not have a broadcast capability like
-            // ethernet or wifi interface, so we disable those, too.
-            // Sometimes there is also a dummy0 interface without a multicast capability which
-            // we disable as well.
-            let incapable = interface.ips.is_empty()
-                || !interface.is_running()
-                || !interface.is_multicast()
-                || !interface.is_broadcast();
-            if incapable {
-                Some(IfKind::from(interface.name.as_str()))
-            } else {
-                None
-            }
+        .filter(|interface| {
+            // Skip loopback and point to point outright as those are disabled by default and
+            // never part of the mDNS interface selection.
+            !interface.is_loopback()
+                && !interface.is_point_to_point()
+                && !is_mdns_capable_pnet(interface)
         })
+        .map(|interface| IfKind::from(interface.name.as_str()))
         .collect()
+}
+
+#[cfg(not(windows))]
+fn enumerate_mdns_capable_interfaces() -> Vec<NetworkInterface> {
+    use pnet::datalink;
+    let mut interfaces: Vec<NetworkInterface> = datalink::interfaces()
+        .iter()
+        .filter(|interface| is_mdns_capable_pnet(interface))
+        .map(|interface| NetworkInterface {
+            name: interface.name.clone(),
+            addresses: interface.ips.iter().map(|ip| ip.ip().to_string()).collect(),
+            enabled: true,
+        })
+        .collect();
+    interfaces.sort_by(|a, b| a.name.cmp(&b.name));
+    interfaces
 }
 
 #[cfg(not(windows))]
@@ -425,11 +497,48 @@ mod tests {
             loopback_names
         );
     }
+
+    #[test]
+    fn test_loopback_not_included_in_mdns_capable_interfaces() {
+        let result = enumerate_mdns_capable_interfaces();
+        // Gather actual loopback interface names on this system.
+        let loopback_names: std::collections::HashSet<String> = {
+            datalink::interfaces()
+                .into_iter()
+                .filter(|iface| iface.is_loopback())
+                .map(|iface| iface.name)
+                .collect()
+        };
+        assert!(
+            !loopback_names.is_empty(),
+            "No loopback interfaces detected on this host; test cannot validate exclusion"
+        );
+        let any_loopback_found = result
+            .iter()
+            .any(|interface| loopback_names.contains(&interface.name));
+        assert!(
+            !any_loopback_found,
+            "Loopback interfaces {:?} should not be included in mdns-capable interfaces",
+            loopback_names
+        );
+    }
+}
+
+#[cfg(windows)]
+/// Checks whether a network adapter is capable of mDNS discovery.
+///
+/// mDNS capable adapters must have at least one IP address, must be up and must be of type
+/// ethernet or IEEE 802.11 (WiFi).
+fn is_mdns_capable_ipconfig(adapter: &ipconfig::Adapter) -> bool {
+    !adapter.ip_addresses().is_empty()
+        && adapter.oper_status() == ipconfig::OperStatus::IfOperStatusUp
+        && (adapter.if_type() == ipconfig::IfType::EthernetCsmacd
+            || adapter.if_type() == ipconfig::IfType::Ieee80211)
 }
 
 #[cfg(windows)]
 fn enumerate_mdns_incapable_interfaces() -> Vec<IfKind> {
-    use ipconfig::{IfType, OperStatus};
+    use ipconfig::IfType;
 
     if let Ok(adapters) = ipconfig::get_adapters() {
         adapters
@@ -443,11 +552,7 @@ fn enumerate_mdns_incapable_interfaces() -> Vec<IfKind> {
                 ) {
                     return None;
                 }
-                if adapter.ip_addresses().is_empty()
-                    || adapter.oper_status() != OperStatus::IfOperStatusUp
-                    || (adapter.if_type() != IfType::EthernetCsmacd
-                        && adapter.if_type() != IfType::Ieee80211)
-                {
+                if !is_mdns_capable_ipconfig(adapter) {
                     Some(IfKind::from(adapter.friendly_name()))
                 } else {
                     None
@@ -457,6 +562,29 @@ fn enumerate_mdns_incapable_interfaces() -> Vec<IfKind> {
     } else {
         vec![]
     }
+}
+
+#[cfg(windows)]
+fn enumerate_mdns_capable_interfaces() -> Vec<NetworkInterface> {
+    let mut interfaces: Vec<NetworkInterface> = ipconfig::get_adapters()
+        .map(|adapters| {
+            adapters
+                .iter()
+                .filter(|adapter| is_mdns_capable_ipconfig(adapter))
+                .map(|adapter| NetworkInterface {
+                    name: adapter.friendly_name().to_string(),
+                    addresses: adapter
+                        .ip_addresses()
+                        .iter()
+                        .map(|ip| ip.to_string())
+                        .collect(),
+                    enabled: true,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    interfaces.sort_by(|a, b| a.name.cmp(&b.name));
+    interfaces
 }
 
 #[cfg(windows)]
@@ -491,6 +619,32 @@ mod tests {
             loopback_names
         );
     }
+
+    #[test]
+    fn test_loopback_not_included_in_mdns_capable_interfaces() {
+        let result = enumerate_mdns_capable_interfaces();
+        let loopback_names: std::collections::HashSet<String> = ipconfig::get_adapters()
+            .map(|adapters| {
+                adapters
+                    .into_iter()
+                    .filter(|a| a.if_type() == IfType::SoftwareLoopback)
+                    .map(|a| a.friendly_name().to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert!(
+            !loopback_names.is_empty(),
+            "No loopback interfaces detected on this host; test cannot validate exclusion"
+        );
+        let loopback_present = result
+            .iter()
+            .any(|interface| loopback_names.contains(&interface.name));
+        assert!(
+            !loopback_present,
+            "Software loopback adapters {:?} should not be included in mdns-capable interfaces",
+            loopback_names
+        );
+    }
 }
 
 #[cfg(not(windows))]
@@ -509,15 +663,8 @@ fn has_mdns_capable_interfaces() -> bool {
 
 #[cfg(windows)]
 fn has_mdns_capable_interfaces() -> bool {
-    use ipconfig::{IfType, OperStatus};
-
     if let Ok(adapters) = ipconfig::get_adapters() {
-        adapters.iter().any(|adapter| {
-            !adapter.ip_addresses().is_empty()
-                && adapter.oper_status() == OperStatus::IfOperStatusUp
-                && (adapter.if_type() == IfType::EthernetCsmacd
-                    || adapter.if_type() == IfType::Ieee80211)
-        })
+        adapters.iter().any(is_mdns_capable_ipconfig)
     } else {
         log::warn!("Unable to determine whether we have mDNS capable network adapters, assuming no network is present");
         false
@@ -564,6 +711,56 @@ fn subscribe_can_browse(window: Window, state: State<ManagedState>) {
             &CanBrowseChangedEvent {
                 can_browse: has_mdns_capable_interfaces(),
             },
+        );
+    }
+}
+
+async fn poll_interfaces(window: Window, disabled_interfaces: Arc<Mutex<HashSet<String>>>) {
+    let mut current: Vec<NetworkInterface> = Vec::new();
+    loop {
+        let disabled = match disabled_interfaces.lock() {
+            Ok(disabled) => disabled.clone(),
+            Err(err) => {
+                log::error!("Failed to lock disabled interfaces: {err:?}");
+                return;
+            }
+        };
+        let interfaces =
+            set_interface_enabled_flags(enumerate_mdns_capable_interfaces(), &disabled);
+        if interfaces != current {
+            current = interfaces.clone();
+            emit_event(
+                &window,
+                "interfaces-changed",
+                &InterfacesChangedEvent { interfaces },
+            );
+        }
+        tokio::time::sleep(INTERFACES_LIST_CHECK_INTERVAL).await;
+    }
+}
+
+#[tauri::command]
+fn subscribe_interfaces(window: Window, state: State<ManagedState>) {
+    if state
+        .interfaces_subscribed
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        tauri::async_runtime::spawn(poll_interfaces(window, state.disabled_interfaces.clone()));
+    } else {
+        let disabled = match state.disabled_interfaces.lock() {
+            Ok(disabled) => disabled.clone(),
+            Err(err) => {
+                log::error!("Failed to lock disabled interfaces: {err:?}");
+                return;
+            }
+        };
+        let interfaces =
+            set_interface_enabled_flags(enumerate_mdns_capable_interfaces(), &disabled);
+        emit_event(
+            &window,
+            "interfaces-changed",
+            &InterfacesChangedEvent { interfaces },
         );
     }
 }
@@ -637,27 +834,38 @@ fn get_protocol_flags(state: State<ManagedState>) -> ProtocolFlags {
     }
 }
 
-fn update_interface(
-    current_flag: bool,
-    new_flag: bool,
-    state_flag: &std::sync::atomic::AtomicBool,
+/// Applies the configured interface selections to the mDNS daemon.
+///
+/// The daemon applies selections in order with later selections taking precedence, so we first
+/// disable all interfaces, then re-enable the IPv4/IPv6 families based on the protocol flags,
+/// then disable the interfaces the user has unselected, and finally re-disable the interfaces
+/// that are not capable of mDNS.
+fn apply_interface_selections(
     daemon: &std::sync::MutexGuard<ServiceDaemon>,
-    if_kind: &IfKind,
+    disabled_interfaces: &HashSet<String>,
+    ipv4_enabled: bool,
+    ipv6_enabled: bool,
 ) -> Result<(), String> {
-    if current_flag != new_flag {
-        if new_flag {
-            daemon
-                .enable_interface(if_kind.clone())
-                .map_err(|e| format!("Failed to enable {if_kind:?} interface: {e:?}"))?;
-        } else {
-            daemon
-                .disable_interface(if_kind.clone())
-                .map_err(|e| format!("Failed to disable {if_kind:?} interface: {e:?}"))?;
-        }
-        state_flag.store(new_flag, Ordering::SeqCst);
+    daemon
+        .disable_interface(IfKind::All)
+        .map_err(|e| format!("Failed to disable all interfaces: {e:?}"))?;
+    if ipv4_enabled {
+        daemon
+            .enable_interface(IfKind::IPv4)
+            .map_err(|e| format!("Failed to enable IPv4 interfaces: {e:?}"))?;
     }
-    // We have to disable interfaces that are not needed anymore, as enabling IPv4 or IPv6 may also
-    // enable those interfaces.
+    if ipv6_enabled {
+        daemon
+            .enable_interface(IfKind::IPv6)
+            .map_err(|e| format!("Failed to enable IPv6 interfaces: {e:?}"))?;
+    }
+    for name in disabled_interfaces {
+        daemon
+            .disable_interface(IfKind::Name(name.clone()))
+            .map_err(|e| format!("Failed to disable {name} interface: {e:?}"))?;
+    }
+    // We have to disable interfaces that are not capable of mDNS, as enabling IPv4 or IPv6 may
+    // also enable those interfaces.
     if let Err(err) = daemon.disable_interface(enumerate_mdns_incapable_interfaces()) {
         // Log the error but continue, as this is not critical.
         log::warn!("Failed to disable interfaces: {err:?}, continuing anyway");
@@ -665,31 +873,63 @@ fn update_interface(
     Ok(())
 }
 
+/// Marks the given interfaces as enabled based on the provided set of disabled interface names.
+fn set_interface_enabled_flags(
+    mut interfaces: Vec<NetworkInterface>,
+    disabled: &HashSet<String>,
+) -> Vec<NetworkInterface> {
+    for interface in &mut interfaces {
+        interface.enabled = !disabled.contains(&interface.name);
+    }
+    interfaces
+}
+
 #[tauri::command]
 fn set_protocol_flags(state: State<ManagedState>, flags: ProtocolFlags) -> Result<(), String> {
+    state.ipv4_enabled.store(flags.ipv4, Ordering::SeqCst);
+    state.ipv6_enabled.store(flags.ipv6, Ordering::SeqCst);
+    let disabled_interfaces = state
+        .disabled_interfaces
+        .lock()
+        .map_err(|e| format!("Failed to lock disabled interfaces: {e:?}"))?
+        .clone();
     let daemon = state
         .daemon
         .lock()
         .map_err(|e| format!("Failed to lock daemon: {e:?}"))?;
-    let current_ipv4 = state.ipv4_enabled.load(Ordering::SeqCst);
-    update_interface(
-        current_ipv4,
-        flags.ipv4,
-        &state.ipv4_enabled,
-        &daemon,
-        &IfKind::IPv4,
-    )?;
+    apply_interface_selections(&daemon, &disabled_interfaces, flags.ipv4, flags.ipv6)
+}
 
-    let current_ipv6 = state.ipv6_enabled.load(Ordering::SeqCst);
-    update_interface(
-        current_ipv6,
-        flags.ipv6,
-        &state.ipv6_enabled,
-        &daemon,
-        &IfKind::IPv6,
-    )?;
+#[tauri::command]
+fn set_interfaces(state: State<ManagedState>, enabled: Vec<String>) -> Result<(), String> {
+    let enabled: HashSet<String> = enabled.into_iter().collect();
+    let capable_names: HashSet<String> = enumerate_mdns_capable_interfaces()
+        .into_iter()
+        .map(|interface| interface.name)
+        .collect();
+    let new_disabled = capable_names
+        .difference(&enabled)
+        .cloned()
+        .collect::<HashSet<_>>();
 
-    Ok(())
+    let mut disabled_interfaces = state
+        .disabled_interfaces
+        .lock()
+        .map_err(|e| format!("Failed to lock disabled interfaces: {e:?}"))?;
+    if *disabled_interfaces == new_disabled {
+        return Ok(());
+    }
+    *disabled_interfaces = new_disabled;
+    let disabled = disabled_interfaces.clone();
+    drop(disabled_interfaces);
+
+    let daemon = state
+        .daemon
+        .lock()
+        .map_err(|e| format!("Failed to lock daemon: {e:?}"))?;
+    let ipv4_enabled = state.ipv4_enabled.load(Ordering::SeqCst);
+    let ipv6_enabled = state.ipv6_enabled.load(Ordering::SeqCst);
+    apply_interface_selections(&daemon, &disabled, ipv4_enabled, ipv6_enabled)
 }
 
 #[tauri::command]
@@ -1025,8 +1265,10 @@ pub fn run() {
             get_protocol_flags,
             is_desktop,
             open_url,
+            set_interfaces,
             set_protocol_flags,
             subscribe_can_browse,
+            subscribe_interfaces,
             subscribe_metrics,
             stop_browse,
             theme,
@@ -1068,8 +1310,10 @@ pub fn run_mobile() {
             get_protocol_flags,
             is_desktop,
             open_url,
+            set_interfaces,
             set_protocol_flags,
             subscribe_can_browse,
+            subscribe_interfaces,
             subscribe_metrics,
             stop_browse,
             theme,

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -31,6 +31,16 @@ use super::{
     values_table::ValuesTable,
 };
 
+#[derive(Clone, Debug)]
+pub struct BrowsingInjection(pub RwSignal<bool>);
+
+impl BrowsingInjection {
+    #[track_caller]
+    pub fn expect_context() -> RwSignal<bool> {
+        expect_context::<Self>().0
+    }
+}
+
 /// Initiates browsing for available network service types asynchronously.
 ///
 /// Invokes the `"browse_types"` command to start discovering service types on the network.
@@ -879,7 +889,7 @@ pub fn Browse() -> impl IntoView {
         false,
     );
 
-    let browsing = RwSignal::new(false);
+    let browsing = BrowsingInjection::expect_context();
     let service_type = RwSignal::new(String::new());
     let not_browsing = Signal::derive(move || !browsing.get());
     let service_type_invalid = Signal::derive(move || {

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -32,6 +32,9 @@ use super::{
     values_table::ValuesTable,
 };
 
+/// Injection providing a signal that tracks whether a browse is currently active.
+///
+/// Other components use this signal to disable controls while browsing is running.
 #[derive(Clone, Debug)]
 pub struct BrowsingInjection(pub RwSignal<bool>);
 

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -27,6 +27,7 @@ use super::{
     invoke::invoke_no_args,
     is_desktop::IsDesktopInjection,
     listen::{listen_add_remove, listen_events, listen_to_named_event},
+    network_interfaces::HasEnabledInterfacesInjection,
     protocol_flags::ProtocolFlags,
     values_table::ValuesTable,
 };
@@ -900,8 +901,13 @@ pub fn Browse() -> impl IntoView {
 
     let browsing_or_cannot_browse = Signal::derive(move || browsing.get() || !can_browse.get());
 
-    let browsing_or_service_type_invalid_or_cannot_browse =
-        Signal::derive(move || !can_browse.get() || browsing.get() || service_type_invalid.get());
+    let has_enabled_interfaces = HasEnabledInterfacesInjection::expect_context();
+    let browse_disabled = Signal::derive(move || {
+        !can_browse.get()
+            || browsing.get()
+            || service_type_invalid.get()
+            || !has_enabled_interfaces.get()
+    });
 
     let browse_all_action = Action::new_local(|input: &ServiceTypes| {
         let input = input.clone();
@@ -1052,7 +1058,7 @@ pub fn Browse() -> impl IntoView {
                     <Button
                         appearance=ButtonAppearance::Primary
                         on_click=on_browse_click
-                        disabled=browsing_or_service_type_invalid_or_cannot_browse
+                        disabled=browse_disabled
                     >
                         "Browse"
                     </Button>

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -8,7 +8,7 @@ use super::{
     invoke::invoke_no_args,
     is_desktop::{IsDesktopInjection, get_is_desktop},
     metrics::Metrics,
-    network_interfaces::NetworkInterfaces,
+    network_interfaces::{HasEnabledInterfacesInjection, NetworkInterfaces},
     theme_switcher::ThemeSwitcher,
 };
 use js_sys::{
@@ -105,6 +105,8 @@ pub fn Main() -> impl IntoView {
     provide_context(IsDesktopInjection(is_desktop));
     let browsing = RwSignal::new(false);
     provide_context(BrowsingInjection(browsing));
+    let has_enabled_interfaces = RwSignal::new(false);
+    provide_context(HasEnabledInterfacesInjection(has_enabled_interfaces));
     view! {
         <ConfigProvider theme>
             <ToasterProvider>

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -3,11 +3,12 @@
 
 use super::{
     about::About,
-    browse::Browse,
+    browse::{Browse, BrowsingInjection},
     css::get_class,
     invoke::invoke_no_args,
     is_desktop::{IsDesktopInjection, get_is_desktop},
     metrics::Metrics,
+    network_interfaces::NetworkInterfaces,
     theme_switcher::ThemeSwitcher,
 };
 use js_sys::{
@@ -102,6 +103,8 @@ pub fn Main() -> impl IntoView {
     LocalResource::new(close_splashscreen);
     let layout_class = get_class(&is_desktop, "outer-layout");
     provide_context(IsDesktopInjection(is_desktop));
+    let browsing = RwSignal::new(false);
+    provide_context(BrowsingInjection(browsing));
     view! {
         <ConfigProvider theme>
             <ToasterProvider>
@@ -118,6 +121,7 @@ pub fn Main() -> impl IntoView {
                             </GridItem>
                         </Grid>
                         <Metrics />
+                        <NetworkInterfaces disabled=browsing />
                         <Browse />
                     </Suspense>
                 </Layout>

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11,6 +11,7 @@ mod is_desktop;
 mod listen;
 pub mod main;
 mod metrics;
+mod network_interfaces;
 mod protocol_flags;
 mod theme_switcher;
 mod values_table;

--- a/src/app/network_interfaces.rs
+++ b/src/app/network_interfaces.rs
@@ -13,6 +13,16 @@ use thaw::{
 
 use super::{css::get_class, is_desktop::IsDesktopInjection, listen::listen_to_named_event};
 
+#[derive(Clone, Debug)]
+pub struct HasEnabledInterfacesInjection(pub RwSignal<bool>);
+
+impl HasEnabledInterfacesInjection {
+    #[track_caller]
+    pub fn expect_context() -> RwSignal<bool> {
+        expect_context::<Self>().0
+    }
+}
+
 #[derive(Store, Default)]
 struct InterfacesState {
     #[store(key: String = |interface| interface.name.clone())]
@@ -106,6 +116,20 @@ pub fn NetworkInterfaces(#[prop(optional, into)] disabled: Signal<bool>) -> impl
 
     let is_desktop = IsDesktopInjection::expect_context();
     let layout_class = get_class(&is_desktop, "interfaces-layout");
+    let has_enabled_interfaces = HasEnabledInterfacesInjection::expect_context();
+    Effect::watch(
+        move || {
+            store
+                .interfaces()
+                .iter_unkeyed()
+                .map(|interface| interface.enabled().get())
+                .collect::<Vec<_>>()
+        },
+        move |enabled_flags, _, _| {
+            has_enabled_interfaces.set(enabled_flags.iter().any(|enabled| *enabled));
+        },
+        false,
+    );
 
     view! {
         <Layout class=layout_class>

--- a/src/app/network_interfaces.rs
+++ b/src/app/network_interfaces.rs
@@ -5,14 +5,18 @@ use leptos::prelude::*;
 use models::*;
 use reactive_stores::{Field, Store, StoreFieldIterator};
 use serde::{Deserialize, Serialize};
-use tauri_sys::core::invoke;
+use tauri_sys::core::invoke_result;
 use thaw::{
     Accordion, AccordionHeader, AccordionItem, Checkbox, Flex, FlexAlign, FlexGap, FlexJustify,
-    Layout,
+    Layout, Toast, ToastBody, ToastTitle, ToasterInjection,
 };
 
 use super::{css::get_class, is_desktop::IsDesktopInjection, listen::listen_to_named_event};
 
+/// Injection providing a signal that tracks whether any network interface is currently enabled.
+///
+/// The browse button uses this signal to disable itself when no mDNS-capable interface is
+/// enabled.
 #[derive(Clone, Debug)]
 pub struct HasEnabledInterfacesInjection(pub RwSignal<bool>);
 
@@ -51,13 +55,23 @@ async fn listen_to_interfaces_events(
 }
 
 #[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[allow(non_snake_case)]
 struct SetInterfacesArgs {
     enabled: Vec<String>,
 }
 
-async fn set_interfaces(enabled: Vec<String>) {
-    let _ = invoke::<()>("set_interfaces", &SetInterfacesArgs { enabled }).await;
+async fn set_interfaces(enabled: Vec<String>) -> Result<(), String> {
+    invoke_result::<(), String>("set_interfaces", &SetInterfacesArgs { enabled }).await
+}
+
+fn create_set_interfaces_error_toast(message: String) -> impl IntoView {
+    view! {
+        <Toast>
+            <ToastTitle>"Failed to set interfaces"</ToastTitle>
+            <ToastBody>{message}</ToastBody>
+        </Toast>
+    }
 }
 
 /// Renders a single network interface as a checkbox with its name and IP addresses as label.
@@ -88,9 +102,18 @@ pub fn NetworkInterfaces(#[prop(optional, into)] disabled: Signal<bool>) -> impl
     let last_backend_selection: StoredValue<Vec<String>> = StoredValue::new(Vec::new());
     LocalResource::new(move || listen_to_interfaces_events(store, last_backend_selection));
 
-    let set_interfaces_action = Action::new_local(|enabled: &Vec<String>| {
+    let toaster = ToasterInjection::expect_context();
+    let set_interfaces_action = Action::new_local(move |enabled: &Vec<String>| {
         let enabled = enabled.clone();
-        async move { set_interfaces(enabled).await }
+        async move {
+            if let Err(e) = set_interfaces(enabled).await {
+                log::error!("failed to set interfaces: {e}");
+                toaster.dispatch_toast(
+                    move || create_set_interfaces_error_toast(e),
+                    Default::default(),
+                );
+            }
+        }
     });
 
     Effect::watch(

--- a/src/app/network_interfaces.rs
+++ b/src/app/network_interfaces.rs
@@ -1,0 +1,128 @@
+// Copyright 2026 hrzlgnm
+// SPDX-License-Identifier: MIT-0
+
+use leptos::prelude::*;
+use models::*;
+use reactive_stores::{Field, Store, StoreFieldIterator};
+use serde::{Deserialize, Serialize};
+use tauri_sys::core::invoke;
+use thaw::{
+    Accordion, AccordionHeader, AccordionItem, Checkbox, Flex, FlexAlign, FlexGap, FlexJustify,
+    Layout,
+};
+
+use super::{css::get_class, is_desktop::IsDesktopInjection, listen::listen_to_named_event};
+
+#[derive(Store, Default)]
+struct InterfacesState {
+    #[store(key: String = |interface| interface.name.clone())]
+    interfaces: Vec<NetworkInterface>,
+}
+
+/// Listens for "interfaces" events and updates the provided store with the latest interface list.
+///
+/// Also records the last interface selection observed from the backend so that the component can
+/// avoid echoing applied selections back to the backend as new changes.
+async fn listen_to_interfaces_events(
+    store: Store<InterfacesState>,
+    last_backend_selection: StoredValue<Vec<String>>,
+) {
+    listen_to_named_event("interfaces", move |event: InterfacesChangedEvent| {
+        let enabled = event
+            .interfaces
+            .iter()
+            .filter(|interface| interface.enabled)
+            .map(|interface| interface.name.clone())
+            .collect();
+        last_backend_selection.set_value(enabled);
+        *store.interfaces().write() = event.interfaces;
+    })
+    .await;
+}
+
+#[derive(Serialize, Deserialize)]
+#[allow(non_snake_case)]
+struct SetInterfacesArgs {
+    enabled: Vec<String>,
+}
+
+async fn set_interfaces(enabled: Vec<String>) {
+    let _ = invoke::<()>("set_interfaces", &SetInterfacesArgs { enabled }).await;
+}
+
+/// Renders a single network interface as a checkbox with its name and IP addresses as label.
+#[component]
+fn NetworkInterfaceItem(
+    #[prop(into)] interface: Field<NetworkInterface>,
+    #[prop(into)] disabled: Signal<bool>,
+) -> impl IntoView {
+    let label = Memo::new(move |_| {
+        let name = interface.name().get();
+        let addresses = interface.addresses().get();
+        if addresses.is_empty() {
+            name
+        } else {
+            format!("{name} ({})", addresses.join(", "))
+        }
+    });
+    view! { <Checkbox checked=interface.enabled() disabled=disabled label=label /> }
+}
+
+/// Component for selecting the network interfaces used for mDNS browsing.
+///
+/// Displays a checkbox per mDNS-capable network interface. The checkboxes are disabled while a
+/// browse is active, and selections are applied to the backend daemon.
+#[component]
+pub fn NetworkInterfaces(#[prop(optional, into)] disabled: Signal<bool>) -> impl IntoView {
+    let store = Store::new(InterfacesState::default());
+    let last_backend_selection: StoredValue<Vec<String>> = StoredValue::new(Vec::new());
+    LocalResource::new(move || listen_to_interfaces_events(store, last_backend_selection));
+
+    let set_interfaces_action = Action::new_local(|enabled: &Vec<String>| {
+        let enabled = enabled.clone();
+        async move { set_interfaces(enabled).await }
+    });
+
+    Effect::watch(
+        move || {
+            store
+                .interfaces()
+                .iter_unkeyed()
+                .map(|interface| interface.get())
+                .collect::<Vec<_>>()
+        },
+        move |interfaces, _, _| {
+            let enabled: Vec<String> = interfaces
+                .iter()
+                .filter(|interface| interface.enabled)
+                .map(|interface| interface.name.clone())
+                .collect();
+            if enabled != last_backend_selection.get_value() {
+                set_interfaces_action.dispatch(enabled);
+            }
+        },
+        false,
+    );
+
+    let is_desktop = IsDesktopInjection::expect_context();
+    let layout_class = get_class(&is_desktop, "interfaces-layout");
+
+    view! {
+        <Layout class=layout_class>
+            <Accordion multiple=true>
+                <AccordionItem value="network-interfaces">
+                    <AccordionHeader slot>"Network interfaces"</AccordionHeader>
+                    <Flex gap=FlexGap::Small align=FlexAlign::Center justify=FlexJustify::Start>
+                        <For
+                            each=move || store.interfaces()
+                            key=move |interface| interface.get().name
+                            let:interface
+                        >
+                            <NetworkInterfaceItem interface disabled />
+                        </For>
+                    </Flex>
+                </AccordionItem>
+            </Accordion>
+        </Layout>
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -72,6 +72,9 @@ body {
 .mobile-metrics-layout {
     border: 0;
 }
+.mobile-interfaces-layout {
+    border: 0;
+}
 .mobile-browse-layout {
     padding-top: 0px;
 }
@@ -108,6 +111,9 @@ body {
     padding-top: 10px;
 }
 .desktop-metrics-layout {
+    border: 0;
+}
+.desktop-interfaces-layout {
     border: 0;
 }
 .desktop-resolved-service-card {


### PR DESCRIPTION
Closes #2401

## Summary
Adds an own accordion below Metrics listing all mDNS-capable network interfaces. Each interface row shows its name and IP addresses, with a checkbox to enable/disable it for browsing. The checkboxes are disabled while a browse is active.

## Backend
- New `NetworkInterface` and `InterfacesChangedEvent` models; `INTERFACES_LIST_CHECK_INTERVAL` constant
- `enumerate_mdns_capable_interfaces()` on desktop/mobile (pnet-based on non-Windows, ipconfig-based on Windows)
- Consolidated interface selection into `apply_interface_selections()`: disable all → re-enable IPv4/IPv6 families per protocol flags → disable unselected NICs → re-disable mDNS-incapable interfaces (last wins, mirroring `mdns-tui-browser`'s `configure_interfaces`)
- `set_interfaces(enabled)` stores the disabled set and re-applies selections; no-ops when nothing changed
- `set_protocol_flags` now re-applies full interface selections so it no longer clobbers per-NIC choices
- `subscribe_interfaces` + `poll_interfaces` emit `interfaces-changed` on a 1s interval (mirrors `subscribe_can_browse`); re-subscribes emit the current state
- Commands registered in both desktop and mobile invoke handlers

## Frontend
- New `NetworkInterfaces` accordion component (between Metrics and Browse), checkboxes per interface disabled while `browsing` is active
- `BrowsingInjection` context shares the browsing signal between Browse and the new component
- Echo-loop avoidance: the component tracks the last backend snapshot and only dispatches `set_interfaces` on real user changes

## Testing
- Unit tests for `set_interface_enabled_flags` and loopback exclusion from both capable and incapable lists (desktop + Windows variants)
- `cargo fmt`, `leptosfmt --check src`, `cargo clippy --workspace --tests -- -D warnings`, `cargo clippy --release --workspace --tests -- -D warnings`, `cargo nextest run --profile ci --workspace` (40 passed), `cargo --locked tauri build --no-bundle --no-sign` all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a network interface selector for mDNS browsing, allowing you to enable/disable interfaces from the app.
  * Interface capabilities and selections are now applied in a unified way, and the interface list updates automatically as changes are detected.

* **Bug Fixes**
  * Improved mDNS capability detection to exclude loopback and unsupported adapters from browsing options.
  * Browsing now automatically turns off when no enabled interfaces are available.

* **Style**
  * Refreshed mobile and desktop interface layout styling for a cleaner look.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->