### PR TITLE
refactor(ci): always sbom scan and cache db when run on main

### DIFF
--- a/.github/actions/sbom/action.yml
+++ b/.github/actions/sbom/action.yml
@@ -31,7 +31,7 @@ runs:
       with:
         sbom: "sbom.spdx.json"
         severity-cutoff: medium
-        cache-db: true
+        cache-db: ${{ github.ref == 'refs/heads/main' }}
 
     - name: 🔍 Inspect SARIF report
       if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/android-reusable.yml
+++ b/.github/workflows/android-reusable.yml
@@ -55,7 +55,6 @@ jobs:
           echo "current-version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: 📜 Create and 🔍 scan SBOM for vulnerabilities
-        if: inputs.tagName
         uses: ./.github/actions/sbom
         with:
           artifact-name: "sbom.android.spdx.json"

--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -89,7 +89,6 @@ jobs:
           cp changelog-artifact/CHANGELOG.md CHANGELOG.md
 
       - name: 📜 Create and 🔍 scan SBOM for vulnerabilities
-        if: inputs.tagName
         uses: ./.github/actions/sbom
         with:
           artifact-name: "sbom.${{ matrix.platform }}.spdx.json"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflows to run for both tagged and untagged builds.
  * Restricted vulnerability database caching to scans running on the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->