### PR TITLE
feat: add opt-in verbosity flag for NVIDIA workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Options:
   -d, --disable-dmabuf-renderer     Disable dmabuf renderer (Linux only), useful when having rendering issues
       --disable-nv-explicit-sync    Disable NVIDIA explicit sync (Linux only)
       --no-nvidia-workaround        Disable all NVIDIA workarounds entirely (Linux only)
+      --nvidia-workaround-verbose   Print diagnostic notes when applying an NVIDIA workaround (Linux only)
   -h, --help                        Print help
   -V, --version                     Print version
 
@@ -113,6 +114,11 @@ This option disables all NVIDIA workarounds entirely, including automatic detect
 Useful for testing whether rendering issues are caused by the workarounds or to completely disable them.
 
 This option takes precedence over both `--disable-dmabuf-renderer` and `--disable-nv-explicit-sync`.
+
+### nvidia-workaround-verbose (Linux only)
+
+This option prints diagnostic notes to stderr when a NVIDIA workaround is applied, so you can confirm which workarounds are active.
+It only affects diagnostic output and does not change any behavior.
 
 ## Where to find the executables?
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ This option takes precedence over both `--disable-dmabuf-renderer` and `--disabl
 This option prints diagnostic notes to stderr when a NVIDIA workaround is applied, so you can confirm which workarounds are active.
 It only affects diagnostic output and does not change any behavior.
 
+This option has been added with release [v1.18.0](https://github.com/hrzlgnm/mdns-browser/releases/tag/v1.18.0)
+
 ## Where to find the executables?
 
 ### GitHub Releases

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ Options:
   -D, --enable-devtools             Enable devtools at startup
   -f, --log-to-file                 Enable logging to file
   -d, --disable-dmabuf-renderer     Disable dmabuf renderer (Linux only), useful when having rendering issues
-      --disable-nv-explicit-sync    Disable NVIDIA explicit sync (Linux only)
-      --no-nvidia-workaround        Disable all NVIDIA workarounds entirely (Linux only)
-      --nvidia-workaround-verbose   Print diagnostic notes when applying an NVIDIA workaround (Linux only)
+  -e, --disable-nv-explicit-sync    Disable NVIDIA explicit sync (Linux only)
+  -n, --no-nvidia-workaround        Disable all NVIDIA workarounds entirely (Linux only)
+  -v, --nvidia-workaround-verbose   Print diagnostic notes when applying an NVIDIA workaround (Linux only)
   -h, --help                        Print help
   -V, --version                     Print version
 

--- a/docs/mdns-browser.1
+++ b/docs/mdns-browser.1
@@ -1,4 +1,4 @@
-.TH mdns-browser 1 "2026-02-07" "mdns-browser" "User Commands"
+.TH mdns-browser 1 "2026-08-18" "mdns-browser" "User Commands"
 .SH NAME
 mdns-browser \- Browse mDNS services
 .SH SYNOPSIS
@@ -25,6 +25,9 @@ Disable NVIDIA explicit sync even if NVIDIA is not detected (Linux only)
 .TP
 .BI \-\-no\-nvidia\-workaround
 Disable all NVIDIA workarounds entirely (Linux only)
+.TP
+.BI \-\-nvidia\-workaround\-verbose
+Print diagnostic notes when applying an NVIDIA workaround (Linux only)
 .TP
 .BI \-h , \-\-help
 Print help

--- a/docs/mdns-browser.1
+++ b/docs/mdns-browser.1
@@ -20,13 +20,13 @@ Enable logging to file
 .BI \-d , \-\-disable\-dmabuf\-renderer
 Disable dmabuf renderer (Linux only), useful when having rendering issues
 .TP
-.BI \-\-disable\-nv\-explicit\-sync
+.BI \-e , \-\-disable\-nv\-explicit\-sync
 Disable NVIDIA explicit sync even if NVIDIA is not detected (Linux only)
 .TP
-.BI \-\-no\-nvidia\-workaround
+.BI \-n , \-\-no\-nvidia\-workaround
 Disable all NVIDIA workarounds entirely (Linux only)
 .TP
-.BI \-\-nvidia\-workaround\-verbose
+.BI \-v , \-\-nvidia\-workaround\-verbose
 Print diagnostic notes when applying an NVIDIA workaround (Linux only)
 .TP
 .BI \-h , \-\-help

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1032,6 +1032,13 @@ struct Args {
         help = "Disable all NVIDIA workarounds entirely"
     )]
     no_nvidia_workaround: bool,
+    #[cfg(target_os = "linux")]
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Print diagnostic notes when applying a NVIDIA workaround"
+    )]
+    nvidia_workaround_verbose: bool,
 }
 
 #[cfg(desktop)]
@@ -1234,7 +1241,8 @@ pub fn run() {
         if !args.no_nvidia_workaround {
             let options = ApplyWorkaroundOptions::default()
                 .force_disable_dmabuf(args.disable_dmabuf_renderer)
-                .force_disable_nv_explicit_sync(args.disable_nv_explicit_sync);
+                .force_disable_nv_explicit_sync(args.disable_nv_explicit_sync)
+                .verbose(args.nvidia_workaround_verbose);
             apply_workaround_with_options(options);
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1036,7 +1036,7 @@ struct Args {
     #[arg(
         long,
         default_value_t = false,
-        help = "Print diagnostic notes when applying a NVIDIA workaround"
+        help = "Print diagnostic notes when applying an NVIDIA workaround"
     )]
     nvidia_workaround_verbose: bool,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1020,6 +1020,7 @@ struct Args {
     disable_dmabuf_renderer: bool,
     #[cfg(target_os = "linux")]
     #[arg(
+        short = 'e',
         long,
         default_value_t = false,
         help = "Disable NVIDIA explicit sync even if NVIDIA is not detected"
@@ -1027,6 +1028,7 @@ struct Args {
     disable_nv_explicit_sync: bool,
     #[cfg(target_os = "linux")]
     #[arg(
+        short = 'n',
         long,
         default_value_t = false,
         help = "Disable all NVIDIA workarounds entirely"
@@ -1034,6 +1036,7 @@ struct Args {
     no_nvidia_workaround: bool,
     #[cfg(target_os = "linux")]
     #[arg(
+        short = 'v',
         long,
         default_value_t = false,
         help = "Print diagnostic notes when applying an NVIDIA workaround"


### PR DESCRIPTION
## Summary
- Adds a `--nvidia-workaround-verbose` CLI flag (opt-in, default `false`, Linux only) to the `Args` struct in `src-tauri/src/lib.rs`.
- Wires the flag through to `ApplyWorkaroundOptions::verbose()` so diagnostic notes are printed to stderr only when explicitly requested.
- Adds short options for all NVIDIA workaround flags: `-d` (`--disable-dmabuf-renderer`, unchanged), `-e` (`--disable-nv-explicit-sync`), `-n` (`--no-nvidia-workaround`), `-v` (`--nvidia-workaround-verbose`). `-v` is distinct from the uppercase `-V` used for `--version`.
- Documents the new flag and the short aliases in the man-page (`docs/mdns-browser.1`) and the README command-line options section.

## Testing performed
- `cargo fmt -- --check`, `cargo clippy --workspace --tests -- -D warnings`, `cargo clippy --release --workspace --tests -- -D warnings`
- `cargo nextest run --profile ci --workspace` (68 passed)
- `leptosfmt --check src`, `actionlint .github/workflows/*.yml`

This complements the existing opt-in NVIDIA workaround flags.

🤖 Generated with [opencode](https://opencode.ai)