### PR TITLE
chore: don't duplicate license file in bundling

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,6 @@
             "deb": {
                 "changelog": "../CHANGELOG.md",
                 "files": {
-                    "/usr/share/doc/mdns-browser/copyright": "../LICENSE",
                     "/usr/share/man/man1/mdns-browser.1": "../docs/mdns-browser.1"
                 }
             },
@@ -39,7 +38,6 @@
                     "level": 6
                 },
                 "files": {
-                    "/usr/share/licenses/mdns-browser/LICENSE": "../LICENSE",
                     "/usr/share/doc/mdns-browser/changelog": "../CHANGELOG.md",
                     "/usr/share/man/man1/mdns-browser.1": "../docs/mdns-browser.1"
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated desktop packaging configuration by removing automatic license-file mappings for Debian and RPM bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->