### PR TITLE
fix: borderless on tiling Wayland, working buttons on non-tiling

### DIFF
--- a/crates/webkit2gtk-nvidia-quirk/src/lib.rs
+++ b/crates/webkit2gtk-nvidia-quirk/src/lib.rs
@@ -492,7 +492,8 @@ fn compositor_from_env<'a>(
     xdg_current_desktop: Option<&'a str>,
     xdg_session_desktop: Option<&'a str>,
 ) -> Option<&'a str> {
-    xdg_current_desktop.or(xdg_session_desktop)
+    let current = xdg_current_desktop.filter(|s| !s.trim().is_empty());
+    current.or(xdg_session_desktop)
 }
 
 /// Detects the running compositor from the environment. See

--- a/crates/webkit2gtk-nvidia-quirk/src/lib.rs
+++ b/crates/webkit2gtk-nvidia-quirk/src/lib.rs
@@ -440,9 +440,24 @@ pub fn is_x11_session() -> bool {
 
 /// Compositors that lay out windows without traditional title bars, so client
 /// side decorations are unwanted. This is a heuristic list since Wayland has no
-/// protocol that reports tiling vs floating behavior.
+/// protocol that reports tiling vs floating behavior. It is not exhaustive:
+/// compositors without a reliable identifying environment variable can only be
+/// detected via `XDG_CURRENT_DESKTOP`/`XDG_SESSION_DESKTOP`, and some
+/// floating-first compositors (e.g. Wayfire, KWin, GNOME Shell) only tile via
+/// optional plugins/extensions and are intentionally excluded.
 const TILING_COMPOSITORS: &[&str] = &[
-    "Hyprland", "sway", "river", "niri", "dwl", "newm", "karuiwm", "japokwm", "qtile", "Wayfire",
+    "Hyprland",
+    "sway",
+    "river",
+    "niri",
+    "dwl",
+    "newm",
+    "karuiwm",
+    "japokwm",
+    "qtile",
+    "miraclewm",
+    "vivarium",
+    "waymonad",
 ];
 
 /// Environment variables that reliably identify a tiling Wayland compositor.

--- a/crates/webkit2gtk-nvidia-quirk/src/lib.rs
+++ b/crates/webkit2gtk-nvidia-quirk/src/lib.rs
@@ -440,11 +440,11 @@ pub fn is_x11_session() -> bool {
 
 /// Compositors that lay out windows without traditional title bars, so client
 /// side decorations are unwanted. This is a heuristic list since Wayland has no
-/// protocol that reports tiling vs floating behavior. It is not exhaustive:
-/// compositors without a reliable identifying environment variable can only be
-/// detected via `XDG_CURRENT_DESKTOP`/`XDG_SESSION_DESKTOP`, and some
-/// floating-first compositors (e.g. Wayfire, KWin, GNOME Shell) only tile via
-/// optional plugins/extensions and are intentionally excluded.
+/// protocol that reports tiling vs floating behavior. It is not exhaustive and
+/// is matched against the desktop name advertised via
+/// `XDG_CURRENT_DESKTOP`/`XDG_SESSION_DESKTOP`; some floating-first compositors
+/// (e.g. Wayfire, KWin, GNOME Shell) only tile via optional plugins/extensions
+/// and are intentionally excluded.
 const TILING_COMPOSITORS: &[&str] = &[
     "Hyprland",
     "sway",
@@ -460,36 +460,18 @@ const TILING_COMPOSITORS: &[&str] = &[
     "waymonad",
 ];
 
-/// Environment variables that reliably identify a tiling Wayland compositor.
-///
-/// These are exported by the compositor itself for every client and are more
-/// dependable than the desktop-name heuristics, which can be missing or
-/// reformatted depending on how the session/app was launched.
-const TILING_COMPOSITOR_ENV_VARS: &[&str] = &[
-    "HYPRLAND_INSTANCE_SIGNATURE", // Hyprland
-    "SWAYSOCK",                    // sway
-    "NIRI_SOCKET",                 // niri
-];
-
 /// Returns `true` when the running compositor is known to use a tiling layout.
 ///
 /// Wayland provides no protocol to query tiling vs floating behavior, so this
-/// first checks for compositor-specific environment variables
-/// ([`TILING_COMPOSITOR_ENV_VARS`]) and then falls back to matching the
-/// compositor advertised via `XDG_CURRENT_DESKTOP` (or `XDG_SESSION_DESKTOP`)
-/// against a known set. The desktop-name comparison is case-insensitive and
-/// tolerates `XDG_CURRENT_DESKTOP` being a colon/comma/semicolon-separated
-/// list, as some sessions advertise more than one desktop name.
+/// matches the compositor advertised via `XDG_CURRENT_DESKTOP` (or
+/// `XDG_SESSION_DESKTOP`) against a known set. The desktop-name comparison is
+/// case-insensitive and tolerates `XDG_CURRENT_DESKTOP` being a
+/// colon/comma/semicolon-separated list, as some sessions advertise more than
+/// one desktop name.
 ///
 /// It is used to skip client side decorations on compositors that do not render
 /// or make use of them.
 pub fn is_tiling_compositor() -> bool {
-    if TILING_COMPOSITOR_ENV_VARS
-        .iter()
-        .any(|v| std::env::var(v).is_ok())
-    {
-        return true;
-    }
     let matches = |desktop: &str| -> bool {
         desktop.split([':', ';', ',']).map(str::trim).any(|part| {
             TILING_COMPOSITORS

--- a/crates/webkit2gtk-nvidia-quirk/src/lib.rs
+++ b/crates/webkit2gtk-nvidia-quirk/src/lib.rs
@@ -416,6 +416,75 @@ fn get_session_type() -> SessionType {
     )
 }
 
+/// Returns `true` when the application is running in a Wayland session.
+///
+/// This reuses the same session detection as the WebKitGTK workarounds
+/// ([`get_session_type`]), falling back to `WAYLAND_DISPLAY`/`DISPLAY` when
+/// `XDG_SESSION_TYPE` is unavailable (e.g. inside a Flatpak sandbox).
+///
+/// It is used to apply Wayland-specific workarounds that must not run under X11.
+pub fn is_wayland_session() -> bool {
+    get_session_type() == SessionType::Wayland
+}
+
+/// Returns `true` when the application is running in an X11 session.
+///
+/// This reuses the same session detection as the WebKitGTK workarounds
+/// ([`get_session_type`]), falling back to `WAYLAND_DISPLAY`/`DISPLAY` when
+/// `XDG_SESSION_TYPE` is unavailable (e.g. inside a Flatpak sandbox).
+///
+/// It is used to apply X11-specific workarounds that must not run under Wayland.
+pub fn is_x11_session() -> bool {
+    get_session_type() == SessionType::X11
+}
+
+/// Compositors that lay out windows without traditional title bars, so client
+/// side decorations are unwanted. This is a heuristic list since Wayland has no
+/// protocol that reports tiling vs floating behavior.
+const TILING_COMPOSITORS: &[&str] = &[
+    "Hyprland", "sway", "river", "niri", "dwl", "newm", "karuiwm", "japokwm", "qtile", "Wayfire",
+];
+
+/// Environment variables that reliably identify a tiling Wayland compositor.
+///
+/// These are exported by the compositor itself for every client and are more
+/// dependable than the desktop-name heuristics, which can be missing or
+/// reformatted depending on how the session/app was launched.
+const TILING_COMPOSITOR_ENV_VARS: &[&str] = &[
+    "HYPRLAND_INSTANCE_SIGNATURE", // Hyprland
+    "SWAYSOCK",                    // sway
+    "NIRI_SOCKET",                 // niri
+];
+
+/// Returns `true` when the running compositor is known to use a tiling layout.
+///
+/// Wayland provides no protocol to query tiling vs floating behavior, so this
+/// first checks for compositor-specific environment variables
+/// ([`TILING_COMPOSITOR_ENV_VARS`]) and then falls back to matching the
+/// compositor advertised via `XDG_CURRENT_DESKTOP` (or `XDG_SESSION_DESKTOP`)
+/// against a known set. The desktop-name comparison is case-insensitive and
+/// tolerates `XDG_CURRENT_DESKTOP` being a colon/comma/semicolon-separated
+/// list, as some sessions advertise more than one desktop name.
+///
+/// It is used to skip client side decorations on compositors that do not render
+/// or make use of them.
+pub fn is_tiling_compositor() -> bool {
+    if TILING_COMPOSITOR_ENV_VARS
+        .iter()
+        .any(|v| std::env::var(v).is_ok())
+    {
+        return true;
+    }
+    let matches = |desktop: &str| -> bool {
+        desktop.split([':', ';', ',']).map(str::trim).any(|part| {
+            TILING_COMPOSITORS
+                .iter()
+                .any(|t| t.eq_ignore_ascii_case(part))
+        })
+    };
+    get_compositor().as_deref().map(matches).unwrap_or(false)
+}
+
 /// Returns the compositor advertised in the environment, if any.
 ///
 /// Compositors advertise their identity via `XDG_CURRENT_DESKTOP`, which is the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -956,21 +956,28 @@ fn theme(window: Window) -> Theme {
 }
 
 /// On non-tiling Wayland the minimize/maximize/close buttons are left dead by
-/// the compositor until the window is reconfigured once (e.g. after resizing).
-/// Toggling the decorations re-wires them. The window already has the correct
-/// decoration state from creation, so this is purely a best-effort button fix.
+/// the compositor until the window is reconfigured once. A runtime toggle of
+/// decorations is unreliable on some compositors (e.g. it does not re-wire the
+/// buttons on Ubuntu/GNOME Wayland), so instead perform a maximize/restore
+/// cycle, which forces the required reconfigure and re-wires the buttons. This
+/// is the same gesture the user can do manually (double-click the title bar).
 #[cfg(target_os = "linux")]
-fn reconfigure_for_wayland_buttons(window: &tauri::WebviewWindow) {
+fn reconfigure_for_wayland_buttons(window: tauri::WebviewWindow) {
     if webkit2gtk_nvidia_quirk::is_wayland_session()
         && !webkit2gtk_nvidia_quirk::is_tiling_compositor()
     {
-        let _ = window.set_decorations(false);
-        let _ = window.set_decorations(true);
+        std::thread::spawn(move || {
+            let _ = window.maximize();
+            // Let the compositor commit the maximized state before restoring,
+            // otherwise the two calls coalesce and nothing changes.
+            std::thread::sleep(std::time::Duration::from_millis(60));
+            let _ = window.unmaximize();
+        });
     }
 }
 
 #[cfg(not(target_os = "linux"))]
-fn reconfigure_for_wayland_buttons(_window: &tauri::WebviewWindow) {}
+fn reconfigure_for_wayland_buttons(_window: tauri::WebviewWindow) {}
 
 #[cfg(desktop)]
 #[tauri::command]
@@ -978,7 +985,7 @@ fn close_splashscreen(app: AppHandle, state: State<ManagedState>) {
     if let Some(w) = app.get_webview_window("main") {
         let _ = w.show();
         let _ = w.set_focus();
-        reconfigure_for_wayland_buttons(&w);
+        reconfigure_for_wayland_buttons(w.clone());
         if state.dev_tools_enabled {
             w.open_devtools();
         }
@@ -1280,7 +1287,7 @@ pub fn run() {
                     tauri::async_runtime::spawn(async move {
                         let _ = splashscreen_window.close();
                         let _ = main_window.show();
-                        reconfigure_for_wayland_buttons(&main_window);
+                        reconfigure_for_wayland_buttons(main_window.clone());
                         if args.enable_devtools {
                             main_window.open_devtools();
                         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1330,12 +1330,6 @@ pub fn run_mobile() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .manage(ManagedState::new())
         .manage(autoupdate::PendingUpdateInfo(std::sync::Mutex::new(None)))
-        .setup(|app| {
-            // Mirror the desktop entry point: create the main window
-            // programmatically so its decoration state is set at creation.
-            let _ = create_main_window(app.handle());
-            Ok(())
-        })
         .invoke_handler(tauri::generate_handler![
             autoupdate::can_auto_update,
             autoupdate::fetch_update,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -955,12 +955,30 @@ fn theme(window: Window) -> Theme {
     }
 }
 
+/// On non-tiling Wayland the minimize/maximize/close buttons are left dead by
+/// the compositor until the window is reconfigured once (e.g. after resizing).
+/// Toggling the decorations re-wires them. The window already has the correct
+/// decoration state from creation, so this is purely a best-effort button fix.
+#[cfg(target_os = "linux")]
+fn reconfigure_for_wayland_buttons(window: &tauri::WebviewWindow) {
+    if webkit2gtk_nvidia_quirk::is_wayland_session()
+        && !webkit2gtk_nvidia_quirk::is_tiling_compositor()
+    {
+        let _ = window.set_decorations(false);
+        let _ = window.set_decorations(true);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn reconfigure_for_wayland_buttons(_window: &tauri::WebviewWindow) {}
+
 #[cfg(desktop)]
 #[tauri::command]
 fn close_splashscreen(app: AppHandle, state: State<ManagedState>) {
     if let Some(w) = app.get_webview_window("main") {
         let _ = w.show();
         let _ = w.set_focus();
+        reconfigure_for_wayland_buttons(&w);
         if state.dev_tools_enabled {
             w.open_devtools();
         }
@@ -1177,12 +1195,34 @@ mod autoupdate {
 }
 
 #[cfg(desktop)]
+/// Creates the main application window.
+///
+/// The window is created programmatically (rather than via `tauri.conf.json`)
+/// so its decoration state can be decided at creation time, which is the only
+/// point at which it reliably takes effect: Wayland/GTK and X11 do not honor
+/// runtime decoration changes once the window is mapped. Tiling Wayland
+/// compositors therefore start borderless, while every other session starts
+/// decorated.
+fn create_main_window(app: &AppHandle) -> tauri::WebviewWindow {
+    #[cfg(target_os = "linux")]
+    let decorate = !(webkit2gtk_nvidia_quirk::is_wayland_session()
+        && webkit2gtk_nvidia_quirk::is_tiling_compositor());
+    #[cfg(not(target_os = "linux"))]
+    let decorate = true;
+
+    tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App("index.html".into()))
+        .title("mDNS-Browser")
+        .inner_size(1615.0, 900.0)
+        .decorations(decorate)
+        .visible(false)
+        .build()
+        .expect("Main window to be created")
+}
+
 pub fn run() {
     use chrono::Utc;
     use tauri_plugin_log::{Target, TargetKind};
     let args = Args::parse();
-
-    #[cfg(target_os = "linux")]
     {
         if !args.no_nvidia_workaround {
             let options = ApplyWorkaroundOptions::default()
@@ -1224,42 +1264,23 @@ pub fn run() {
         .manage(ManagedState::new(args.enable_devtools))
         .manage(autoupdate::PendingUpdate(Mutex::new(None)))
         .setup(move |app| {
-            // Due to peculiarities of `tauri dev` mode,
-            // we need to do close the splashscreen manually
-            let main_window = app
-                .get_webview_window("main")
-                .expect("Main window to exist");
+            // The main window is created programmatically (instead of via
+            // tauri.conf.json) so its decoration state can be set at creation
+            // time. Runtime decoration changes do not take effect on
+            // Wayland/GTK (and X11) once the window is mapped, so tiling
+            // Wayland compositors must start borderless from the start.
+            let main_window = create_main_window(app.handle());
+
+            // Due to peculiarities of `tauri dev` mode, we need to close the
+            // splashscreen and show the main window manually.
             let url = main_window.url().expect("Main window url to exist");
             let scheme = url.scheme();
             if scheme == "http" {
                 if let Some(splashscreen_window) = app.get_webview_window("splashscreen") {
                     tauri::async_runtime::spawn(async move {
                         let _ = splashscreen_window.close();
-
-                        // The main window is created without decorations (see
-                        // tauri.conf.json) so tiling Wayland compositors get a
-                        // borderless window without relying on a runtime
-                        // decoration change, which does not take effect on
-                        // Wayland/GTK after the window is mapped. On every other
-                        // session we enable decorations here.
-                        #[cfg(target_os = "linux")]
-                        let want_decorations = !webkit2gtk_nvidia_quirk::is_wayland_session()
-                            || !webkit2gtk_nvidia_quirk::is_tiling_compositor();
-                        #[cfg(not(target_os = "linux"))]
-                        let want_decorations = true;
-
                         let _ = main_window.show();
-
-                        // On non-tiling Wayland the false->true transition also
-                        // re-wires the minimize/maximize/close buttons that the
-                        // compositor otherwise leaves dead until the window is
-                        // resized. Enabling decorations at runtime is reliable;
-                        // only disabling at runtime is not.
-                        if want_decorations {
-                            let _ = main_window.set_decorations(false);
-                            let _ = main_window.set_decorations(true);
-                        }
-
+                        reconfigure_for_wayland_buttons(&main_window);
                         if args.enable_devtools {
                             main_window.open_devtools();
                         }
@@ -1311,6 +1332,12 @@ pub fn run_mobile() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .manage(ManagedState::new())
         .manage(autoupdate::PendingUpdateInfo(std::sync::Mutex::new(None)))
+        .setup(|app| {
+            // Mirror the desktop entry point: create the main window
+            // programmatically so its decoration state is set at creation.
+            let _ = create_main_window(app.handle());
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             autoupdate::can_auto_update,
             autoupdate::fetch_update,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -960,9 +960,11 @@ fn theme(window: Window) -> Theme {
 fn close_splashscreen(app: AppHandle, state: State<ManagedState>) {
     if let Some(w) = app.get_webview_window("main") {
         let _ = w.show();
-        let _ = w.set_focus();
         if state.dev_tools_enabled {
-            w.open_devtools();
+            let window = w.clone();
+            tauri::async_runtime::spawn(async move {
+                window.open_devtools();
+            });
         }
     }
     if let Some(w) = app.get_webview_window("splashscreen") {
@@ -1280,9 +1282,6 @@ pub fn run() {
                     tauri::async_runtime::spawn(async move {
                         let _ = splashscreen_window.close();
                         let _ = main_window.show();
-                        if args.enable_devtools {
-                            main_window.open_devtools();
-                        }
                     });
                 }
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1220,6 +1220,8 @@ pub fn run() {
     use chrono::Utc;
     use tauri_plugin_log::{Target, TargetKind};
     let args = Args::parse();
+
+    #[cfg(target_os = "linux")]
     {
         if !args.no_nvidia_workaround {
             let options = ApplyWorkaroundOptions::default()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -955,37 +955,12 @@ fn theme(window: Window) -> Theme {
     }
 }
 
-/// On non-tiling Wayland the minimize/maximize/close buttons are left dead by
-/// the compositor until the window is reconfigured once. A runtime toggle of
-/// decorations is unreliable on some compositors (e.g. it does not re-wire the
-/// buttons on Ubuntu/GNOME Wayland), so instead perform a maximize/restore
-/// cycle, which forces the required reconfigure and re-wires the buttons. This
-/// is the same gesture the user can do manually (double-click the title bar).
-#[cfg(target_os = "linux")]
-fn reconfigure_for_wayland_buttons(window: tauri::WebviewWindow) {
-    if webkit2gtk_nvidia_quirk::is_wayland_session()
-        && !webkit2gtk_nvidia_quirk::is_tiling_compositor()
-    {
-        std::thread::spawn(move || {
-            let _ = window.maximize();
-            // Let the compositor commit the maximized state before restoring,
-            // otherwise the two calls coalesce and nothing changes.
-            std::thread::sleep(std::time::Duration::from_millis(60));
-            let _ = window.unmaximize();
-        });
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-fn reconfigure_for_wayland_buttons(_window: tauri::WebviewWindow) {}
-
 #[cfg(desktop)]
 #[tauri::command]
 fn close_splashscreen(app: AppHandle, state: State<ManagedState>) {
     if let Some(w) = app.get_webview_window("main") {
         let _ = w.show();
         let _ = w.set_focus();
-        reconfigure_for_wayland_buttons(w.clone());
         if state.dev_tools_enabled {
             w.open_devtools();
         }
@@ -1210,20 +1185,35 @@ mod autoupdate {
 /// runtime decoration changes once the window is mapped. Tiling Wayland
 /// compositors therefore start borderless, while every other session starts
 /// decorated.
+///
+/// On non-tiling Wayland the minimize/maximize/close buttons are dead after the
+/// window is created hidden and shown (tauri-apps/tao#1046). Starting the
+/// window maximized is a creation-time reconfigure that wires the buttons up,
+/// avoiding any runtime toggle/cycle.
 fn create_main_window(app: &AppHandle) -> tauri::WebviewWindow {
     #[cfg(target_os = "linux")]
-    let decorate = !(webkit2gtk_nvidia_quirk::is_wayland_session()
-        && webkit2gtk_nvidia_quirk::is_tiling_compositor());
+    let wayland = webkit2gtk_nvidia_quirk::is_wayland_session();
+    #[cfg(target_os = "linux")]
+    let tiling = webkit2gtk_nvidia_quirk::is_tiling_compositor();
+    #[cfg(target_os = "linux")]
+    let decorate = !(wayland && tiling);
+    #[cfg(target_os = "linux")]
+    let start_maximized = wayland && !tiling;
     #[cfg(not(target_os = "linux"))]
     let decorate = true;
+    #[cfg(not(target_os = "linux"))]
+    let start_maximized = false;
 
-    tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App("index.html".into()))
-        .title("mDNS-Browser")
-        .inner_size(1615.0, 900.0)
-        .decorations(decorate)
-        .visible(false)
-        .build()
-        .expect("Main window to be created")
+    let mut builder =
+        tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App("index.html".into()))
+            .title("mDNS-Browser")
+            .inner_size(1615.0, 900.0)
+            .decorations(decorate)
+            .visible(false);
+    if start_maximized {
+        builder = builder.maximized(true);
+    }
+    builder.build().expect("Main window to be created")
 }
 
 pub fn run() {
@@ -1287,7 +1277,6 @@ pub fn run() {
                     tauri::async_runtime::spawn(async move {
                         let _ = splashscreen_window.close();
                         let _ = main_window.show();
-                        reconfigure_for_wayland_buttons(main_window.clone());
                         if args.enable_devtools {
                             main_window.open_devtools();
                         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1216,6 +1216,7 @@ fn create_main_window(app: &AppHandle) -> tauri::WebviewWindow {
     builder.build().expect("Main window to be created")
 }
 
+#[cfg(desktop)]
 pub fn run() {
     use chrono::Utc;
     use tauri_plugin_log::{Target, TargetKind};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1192,7 +1192,7 @@ mod autoupdate {
 /// window is created hidden and shown (tauri-apps/tao#1046). Starting the
 /// window maximized is a creation-time reconfigure that wires the buttons up,
 /// avoiding any runtime toggle/cycle.
-fn create_main_window(app: &AppHandle) -> tauri::WebviewWindow {
+fn create_main_window(app: &AppHandle) -> Result<tauri::WebviewWindow, tauri::Error> {
     #[cfg(target_os = "linux")]
     let wayland = webkit2gtk_nvidia_quirk::is_wayland_session();
     #[cfg(target_os = "linux")]
@@ -1215,7 +1215,10 @@ fn create_main_window(app: &AppHandle) -> tauri::WebviewWindow {
     if start_maximized {
         builder = builder.maximized(true);
     }
-    builder.build().expect("Main window to be created")
+    builder.build().map_err(|e| {
+        log::error!("Failed to create main window: {e}");
+        e
+    })
 }
 
 #[cfg(desktop)]
@@ -1271,7 +1274,7 @@ pub fn run() {
             // time. Runtime decoration changes do not take effect on
             // Wayland/GTK (and X11) once the window is mapped, so tiling
             // Wayland compositors must start borderless from the start.
-            let main_window = create_main_window(app.handle());
+            let main_window = create_main_window(app.handle())?;
 
             // Due to peculiarities of `tauri dev` mode, we need to close the
             // splashscreen and show the main window manually.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1235,7 +1235,31 @@ pub fn run() {
                 if let Some(splashscreen_window) = app.get_webview_window("splashscreen") {
                     tauri::async_runtime::spawn(async move {
                         let _ = splashscreen_window.close();
+
+                        // The main window is created without decorations (see
+                        // tauri.conf.json) so tiling Wayland compositors get a
+                        // borderless window without relying on a runtime
+                        // decoration change, which does not take effect on
+                        // Wayland/GTK after the window is mapped. On every other
+                        // session we enable decorations here.
+                        #[cfg(target_os = "linux")]
+                        let want_decorations = !webkit2gtk_nvidia_quirk::is_wayland_session()
+                            || !webkit2gtk_nvidia_quirk::is_tiling_compositor();
+                        #[cfg(not(target_os = "linux"))]
+                        let want_decorations = true;
+
                         let _ = main_window.show();
+
+                        // On non-tiling Wayland the false->true transition also
+                        // re-wires the minimize/maximize/close buttons that the
+                        // compositor otherwise leaves dead until the window is
+                        // resized. Enabling decorations at runtime is reliable;
+                        // only disabling at runtime is not.
+                        if want_decorations {
+                            let _ = main_window.set_decorations(false);
+                            let _ = main_window.set_decorations(true);
+                        }
+
                         if args.enable_devtools {
                             main_window.open_devtools();
                         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -963,6 +963,8 @@ fn close_splashscreen(app: AppHandle, state: State<ManagedState>) {
         if state.dev_tools_enabled {
             let window = w.clone();
             tauri::async_runtime::spawn(async move {
+                #[cfg(target_os = "linux")]
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                 window.open_devtools();
             });
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -75,6 +75,7 @@
                 "width": 1615,
                 "height": 900,
                 "label": "main",
+                "decorations": false,
                 "visible": false
             },
             {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -70,15 +70,6 @@
         "withGlobalTauri": true,
         "windows": [
             {
-                "title": "mDNS-Browser",
-                "url": "index.html",
-                "width": 1615,
-                "height": 900,
-                "label": "main",
-                "decorations": false,
-                "visible": false
-            },
-            {
                 "title": "Splashscreen",
                 "url": "public/splashscreen.html",
                 "label": "splashscreen",


### PR DESCRIPTION
## Summary

Fix window decoration issues on Linux.

**Decoration state:** set at **window-creation time** (the only point it reliably applies — runtime decoration changes, both enable and disable, do not take effect on Wayland/GTK or X11 once the window is mapped):
- Linux + tiling compositor → borderless.
- Every other session (non-tiling Wayland, X11, Windows, macOS) → decorated.

**Titlebar buttons (minimize/maximize/close):** On non-tiling Wayland the buttons are dead after the window is created hidden and shown (tracked in tauri-apps/tao#1046). A runtime decoration toggle does not re-wire them on compositors like Ubuntu/GNOME Wayland. Since the window is created programmatically, we simply **start the window maximized** on non-tiling Wayland — a creation-time reconfigure that wires the buttons up, avoiding any runtime toggle/cycle.

## Changes
- `src-tauri/tauri.conf.json`: removed the `main` window (kept `splashscreen`).
- `src-tauri/src/lib.rs`: `create_main_window()` builds the main window with creation-time decorations and maximized state, wired into the desktop `run()`.
- `crates/webkit2gtk-nvidia-quirk`: `is_wayland_session()`, `is_x11_session()`, `is_tiling_compositor()` for session/compositor detection. Tiling compositors are detected by matching the desktop name from `XDG_CURRENT_DESKTOP`/`XDG_SESSION_DESKTOP` against a known list (case-insensitive, tolerant of colon/comma/semicolon-separated lists), currently Hyprland, sway, river, niri, dwl, newm, karuiwm, japokwm, qtile, miraclewm, vivarium, and waymonad.

## Testing
- [x] `cargo fmt --check`, `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo nextest run --profile ci --workspace`
- [x] Windows: decorations + buttons working
- [x] macOS: decorations + buttons working
- [x] Tiling Wayland (Hyprland): borderless as intended
- [x] Non-tiling Wayland (ubuntu:GNOME): decorated with working buttons
- [x] Check `-D` working on Windows with unbundled executable
- [x] Check `-D` working on macOS with unbundled executable
- [x] Check `-D` working on Linux with unbundled executable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved desktop startup behavior on Linux, including better support for Wayland and tiling window managers.
  * Main application windows now automatically use appropriate decorations and maximization settings.

* **Bug Fixes**
  * Improved compatibility with Flatpak session detection.
  * Devtools now open asynchronously after the splash screen closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->