### PR TITLE
feat(cliff): move CI-related commits into dedicated Maintenance group

### DIFF
--- a/.github/cliff-release.toml
+++ b/.github/cliff-release.toml
@@ -16,6 +16,7 @@ body = """
     {% elif group == "Added" -%}### :sparkles: New Features\n
     {% elif group == "Fixed" -%}### :bug: Bug Fixes\n
     {% elif group == "Changed" -%}### 🧰 Maintenance\n
+    {% elif group == "Maintenance" -%}### :wrench: CI/CD\n
     {% elif group == "Performance" -%}### :zap: Performance\n
     {% elif group == "Refactor" -%}### :recycle: Refactor\n
     {% elif group == "Documentation" -%}### :scroll: Documentation\n
@@ -74,17 +75,17 @@ commit_parsers = [
     { message = "^refactor!", group = "Breaking" },
     { message = "^perf!", group = "Breaking" },
     { message = "^chore!", group = "Breaking" },
+    { message = "^\\w+\\(ci\\)", group = "Maintenance" },
     { message = "^feat", group = "Added" },
     { message = "^fix\\(deps\\)", group = "Dependencies" },
-    { message = "^fix\\(ci\\)", skip = true },
     { message = "^fix", group = "Fixed" },
     { message = "^doc", group = "Documentation" },
     { message = "^perf", group = "Performance" },
     { message = "^refactor", group = "Refactor" },
     { message = "^style", group = "Refactor" },
     { message = "^test", group = "Test" },
-    { message = "^ci", group = "Other" },
-    { message = "^build", group = "Other" },
+    { message = "^ci", group = "Maintenance" },
+    { message = "^build", group = "Maintenance" },
     { message = "^chore\\(deps\\)", group = "Dependencies" },
     { message = "^chore\\(renovate", skip = true },
     { message = "^chore\\(arch-aur", skip = true },

--- a/cliff-webkit2gtk.toml
+++ b/cliff-webkit2gtk.toml
@@ -24,6 +24,8 @@ body = """
         ### Dependencies\n
     {% elif group == "Security" -%}\
         ### Security\n
+    {% elif group == "Maintenance" -%}\
+        ### Maintenance\n
     {% elif group == "Miscellaneous" -%}\
         ### Miscellaneous\n
     {% endif -%}\
@@ -71,17 +73,17 @@ filter_unconventional = true
 split_commits = false
 # regex for parsing and grouping commits
 commit_parsers = [
+    { message = "^\\w+\\(ci\\)", group = "Maintenance" },
     { message = "^feat", group = "Added" },
     { message = "^fix\\(deps\\)", group = "Dependencies" },
-    { message = "^fix\\(ci\\)", skip = true },
     { message = "^fix", group = "Fixed" },
     { message = "^doc", group = "Changed" },
     { message = "^perf", group = "Changed" },
     { message = "^refactor", group = "Changed" },
     { message = "^style", group = "Changed" },
     { message = "^test", group = "Changed" },
-    { message = "^ci", group = "Miscellaneous" },
-    { message = "^build", group = "Miscellaneous" },
+    { message = "^ci", group = "Maintenance" },
+    { message = "^build", group = "Maintenance" },
     { message = "^chore\\(deps\\)", group = "Dependencies" },
     { message = "^chore\\(renovate", skip = true },
     { message = "^chore\\(arch-aur", skip = true },

--- a/cliff.toml
+++ b/cliff.toml
@@ -24,6 +24,8 @@ body = """
         ### Dependencies\n
     {% elif group == "Security" -%}\
         ### Security\n
+    {% elif group == "Maintenance" -%}\
+        ### Maintenance\n
     {% elif group == "Miscellaneous" -%}\
         ### Miscellaneous\n
     {% endif -%}\
@@ -71,17 +73,17 @@ filter_unconventional = true
 split_commits = false
 # regex for parsing and grouping commits
 commit_parsers = [
+    { message = "^\\w+\\(ci\\)", group = "Maintenance" },
     { message = "^feat", group = "Added" },
     { message = "^fix\\(deps\\)", group = "Dependencies" },
-    { message = "^fix\\(ci\\)", skip = true },
     { message = "^fix", group = "Fixed" },
     { message = "^doc", group = "Changed" },
     { message = "^perf", group = "Changed" },
     { message = "^refactor", group = "Changed" },
     { message = "^style", group = "Changed" },
     { message = "^test", group = "Changed" },
-    { message = "^ci", group = "Miscellaneous" },
-    { message = "^build", group = "Miscellaneous" },
+    { message = "^ci", group = "Maintenance" },
+    { message = "^build", group = "Maintenance" },
     { message = "^chore\\(deps\\)", group = "Dependencies" },
     { message = "^chore\\(renovate", skip = true },
     { message = "^chore\\(arch-aur", skip = true },


### PR DESCRIPTION
Previously, `fix(ci)` commits were skipped entirely in the changelog, and `ci`/`build` type commits were grouped under Miscellaneous/Other.

This change adds a new **Maintenance** group that surfaces all CI-related commits:
- `ci` type (e.g., `ci: update action versions`)
- `build` type (e.g., `build: update build system`)
- Any commit with `(ci)` scope (e.g., `fix(ci)`, `chore(ci)`, `feat(ci)`, `refactor(ci)`)

Applied to all three git-cliff configurations:
- `cliff.toml` — main changelog
- `cliff-webkit2gtk.toml` — webkit2gtk-nvidia-quirk changelog
- `.github/cliff-release.toml` — GitHub release notes (labeled `CI/CD` to distinguish from the existing `🧰 Maintenance` section for Changed commits)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a dedicated **Maintenance** section to generated changelogs.
  * CI, build, and related maintenance commits are now grouped consistently under this section.
  * Previously omitted CI fixes are now included in changelog output.
  * CI and build entries no longer appear under miscellaneous or other categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->