### PR TITLE
fix(release): remove incorrect --tag flag from git-cliff changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,8 @@ jobs:
           locked: true
 
       - name: 📝 Update CHANGELOG.md with the new version
-        env:
-          TAG_NAME: ${{ github.ref_name }}
         run: |
-          git-cliff --tag "${TAG_NAME}" --output CHANGELOG.md
+          git-cliff --output CHANGELOG.md
 
       - name: 📤 Upload versioned changelog artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -52,7 +50,6 @@ jobs:
       - name: 🗒️ Generate release notes with git-cliff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}
         run: |
           git-cliff --offline --config .github/cliff-release.toml --current --output release-body.md
 


### PR DESCRIPTION
The `--tag` flag was designed to assign a new tag to unreleased commits, but in the release workflow the tag already exists (it triggered the workflow). This caused git-cliff to emit a spurious warning about the tag already existing. Without `--tag`, git-cliff automatically detects the latest existing tag and generates the full changelog.

Also removes the now-unused `TAG_NAME` env var from both the CHANGELOG generation and release notes steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to generate the changelog without requiring a release tag.
  * Removed an unused release-related configuration variable from the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->