### PR TITLE
fix: strip duplicate (#NNN) PR refs in generated changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -63,6 +63,8 @@ postprocessors = [
     { pattern = 'Workaound', replace = 'Workaround' },
     { pattern = 'bundel', replace = 'bundle' },
     { pattern = 'artifcat', replace = 'artifact' },
+    # remove duplicate (#NNN) PR refs already rendered as links ([#NNN](url))
+    { pattern = '\s*\(#[0-9]+\)', replace = '' },
 ]
 
 [git]


### PR DESCRIPTION
Add postprocessor in cliff.toml to strip bare (#NNN) refs so only linked references ([#NNN](url)) remain. Verified with git cliff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved changelog formatting by removing duplicate pull request references that appear after linked issue references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->