### PR TITLE
fix(ci): generate release notes using GitHub username (@hrzlgnm)

### DIFF
--- a/.github/cliff-release.toml
+++ b/.github/cliff-release.toml
@@ -24,7 +24,7 @@ body = """
     {% else -%}### Other Changes\n
     {% endif -%}\
     {% for commit in commits -%}\
-        - {{ commit.message | upper_first | trim }} @{{ commit.author.name }}{% for link in commit.links %} ([{{ link.text }}]({{ link.href }})){% endfor %}\n
+        - {{ commit.message | upper_first | trim }} @{{ commit.remote.username | default(value=commit.author.name) }}{% for link in commit.links %} ([{{ link.text }}]({{ link.href }})){% endfor %}\n
     {% endfor -%}\
 {% endfor -%}\
 {% if previous and previous.version -%}\n### Full Changelog\n[{{ previous.version }}...{{ version }}](https://github.com/hrzlgnm/mdns-browser/compare/{{ previous.version }}...{{ version }})\n

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: 🗒️ Generate release notes with git-cliff
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
           git-cliff --config .github/cliff-release.toml --current --output release-body.md


### PR DESCRIPTION
The git-cliff release-notes template previously rendered `@{{ commit.author.name }}`, which resolves to the git display name `Valentin Batz` rather than the GitHub username `hrzlgnm`.

This switches the template to `@{{ commit.remote.username | default(value=commit.author.name) }}`, which uses each commit's GitHub login (fetching GitHub metadata requires the GH remote, which git-cliff auto-detects on GitHub-hosted runners). The release workflow now exports `GITHUB_TOKEN` to the `git-cliff` step so the remote author usernames are fetched.

Verified locally: `@Valentin Batz` → `@hrzlgnm` with `@renovate[bot]` and `@github-actions[bot]` preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Notes**
  * Release notes now display contributors’ usernames when available, with their author name shown as a fallback.
  * Automated release-note generation now has the required access to retrieve contributor information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->