### PR TITLE
fix(aur): use correct build directory in aur source build

### DIFF
--- a/packaging/aur/generate-mdns-browser.sh
+++ b/packaging/aur/generate-mdns-browser.sh
@@ -29,7 +29,7 @@ makedepends=('cargo' 'cargo-auditable' 'cargo-edit' 'git' 'file' 'appmenu-gtk-mo
 options=('!strip' '!emptydirs')
 source=("$tag.tar.gz::https://github.com/hrzlgnm/\$pkgname/archive/refs/tags/$tag.tar.gz")
 sha256sums=('$sha256sum')
-_builddir="\$pkgname-$tag"
+_builddir="\$pkgname-$version"
 prepare() {
     cd "\$srcdir/\$_builddir" || exit 1
     cargo set-version --package mdns-browser-ui "$version"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AUR package builds to use the project version when determining the build directory, improving build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->