### PR TITLE
chore: add github-cli to AUR builder Dockerfile

### DIFF
--- a/.github/docker/mdns-browser-arch-aur-builder/Dockerfile
+++ b/.github/docker/mdns-browser-arch-aur-builder/Dockerfile
@@ -12,6 +12,7 @@ RUN pacman -Syu --noconfirm \
     gdk-pixbuf2 \
     git \
     glib2 \
+    github-cli \
     gtk3 \
     jq \
     libappindicator-gtk3 \


### PR DESCRIPTION
Adds github-cli package to the AUR builder container so that `gh` CLI is available for GitHub API checksum retrieval in release workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Arch Linux builder environment to include GitHub CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->