### PR TITLE
fix(ci): remove stray lines causing github-script syntax error

### DIFF
--- a/.github/workflows/approve-bot-pr-workflows.yml
+++ b/.github/workflows/approve-bot-pr-workflows.yml
@@ -50,8 +50,6 @@ jobs:
                 core.warning(`Skipping run ${run.id}: PR #${prNumber} has unverified or modified workflow files`);
                 continue;
               }
-                continue;
-              }
               try {
                 await github.rest.actions.approveWorkflowRun({ owner, repo, run_id: run.id });
                 core.info(`Approved run ${run.id} for PR #${prNumber}`);


### PR DESCRIPTION
## Summary
The `approve-bot-pr-workflows` workflow fails with `SyntaxError: Unexpected token '}'` when the `github-script` step runs.

Root cause: the coderabbitai[bot] suggestion merged in #2417 (commit `bf1d049`) applied the `github.paginate` change but left two stray lines (`continue;` and `}`) behind, breaking the JavaScript.

## Changes
- Removed the duplicate `continue;` and `}` in `.github/workflows/approve-bot-pr-workflows.yml`.

## Verification
- The `script:` body parses cleanly via `new AsyncFunction(...)` (same mechanism github-script uses).
- `actionlint .github/workflows/approve-bot-pr-workflows.yml` passes.