### PR TITLE
fix(ci): resolve GitHub username from noreply email in release notes

### DIFF
--- a/.github/cliff-release.toml
+++ b/.github/cliff-release.toml
@@ -25,7 +25,7 @@ body = """
     {% else -%}### Other Changes\n
     {% endif -%}\
     {% for commit in commits -%}\
-        - {{ commit.message | upper_first | trim }} @{{ commit.remote.username | default(value=commit.author.name) }}{% for link in commit.links %} ([{{ link.text }}]({{ link.href }})){% endfor %}\n
+        - {{ commit.message | upper_first | trim }} @{{ commit.remote.username | default(value=commit.author.email | split(pat="@") | first | split(pat="+") | last) }}{% for link in commit.links %} ([{{ link.text }}]({{ link.href }})){% endfor %}\n
     {% endfor -%}\
 {% endfor -%}\
 {% if previous and previous.version -%}\n### Full Changelog\n[{{ previous.version }}...{{ version }}](https://github.com/hrzlgnm/mdns-browser/compare/{{ previous.version }}...{{ version }})\n

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          git-cliff --config .github/cliff-release.toml --current --output release-body.md
+          git-cliff --offline --config .github/cliff-release.toml --current --output release-body.md
 
       - name: 🚀 Create draft release
         env:


### PR DESCRIPTION
The previous fix (commit 30afce6) changed the template to use `commit.remote.username` with a fallback to `commit.author.name`. However, `remote.username` is not resolving in CI (likely due to git-cliff panicking on GitHub API 403 errors), so the fallback shows the raw author name "Valentin Batz" instead of the GitHub username "hrzlgnm".

This change replaces the fallback with email-based username extraction from the GitHub noreply email format (`hrzlgnm@users.noreply.github.com` → `hrzlgnm`), and adds `--offline` to the git-cliff command to avoid API panics entirely.