### PR TITLE
docs: add FlatPak install method via FlatPark and version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![GitHub Release Date](https://img.shields.io/github/release-date/hrzlgnm/mdns-browser)](https://github.com/hrzlgnm/mdns-browser/releases/latest)
 [![WinGet Package Version](https://img.shields.io/winget/v/hrzlgnm.mdns-browser)](https://winstall.app/apps/hrzlgnm.mdns-browser)
 [![AUR Version](https://img.shields.io/aur/version/mdns-browser-bin)](https://aur.archlinux.org/packages/mdns-browser-bin)
+[![FlatPark Version](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Fflatpark%2Fflatpark%2Fmain%2Fregistry%2Fio.github.hrzlgnm.mdns-browser%2Fio.github.hrzlgnm.mdns-browser.yml&search=download%2Fv%3F%28%3F%3Cversion%3E%5B0-9.%5D%2B%29%2F&replace=%24%3Cversion%3E&label=FlatPark&color=blue)](https://flatpark.org/apps/io.github.hrzlgnm.mdns-browser)
 [![License: MIT](https://img.shields.io/github/license/hrzlgnm/mdns-browser)](https://github.com/hrzlgnm/mdns-browser/blob/main/LICENSE)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/hrzlgnm/mdns-browser/ci.yml)](https://github.com/hrzlgnm/mdns-browser/actions)
 
@@ -48,6 +49,7 @@ Screenshots from [v0.11.28](https://github.com/hrzlgnm/mdns-browser/releases/tag
         - [Arch Linux (AUR)](#arch-linux-aur)
         - [Void Linux](#void-linux)
         - [Homebrew (macOS)](#homebrew-macos)
+        - [Flatpak (FlatPark)](#flatpak-flatpark)
     - [Auditable binaries](#auditable-binaries)
     - [Attested build artifacts](#attested-build-artifacts)
     - [Privacy](#privacy)
@@ -181,6 +183,17 @@ Or add the tap first:
 brew tap hrzlgnm/tap
 brew install --cask mdns-browser
 ```
+
+### Flatpak (FlatPark)
+
+To install on Linux via Flatpak, use the community-maintained [FlatPark](https://flatpark.org/) repository:
+
+```console
+flatpak remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo
+flatpak install flatpark io.github.hrzlgnm.mdns-browser
+```
+
+The package page is available at <https://flatpark.org/apps/io.github.hrzlgnm.mdns-browser>.
 
 ## Auditable binaries
 


### PR DESCRIPTION
Add the FlatPark Flatpak installation as an officially documented install method, as discussed in #2447.

Changes:
- Add a `### Flatpak (FlatPark)` section under "Where to find the executables?" with the `flatpak remote-add`/`flatpak install` commands and a link to the FlatPark app page.
- Add a FlatPark version badge to the badge block (dynamic regex badge reading the version pinned in the flatpark registry manifest).
- Update the README table of contents.

Testing:
- Badge verified to render the current FlatPark version (1.15.1).
- README-only change; no code/lint checks apply.

Closes #2447