### PR TITLE
chore(release): surface webkit2gtk-nvidia-quirk bump in changelog

### DIFF
--- a/.github/workflows/publish-webkit2gtk-nvidia-quirk.yml
+++ b/.github/workflows/publish-webkit2gtk-nvidia-quirk.yml
@@ -147,7 +147,7 @@ jobs:
         if: (!inputs.dry-run)
         run: |
           git add -A
-          git commit -S -m "Bump webkit2gtk-nvidia-quirk to ${{ steps.version.outputs.version }}"
+          git commit -S -m "chore(webkit2gtk-nvidia-quirk): Bump webkit2gtk-nvidia-quirk to ${{ steps.version.outputs.version }}"
           git tag -s -a webkit2gtk-nvidia-quirk-v${{ steps.version.outputs.version }} -m "webkit2gtk-nvidia-quirk Release v${{ steps.version.outputs.version }}"
           git push --follow-tags
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,7 @@ This ensures your workflow changes follow GitHub Actions best practices and will
 
 - **Never** use `unsafe` code - this will cause CI to fail
 - **Never** add `#[allow(warnings)]` attributes to suppress warnings - fix the underlying issues instead
+- **Never** manually bump crate versions in `Cargo.toml` or add `CHANGELOG.md` entries for crates. Version bumps and changelog generation are performed automatically by the crate publishing workflow (git-cliff, based on conventional commits). Only change source, tests, and docs.
 - **Never** amend commits - commits will be squashed in GitHub, just create a new commit instead
 - **Always** format code before committing
 - **Always** run clippy and fix warnings (both debug and release)


### PR DESCRIPTION
## Problem
The crate publishing workflow committed `Bump webkit2gtk-nvidia-quirk to X`, which git-cliff filters out because it is not a Conventional Commit, so the crate bump never appeared in `CHANGELOG.md` (only as separate `webkit2gtk-nvidia-quirk-v*` tag sections).

## Change
- Publish workflow now commits `chore(webkit2gtk-nvidia-quirk): Bump webkit2gtk-nvidia-quirk to X` so it renders as a Changed entry in both the main and crate changelogs.
- Document in `AGENTS.md` that crate version bumps and `CHANGELOG` entries are generated automatically by the publishing workflow and must not be edited manually.

Note: existing historical bump commits remain filtered (pre-existing); only future bumps appear. The crate's per-version history is still preserved via the tag-based crate changelog.

## Verification
- `git-cliff --config cliff.toml` produces no `webkit2gtk-nvidia-quirk-v*` sections in the main changelog; the bump entry now arrives via the conventional commit instead.