### PR TITLE
feat(ci): auto-approve workflow runs of github-actions[bot] PRs

### DIFF
--- a/.github/workflows/approve-bot-pr-workflows.yml
+++ b/.github/workflows/approve-bot-pr-workflows.yml
@@ -40,9 +40,16 @@ jobs:
               if (!prNumber) continue;
               const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
               if (pr.state !== 'open') continue;
-              const { data: files } = await github.rest.pulls.listFiles({ owner, repo, pull_number: prNumber });
-              if (files.some((f) => f.filename.startsWith('.github/workflows/'))) {
-                core.warning(`Skipping run ${run.id}: PR #${prNumber} modifies workflow files`);
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner, repo, pull_number: prNumber, per_page: 100,
+              });
+              if (
+                files.length === 3000 ||
+                files.some((f) => f.filename.startsWith('.github/workflows/'))
+              ) {
+                core.warning(`Skipping run ${run.id}: PR #${prNumber} has unverified or modified workflow files`);
+                continue;
+              }
                 continue;
               }
               try {

--- a/.github/workflows/approve-bot-pr-workflows.yml
+++ b/.github/workflows/approve-bot-pr-workflows.yml
@@ -8,7 +8,7 @@ on:
     workflows: ["CI"]
     types: [requested]
   schedule:
-    - cron: "*/10 * * * *"
+    - cron: "0 */4 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/approve-bot-pr-workflows.yml
+++ b/.github/workflows/approve-bot-pr-workflows.yml
@@ -1,0 +1,54 @@
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT-0
+
+name: "✅ Approve Bot PR Workflows"
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [requested]
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write # needed to approve workflow runs
+
+concurrency:
+  group: approve-bot-pr-workflows
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    runs-on: ubuntu-slim
+    steps:
+      - name: ✅ Approve workflow runs on github-actions[bot] PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner, repo,
+              event: 'pull_request',
+              status: 'action_required',
+              per_page: 100,
+            });
+            for (const run of data.workflow_runs) {
+              if (run.triggering_actor?.login !== 'github-actions[bot]') continue;
+              const prNumber = run.pull_requests?.[0]?.number;
+              if (!prNumber) continue;
+              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+              if (pr.state !== 'open') continue;
+              const { data: files } = await github.rest.pulls.listFiles({ owner, repo, pull_number: prNumber });
+              if (files.some((f) => f.filename.startsWith('.github/workflows/'))) {
+                core.warning(`Skipping run ${run.id}: PR #${prNumber} modifies workflow files`);
+                continue;
+              }
+              try {
+                await github.rest.actions.approveWorkflowRun({ owner, repo, run_id: run.id });
+                core.info(`Approved run ${run.id} for PR #${prNumber}`);
+              } catch (err) {
+                core.warning(`Failed to approve run ${run.id}: ${err.message}`);
+              }
+            }


### PR DESCRIPTION
## Summary
Adds a workflow that automatically approves `action_required` (`awaiting approval`) workflow runs for PRs authored by `github-actions[bot]`.

Context: since GitHub's 2026-06-11 change, PRs created by `github-actions[bot]` (e.g. the nightly changelog PR from `update-changelog.yml`) have their `pull_request` CI runs placed in approval-required state. Without a human clicking "Approve workflows to run", `gh pr merge --auto` can never proceed.

## Changes
- New `.github/workflows/approve-bot-pr-workflows.yml`:
  - Triggers: `workflow_run` on `CI` (`requested`), a 10-minute `schedule` sweep, and `workflow_dispatch`.
  - Lists `event=pull_request&status=action_required` runs and approves those where:
    - `triggering_actor` is `github-actions[bot]`
    - the PR is open
    - the PR does **not** modify `.github/workflows/` (safety guard)
  - Uses `GITHUB_TOKEN` with `actions: write`; approval failures log a warning rather than failing the run.

## Verification
- `actionlint .github/workflows/*.yml` passes.

## Notes / follow-up
- If GitHub blocks self-approval (`github-actions[bot]` approving its own runs), the `github-token` will need to switch to a dedicated PAT secret (`GH_ACTIONS_APPROVE_TOKEN`) with `actions: write`. This is expected to be validated manually via `workflow_dispatch` after merge.
- `workflow_run`/`schedule` only fire from the default branch, so this takes effect once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated handling for eligible pull request checks initiated by project automation.
  * Scheduled and on-demand processing helps workflow-safe changes continue through validation.
  * Added safeguards to skip ineligible changes and record approval outcomes for improved visibility.
  * Processing now verifies relevant change status before taking action, reducing unnecessary interruptions to ongoing checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->