### PR TITLE
fix(homebrew): strip sha256: prefix from checksum

### DIFF
--- a/.github/workflows/homebrew-reusable.yml
+++ b/.github/workflows/homebrew-reusable.yml
@@ -50,6 +50,7 @@ jobs:
             echo "Error: No checksum found for universal.dmg in release $TAG"
             exit 1
           fi
+          CHECKSUM="${CHECKSUM#sha256:}"
           echo "DMG_CHECKSUM=$CHECKSUM" >> "$GITHUB_ENV"
 
       - name: 🔑 Configure Git Identity

--- a/.github/workflows/homebrew-reusable.yml
+++ b/.github/workflows/homebrew-reusable.yml
@@ -50,6 +50,7 @@ jobs:
             echo "Error: No checksum found for universal.dmg in release $TAG"
             exit 1
           fi
+          # strip prefix sha256:
           CHECKSUM="${CHECKSUM#sha256:}"
           echo "DMG_CHECKSUM=$CHECKSUM" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Closes #2414 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release checksum handling so downloaded macOS packages can be verified correctly during Homebrew installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->