### PR TITLE
docs: clarify cargo fmt covers formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,8 +138,7 @@ All source files must include:
 ```
 
 ### Rust Code Style
-- Use `cargo fmt` for formatting
-- Let rustfmt own import formatting: it rewrites `use std::path::{PathBuf};` to `use std::path::PathBuf;`, so write single-component imports without braces
+- `cargo fmt` applies and checks formatting; no need to review formatting or import style, the formatter covers it
 - Clippy must pass with `--tests -- -D warnings`
 - Prefer explicit error handling over `unwrap()`
 - Use `Result<T, String>` for Tauri command return types

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,7 @@ All source files must include:
 
 ### Rust Code Style
 - Use `cargo fmt` for formatting
+- Let rustfmt own import formatting: it rewrites `use std::path::{PathBuf};` to `use std::path::PathBuf;`, so write single-component imports without braces
 - Clippy must pass with `--tests -- -D warnings`
 - Prefer explicit error handling over `unwrap()`
 - Use `Result<T, String>` for Tauri command return types


### PR DESCRIPTION
Adds a note to AGENTS.md that `cargo fmt` applies and checks formatting, so formatting/import-style review comments are unnecessary.