### PR TITLE
fix: restore desktop download-and-install update label

### DIFF
--- a/src/app/about.rs
+++ b/src/app/about.rs
@@ -224,7 +224,13 @@ pub fn About() -> impl IntoView {
                                         on_click=on_install_update_click
                                         icon=icondata::MdiInboxArrowDown
                                     >
-                                        "Open release page "
+                                        {move || {
+                                            if is_desktop.get() {
+                                                "Download and Install "
+                                            } else {
+                                                "Open release page "
+                                            }
+                                        }}
                                         {{ installable_version }}
                                     </Button>
                                 </Show>


### PR DESCRIPTION
Closes #2409 

## Summary

The mobile update refactor (#2359) changed the update button label to "Open release page <version>" unconditionally. On desktop, however, the button still downloads and installs the update via tauri-plugin-updater.

This change makes the label platform-dependent using the existing `is_desktop` signal:

- Desktop: "Download and Install <version>"
- Mobile: "Open release page <version>"

## Testing

- `cargo fmt -- --check` ✅
- `leptosfmt --check src` ✅
- `cargo clippy --workspace --tests -- -D warnings` ✅
- `cargo clippy --release --workspace --tests -- -D warnings` ✅
- `cargo nextest run --profile ci --workspace` ✅ (45 passed)
- `actionlint .github/workflows/*.yml` ✅
- `cargo --locked tauri build --no-bundle --no-sign` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the update button label based on platform:
    * Desktop: “Download and Install”
    * Non-desktop: “Open release page”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->