### PR TITLE
refactor: remove can_browse and network banner

### DIFF
--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -230,11 +230,6 @@ pub struct ThemeChangedEvent {
     pub theme: String,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct CanBrowseChangedEvent {
-    pub can_browse: bool,
-}
-
 #[derive(Deserialize, Serialize, Clone, Eq, PartialEq, Debug, Store)]
 pub struct ProtocolFlags {
     pub ipv4: bool,

--- a/crates/shared_constants/src/lib.rs
+++ b/crates/shared_constants/src/lib.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 pub const MDNS_SD_META_SERVICE: &str = "_services._dns-sd._udp.local.";
 pub const MDNS_SD_IP_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 pub const METRICS_CHECK_INTERVAL: Duration = Duration::from_secs(1);
-pub const INTERFACES_CAN_BROWSE_CHECK_INTERVAL: Duration = Duration::from_millis(500);
 pub const INTERFACES_LIST_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
 pub const AUTO_COMPLETE_AUTO_FOCUS_DELAY: Duration = Duration::from_secs(5);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,8 +13,8 @@ use models::*;
 #[cfg(not(windows))]
 use pnet::datalink;
 use shared_constants::{
-    INTERFACES_CAN_BROWSE_CHECK_INTERVAL, INTERFACES_LIST_CHECK_INTERVAL,
-    MDNS_SD_IP_CHECK_INTERVAL, MDNS_SD_META_SERVICE, METRICS_CHECK_INTERVAL, VERIFY_TIMEOUT,
+    INTERFACES_LIST_CHECK_INTERVAL, MDNS_SD_IP_CHECK_INTERVAL, MDNS_SD_META_SERVICE,
+    METRICS_CHECK_INTERVAL, VERIFY_TIMEOUT,
 };
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
@@ -64,7 +64,6 @@ struct ManagedState {
     daemon: SharedServiceDaemon,
     queriers: Arc<Mutex<HashSet<String>>>,
     metrics_subscribed: AtomicBool,
-    can_browse_subscribed: AtomicBool,
     interfaces_subscribed: AtomicBool,
     ipv4_enabled: AtomicBool,
     ipv6_enabled: AtomicBool,
@@ -80,7 +79,6 @@ impl ManagedState {
             daemon: initialize_shared_daemon(),
             queriers: Arc::new(Mutex::new(HashSet::new())),
             metrics_subscribed: AtomicBool::new(false),
-            can_browse_subscribed: AtomicBool::new(false),
             interfaces_subscribed: AtomicBool::new(false),
             ipv4_enabled: AtomicBool::new(true),
             ipv6_enabled: AtomicBool::new(true),
@@ -95,7 +93,6 @@ impl ManagedState {
             daemon: initialize_shared_daemon(),
             queriers: Arc::new(Mutex::new(HashSet::new())),
             metrics_subscribed: AtomicBool::new(false),
-            can_browse_subscribed: AtomicBool::new(false),
             interfaces_subscribed: AtomicBool::new(false),
             ipv4_enabled: AtomicBool::new(true),
             ipv6_enabled: AtomicBool::new(true),
@@ -692,76 +689,6 @@ mod tests {
     }
 }
 
-#[cfg(not(windows))]
-fn has_mdns_capable_interfaces() -> bool {
-    datalink::interfaces().iter().any(|interface| {
-        is_mdns_capable_pnet(interface) || (interface.is_loopback() && !interface.ips.is_empty())
-    })
-}
-
-#[cfg(windows)]
-fn has_mdns_capable_interfaces() -> bool {
-    if let Ok(adapters) = ipconfig::get_adapters() {
-        adapters.iter().any(|adapter| {
-            is_mdns_capable_ipconfig(adapter)
-                || (adapter.if_type() == ipconfig::IfType::SoftwareLoopback
-                    && !adapter.ip_addresses().is_empty())
-        })
-    } else {
-        log::warn!("Unable to determine whether we have mDNS capable network adapters, assuming no network is present");
-        false
-    }
-}
-
-async fn poll_can_browse(window: Window) {
-    let mut current = has_mdns_capable_interfaces();
-    emit_event(
-        &window,
-        "can-browse-changed",
-        &CanBrowseChangedEvent {
-            can_browse: current,
-        },
-    );
-    loop {
-        tokio::time::sleep(INTERFACES_CAN_BROWSE_CHECK_INTERVAL).await;
-        let new_value = has_mdns_capable_interfaces();
-        if new_value != current {
-            current = new_value;
-            emit_event(
-                &window,
-                "can-browse-changed",
-                &CanBrowseChangedEvent {
-                    can_browse: current,
-                },
-            );
-        }
-    }
-}
-
-/// Subscribes to updates of the mDNS browsing capability.
-///
-/// Starts a background task that polls whether mDNS-capable interfaces are available at regular
-/// intervals, or emits the current state immediately if a subscription is already active. Emits
-/// `"can-browse-changed"` events to the Tauri window.
-#[tauri::command]
-fn subscribe_can_browse(window: Window, state: State<ManagedState>) {
-    if state
-        .can_browse_subscribed
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_ok()
-    {
-        tauri::async_runtime::spawn(poll_can_browse(window));
-    } else {
-        emit_event(
-            &window,
-            "can-browse-changed",
-            &CanBrowseChangedEvent {
-                can_browse: has_mdns_capable_interfaces(),
-            },
-        );
-    }
-}
-
 async fn poll_interfaces(window: Window, disabled_interfaces: Arc<Mutex<HashSet<String>>>) {
     let mut current: Vec<NetworkInterface> = Vec::new();
     loop {
@@ -1330,7 +1257,6 @@ pub fn run() {
             open_url,
             set_interfaces,
             set_protocol_flags,
-            subscribe_can_browse,
             subscribe_interfaces,
             subscribe_metrics,
             stop_browse,
@@ -1374,7 +1300,6 @@ pub fn run_mobile() {
             open_url,
             set_interfaces,
             set_protocol_flags,
-            subscribe_can_browse,
             subscribe_interfaces,
             subscribe_metrics,
             stop_browse,

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -15,8 +15,8 @@ use thaw::{
     AutoComplete, AutoCompleteOption, AutoCompleteRef, AutoCompleteSize, Badge, BadgeAppearance,
     BadgeColor, BadgeSize, Button, ButtonAppearance, ButtonSize, Card, CardHeader, CardPreview,
     ComponentRef, Dialog, DialogBody, DialogSurface, Flex, FlexAlign, FlexGap, FlexJustify, Grid,
-    GridItem, Icon, Input, Layout, MessageBar, MessageBarBody, MessageBarIntent, MessageBarTitle,
-    Scrollbar, Select, Table, TableBody, TableCell, TableRow, Text, TextTag,
+    GridItem, Icon, Input, Layout, Scrollbar, Select, Table, TableBody, TableCell, TableRow, Text,
+    TextTag,
 };
 
 use super::{
@@ -26,7 +26,7 @@ use super::{
     css::get_class,
     invoke::invoke_no_args,
     is_desktop::IsDesktopInjection,
-    listen::{listen_add_remove, listen_events, listen_to_named_event},
+    listen::{listen_add_remove, listen_events},
     network_interfaces::HasEnabledInterfacesInjection,
     protocol_flags::ProtocolFlags,
     values_table::ValuesTable,
@@ -77,17 +77,6 @@ async fn listen_to_service_type_events(writer: WriteSignal<ServiceTypes>) {
             });
         },
     )
-    .await;
-}
-
-/// Subscribes to "can_browse" events and updates the browsing capability signal accordingly.
-///
-/// Updates the provided signal whenever a "can_browse" event is received,
-/// reflecting whether browsing is currently allowed.
-async fn listen_to_can_browse_events(writer: WriteSignal<bool>) {
-    listen_to_named_event("can_browse", move |event: CanBrowseChangedEvent| {
-        writer.update(|evt| *evt = event.can_browse);
-    })
     .await;
 }
 
@@ -851,11 +840,9 @@ pub fn Browse() -> impl IntoView {
     // Stop any previously started browsing, to ensure we not browsing after a frontend reload
     spawn_local(stop_browse());
 
-    let (can_browse, set_can_browse) = signal(false);
     let (service_types, set_service_types) = signal(ServiceTypes::new());
     provide_context(ServiceTypesInjection(service_types));
     LocalResource::new(move || listen_to_service_type_events(set_service_types));
-    LocalResource::new(move || listen_to_can_browse_events(set_can_browse));
     let store = Store::new(Resolved::default());
     let filtered = Store::new(Filtered::default());
 
@@ -902,14 +889,10 @@ pub fn Browse() -> impl IntoView {
             && check_service_type_fully_qualified(service_type.get().clone().as_str()).is_err()
     });
 
-    let browsing_or_cannot_browse = Signal::derive(move || browsing.get() || !can_browse.get());
-
     let has_enabled_interfaces = HasEnabledInterfacesInjection::expect_context();
+    let service_type_input_disabled = Signal::derive(move || browsing.get());
     let browse_disabled = Signal::derive(move || {
-        !can_browse.get()
-            || browsing.get()
-            || service_type_invalid.get()
-            || !has_enabled_interfaces.get()
+        browsing.get() || service_type_invalid.get() || !has_enabled_interfaces.get()
     });
 
     let browse_all_action = Action::new_local(|input: &ServiceTypes| {
@@ -998,30 +981,6 @@ pub fn Browse() -> impl IntoView {
         );
     };
 
-    Effect::watch(
-        move || can_browse.get(),
-        move |can_browse, previous_can_browse, _| {
-            if *can_browse && !previous_can_browse.unwrap_or(&false) {
-                service_type.set(String::new());
-                spawn_local(browse_types());
-                start_auto_focus_timer(
-                    move || comp_ref.get_untracked(),
-                    move |h| {
-                        tutorial_timeout.set_value(h);
-                    },
-                    AUTO_COMPLETE_AUTO_FOCUS_DELAY,
-                );
-            } else {
-                clear_tutorial_timer();
-                set_service_types.set(Vec::new());
-                browsing.set(false);
-                stop_browsing_action.dispatch(());
-                service_type.set(String::new());
-            }
-        },
-        false,
-    );
-
     LocalResource::new(move || listen_for_resolve_events(store));
     let is_desktop = IsDesktopInjection::expect_context();
     let layout_class = get_class(&is_desktop, "browse-layout");
@@ -1031,31 +990,12 @@ pub fn Browse() -> impl IntoView {
         <Layout class=layout_class>
             <BackTop threshold=100 />
             <Flex vertical=true gap=FlexGap::Small>
-                <Show
-                    when=move || { !can_browse.get() }
-                    fallback=move || {
-                        view! { <div class="hidden" /> }
-                    }
-                >
-                    <MessageBar intent=MessageBarIntent::Warning>
-                        <MessageBarBody>
-                            <MessageBarTitle>"No network detected"</MessageBarTitle>
-                            {move || {
-                                if is_desktop.get() {
-                                    "Please connect to WiFi or plug in a network cable."
-                                } else {
-                                    "Please connect to WiFi."
-                                }
-                            }}
-                        </MessageBarBody>
-                    </MessageBar>
-                </Show>
                 <ProtocolFlags disabled=browsing />
                 <Flex gap=FlexGap::Small align=FlexAlign::Center justify=FlexJustify::Start>
                     <AutoCompleteServiceType
                         invalid=service_type_invalid
                         value=service_type
-                        disabled=browsing_or_cannot_browse
+                        disabled=service_type_input_disabled
                         comp_ref=comp_ref
                     />
                     <Button


### PR DESCRIPTION
Removes the now-superfluous can_browse concept from the backend and frontend.

Since the loopback interface is always present and selected by default, there is no longer a need to poll for mDNS-capable interfaces or disable browsing when none are detected. The disabled Browse button when no interface is selected provides enough feedback.

### Changes
- Removed CanBrowseChangedEvent from shared models
- Removed INTERFACES_CAN_BROWSE_CHECK_INTERVAL from shared constants
- Removed has_mdns_capable_interfaces, poll_can_browse, subscribe_can_browse, and related state from the backend
- Removed subscribe_can_browse from desktop and mobile invoke handlers
- Removed can_browse signal, listener, and the No network detected banner from the frontend
- Browse button still disables when no interface is enabled, invalid service type is entered, or already browsing

### Testing performed
- cargo fmt
- leptosfmt --check src
- cargo clippy --workspace --tests -- -D warnings
- cargo clippy --release --workspace --tests -- -D warnings
- cargo nextest run --profile ci --workspace
- cargo --locked tauri build --no-bundle --no-sign

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the network capability warning from the browsing interface.
  * Browse controls now reflect browsing status, service validity, and enabled interfaces.
  * Service-type selection is disabled while a browse operation is active.
  * Removed background capability polling and related event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->