### PR TITLE
fix(aur): sync release version into Cargo and tauri config

### DIFF
--- a/.github/docker/mdns-browser-arch-aur-builder/Dockerfile
+++ b/.github/docker/mdns-browser-arch-aur-builder/Dockerfile
@@ -7,6 +7,7 @@ RUN pacman -Syu --noconfirm \
     appmenu-gtk-module \
     cargo \
     cargo-auditable \
+    cargo-edit \
     coreutils \
     desktop-file-utils \
     gdk-pixbuf2 \

--- a/packaging/aur/generate-mdns-browser.sh
+++ b/packaging/aur/generate-mdns-browser.sh
@@ -25,13 +25,19 @@ url="https://github.com/hrzlgnm/mdns-browser"
 license=('MIT')
 depends=('cairo' 'desktop-file-utils' 'gdk-pixbuf2' 'glib2' 'gtk3' 'hicolor-icon-theme' 'libsoup3' 'pango' 'webkit2gtk-4.1' 'openssl')
 conflicts=('mdns-browser-bin')
-makedepends=('cargo' 'cargo-auditable' 'git' 'file' 'appmenu-gtk-module' 'libappindicator-gtk3' 'librsvg' 'base-devel' 'curl' 'wget' 'rust' 'rust-wasm' 'trunk')
+makedepends=('cargo' 'cargo-auditable' 'cargo-edit' 'git' 'file' 'appmenu-gtk-module' 'libappindicator-gtk3' 'librsvg' 'base-devel' 'curl' 'wget' 'rust' 'rust-wasm' 'trunk' 'jq')
 options=('!strip' '!emptydirs')
 source=("$tag.tar.gz::https://github.com/hrzlgnm/\$pkgname/archive/refs/tags/$tag.tar.gz")
 sha256sums=('$sha256sum')
 _builddir="\$pkgname-$tag"
 prepare() {
     cd "\$srcdir/\$_builddir" || exit 1
+    cargo set-version --package mdns-browser-ui "$version"
+    cargo set-version --package mdns-browser "$version"
+    cargo set-version --package models "$version"
+    cargo set-version --package shared_constants "$version"
+    jq --indent 4 ".version=\"$version\"" src-tauri/tauri.conf.json > src-tauri/tauri.conf.json.new
+    mv src-tauri/tauri.conf.json.new src-tauri/tauri.conf.json
     cargo --locked install tauri-cli@2.11.4
     cargo fetch --locked --target "\$(rustc -vV | sed -n 's/host: //p')"
     cargo fetch --locked --target wasm32-unknown-unknown


### PR DESCRIPTION
## Summary

The `mdns-browser` AUR (source) package builds from the tag source tarball, which only contains the `0.1.0` placeholder version in `Cargo.toml`/`tauri.conf.json`. Since release versions are now derived from the git tag at build time via the `sync-version` action (which never commits), the tarball carries a stale version. This caused:

- the built binary to report version `0.1.0` instead of the release version
- `package()` to fail, since the deb bundle is named `mdns-browser_${pkgver}_amd64` but the build produced `mdns-browser_0.1.0_amd64`

## Changes

- `packaging/aur/generate-mdns-browser.sh`: the emitted PKGBUILD's `prepare()` now syncs `pkgver` into the four workspace packages via `cargo set-version` and into `tauri.conf.json` via `jq`, mirroring the Void template (`packaging/void/generate-template.sh`). Added `cargo-edit` and `jq` to `makedepends`.
- `.github/docker/mdns-browser-arch-aur-builder/Dockerfile`: install `cargo-edit` in the builder image (the image digest pin will be refreshed by renovate).

`mdns-browser-bin` needs no change — it installs the prebuilt binary/deb which are already versioned correctly.

## Testing

- Generated PKGBUILD passes `namcap` and `makepkg --printsrcinfo`
- `shellcheck` and `actionlint` pass
- Verified `cargo set-version` keeps `Cargo.lock` consistent, so the `--locked --frozen` build/check remain valid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Arch Linux packaging tools to support current build requirements.
  * Improved package preparation by synchronizing application and package versions.
  * Added automated updates for bundled Cargo package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->