### PR TITLE
fix(release): escape [bot] brackets and link bot authors in release notes

### DIFF
--- a/.github/cliff-release.toml
+++ b/.github/cliff-release.toml
@@ -39,6 +39,9 @@ footer = ""
 # postprocessors to apply to the changelog
 postprocessors = [
     { pattern = '\s\(#\d+\)\s@', replace = ' @' },
+    # escape [bot] brackets in bot mentions and link to the app profile,
+    # e.g. @renovate[bot] -> @[renovate\[bot\]](https://github.com/apps/renovate)
+    { pattern = '@([A-Za-z0-9._-]+)\[bot\]', replace = '@[$1\[bot\]](https://github.com/apps/$1)' },
     { pattern = 'Simlify', replace = 'Simplify' },
     { pattern = 'hanlding', replace = 'handling' },
     { pattern = 'verision', replace = 'version' },


### PR DESCRIPTION
The git-cliff release-body template in `.github/cliff-release.toml` rendered bot authors as `@renovate[bot]`. GitHub Markdown parses the `[bot]` brackets as a link reference, so the mention was broken (wrong link / orphaned text). The previously-published releases used `@[renovate\[bot\]](https://github.com/apps/renovate)`.

Adds a postprocessor that escapes `[bot]` and wraps bot mentions in the app profile link, matching the prior format. Human mentions (`@hrzlgnm`) and `[bot]` inside commit messages are unaffected.

This fixes the broken bot links in the draft v1.15.0 release body. The existing `v1.15.0` tag already points at HEAD, so re-running `release.yml` for that tag will regenerate the draft with the corrected links.
