### PR TITLE
docs: adjust immutable releases wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,9 @@ Since release v0.8.x
 
 ## Immutable releases
 
-The GitHub releases are now immutable: a release is first created as a draft, all its assets (binaries, checksums, attestations) are uploaded while it is still a draft, and it is only published once everything is in place. This ensures that a published release is always complete and cannot be altered afterwards.
+The GitHub releases are now immutable: a release is first created as a draft, all its assets (binaries, checksums, attestations) are uploaded while it is still a draft, and it is only published once everything is in place. This ensures that a published release is always complete and cannot be altered afterward.
 
-Since release v1.13.0
+This process has been used since release v1.13.0.
 
 ## Privacy
 


### PR DESCRIPTION
Adjusts the immutable releases wording for consistency with mdns-tui-browser ("afterward" and "This process has been used since release v1.13.0.")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Immutable releases” documentation to note usage since release v1.13.0.
  * Corrected wording for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->