### PR TITLE
fix: publish unbundled macOS executable on release

### DIFF
--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -134,7 +134,6 @@ jobs:
 
       - name: 🔨 Build plain executables using tauri action (publish artifacts on release)
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
-        if: ${{ !contains(matrix.os, 'macos') }}
         env:
           RUSTFLAGS: "-D warnings"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -277,14 +277,6 @@ jobs:
           subject-path: |
             target/**/release/mdns-browser
             target/release/mdns-browser.exe
-            target/release/mdns_browser.pdb
-            target/release/mdns-browser-${{ steps.get-version.outputs.current-version }}-debug-symbols-windows.zip
-            target/release/mdns-browser.dwp
-            target/release/mdns-browser-${{ steps.get-version.outputs.current-version }}-debug-symbols-linux.tar.gz
-            target/x86_64-apple-darwin/release/deps/mdns-browser-*.dSYM
-            target/x86_64-apple-darwin/release/deps/mdns-browser-${{ steps.get-version.outputs.current-version }}-debug-symbols-macos-x86_64.tar.gz
-            target/aarch64-apple-darwin/release/deps/mdns-browser-*.dSYM
-            target/aarch64-apple-darwin/release/deps/mdns-browser-${{ steps.get-version.outputs.current-version }}-debug-symbols-macos-aarch64.tar.gz
 
       - name: 🛡️ Attest SBOM (plain binary)
         if: inputs.tagName
@@ -305,3 +297,11 @@ jobs:
             target/**/release/bundle/dmg/*.dmg
             target/release/bundle/deb/*.deb
             target/release/bundle/rpm/*.rpm
+            target/release/mdns_browser.pdb
+            target/release/mdns-browser-${{ steps.get-version.outputs.current-version }}-debug-symbols-windows.zip
+            target/release/mdns-browser.dwp
+            target/release/mdns-browser-${{ steps.get-version.outputs.current-version }}-debug-symbols-linux.tar.gz
+            target/x86_64-apple-darwin/release/deps/mdns-browser-*.dSYM
+            target/x86_64-apple-darwin/release/deps/mdns-browser-${{ steps.get-version.outputs.current-version }}-debug-symbols-macos-x86_64.tar.gz
+            target/aarch64-apple-darwin/release/deps/mdns-browser-*.dSYM
+            target/aarch64-apple-darwin/release/deps/mdns-browser-${{ steps.get-version.outputs.current-version }}-debug-symbols-macos-aarch64.tar.gz

--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -270,16 +270,11 @@ jobs:
           fi
           gh release upload "$TAG_NAME" "${ASSETS[@]}" --clobber
 
-      - name: 🛡️ Attest build provenance (publish release only)
+      - name: 🛡️ Attest build provenance (plain binary)
         if: inputs.tagName
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
         with:
           subject-path: |
-            target/release/bundle/nsis/*
-            target/**/release/bundle/macos/*.tar.gz*
-            target/**/release/bundle/dmg/*.dmg
-            target/release/bundle/deb/*.deb
-            target/release/bundle/rpm/*.rpm
             target/**/release/mdns-browser
             target/release/mdns-browser.exe
             target/release/mdns_browser.pdb
@@ -291,13 +286,22 @@ jobs:
             target/aarch64-apple-darwin/release/deps/mdns-browser-*.dSYM
             target/aarch64-apple-darwin/release/deps/mdns-browser-${{ steps.get-version.outputs.current-version }}-debug-symbols-macos-aarch64.tar.gz
 
-      - name: 🛡️ Attest SBOM
+      - name: 🛡️ Attest SBOM (plain binary)
         if: inputs.tagName
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
         with:
-          subject-path: ${{
-            contains(matrix.os, 'ubuntu') && 'target/release/mdns-browser' ||
-            contains(matrix.os, 'windows') && 'target/release/mdns-browser.exe' ||
-            contains(matrix.os, 'macos') && 'target/universal-apple-darwin/release/mdns-browser'
-            }}
+          subject-path: |
+            target/**/release/mdns-browser
+            target/release/mdns-browser.exe
           sbom-path: "sbom.spdx.json"
+
+      - name: 🛡️ Attest build provenance (bundles)
+        if: inputs.tagName
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-path: |
+            target/release/bundle/nsis/*
+            target/**/release/bundle/macos/*.tar.gz*
+            target/**/release/bundle/dmg/*.dmg
+            target/release/bundle/deb/*.deb
+            target/release/bundle/rpm/*.rpm


### PR DESCRIPTION
## Summary

Releases currently publish the unbundled (plain) executable on Linux and Windows, but not on macOS — the plain-binary `tauri-action` step was skipped there (`if: !contains(matrix.os, 'macos')`), so only the `.app`/`.dmg` bundles were shipped. macOS also was missing a separate attestation for the standalone binary.

- Remove the macOS exclusion so the standalone binary is uploaded (`uploadPlainBinary: true`) on macOS too, matching Linux/Windows.
- The bundling step patches a bundler tag into the bundled binary, so the unbundled executable is a distinct artifact. Split the single attest step into a plain-binary provenance + SBOM step and a bundles-only provenance step, mirroring the sibling `zux` release workflow.
- The bundling step also rebuilds the binary and regenerates the debug symbols (`.pdb`/`.dwp`/`.dSYM`), so those symbols correspond to the bundling output. They are attested with the bundles provenance step, not the plain-binary step (which attests only the binary itself).

## Changes
- `.github/workflows/desktop-reusable.yml`:
  - Drop the `if: ${{ !contains(matrix.os, 'macos') }}` guard on the "Build plain executables" step.
  - Replace the single attest step with a plain-binary provenance + SBOM step (binary only) and a bundles provenance step (bundles + regenerated debug symbols).

## Testing
- [x] `actionlint .github/workflows/*.yml` passes

Base branch: `main`.