### PR TITLE
docs: adopt Git/AI-attribution and engineering-judgment conventions from zux

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,43 @@ All source files must include:
 - CI runs on Ubuntu, macOS, and Windows - ensure cross-platform compatibility
 - The project uses auditible binaries with `cargo-auditable`
 
-## Before Committing
+## Git Conventions
+
+- Conventional commits: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, etc.
+- All changes land via pull requests on a branch (direct pushes to `main` are blocked). Create a `feat/...`, `fix/...`, etc. branch and open a PR.
+
+### When to commit
+
+- Do not leave completed work uncommitted. Once a logical unit of work is done and the tree is green, commit it — don't wait to be asked. This is a standing authorization: treat every task as implicitly including "and commit your work" unless the user says otherwise.
+- Commit as you go, not all at once at the end. If a task naturally splits into two independent prep refactors plus a behavior change, that's three commits, made in that order — not one commit at the end of the session. (Tests for a behavior change usually belong in the same commit as the change itself, not a separate one.)
+
+### How to structure commits
+
+- Prefer a fine-grained commit history. Commits should be as small as possible while still being meaningful and self-contained.
+- Every commit must compile and pass all tests. No "WIP" commits, no commits that leave the tree broken and rely on a follow-up to fix it.
+- Every commit must be formatted and lint-clean before committing — run `cargo fmt`, `leptosfmt`, and `cargo clippy --workspace --tests -- -D warnings` (plus `cargo clippy --release ...` for release builds) and don't introduce a warning in one commit that a later commit (or the user) cleans up.
+- Commit messages explain why, not what. The diff already shows what changed; the message should capture the motivation, the constraint, or the bug being fixed. If the reason is obvious from a one-line subject, no body is needed — but never paraphrase the diff.
+- Separate preparatory refactorings from behavior changes. If a fix or feature is easier to review after a refactor, land the refactor in its own commit first. Pure refactors must be behavior-preserving.
+- Wrap the message body to 72 characters. The subject may go up to 80 characters, or a little more if needed to convey a good single-line summary; the body wraps at 72 exactly.
+
+### Attributing AI usage
+
+- Every commit gets both trailers in a trailer block at the end, after a blank line. Use `--trailer` on the command line so no wrapping or manual formatting is needed:
+  - `Co-authored-by: opencode <noreply@opencode.ai>`
+  - `Assisted-by: opencode (<model-name>)`
+- Trailers are exempt from the 72-character body wrap.
+- Never use `--author` or `--committer` for this attribution. The release-notes tooling derives the credited `@username` from the commit author, so doing so would replace the user with the bot throughout the release notes.
+- `amend!` commits must repeat both trailers in the replacement message body. The replacement overwrites the target's message wholesale, so omitting them strips attribution from the target when the user folds the amend in with `--autosquash`. Plain `fixup!` commits need no special care: their message is discarded on autosquash and the target keeps its own trailers.
+
+### Iterate with fixup! commits
+
+- When refining work that's already committed — adjusting an approach, incorporating an idea from elsewhere, fixing something that belongs to the same logical unit — create a fixup against the target commit (`git commit --fixup=<sha>`) so it sits alongside its target, ready for the user to fold in later with `git rebase --autosquash`. Don't pile follow-up commits on top with the intent of squashing them later.
+- This holds even when the target is HEAD: use `git commit --fixup`, not `git commit --amend`. An `--amend` rewrites the commit on the spot and skips the reviewable checkpoint a fixup provides.
+- If the changes don't map cleanly onto existing commits — they cut across several of them, or restructure something at a different layer than any existing commit naturally owns — stop and ask the user how to proceed.
+- After writing a fixup, re-read the target commit's message. If anything in that message has become inaccurate because of the fixup, use an `amend!` commit instead (`git commit --fixup=amend:<sha>`).
+- Never squash the fixups yourself. Leave them in the history as separate commits; collapsing them into their targets is the user's action, taken once they've reviewed the iterations. If you think the history is ready to collapse, say so and leave it to them.
+
+### Before Committing (checks)
 
 1. **Create a branch** for your changes (never commit directly to main)
 2. **Run the full CI check**:
@@ -254,6 +290,8 @@ After all checks pass and changes are committed:
 ## Before Modifying Workflows or Actions
 
 When changing any GitHub Actions workflows (.github/workflows/*.yml) or actions (.github/actions/*/action.yml):
+
+- Pin actions to commit SHAs with a `# vN` comment (e.g., `@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7`).
 
 1. **Run actionlint validation**:
    ```bash
@@ -286,9 +324,29 @@ When changing any GitHub Actions workflows (.github/workflows/*.yml) or actions 
      run: gh command "$MY_VAR"
    ```
 
-5. **Re-run actionlint** after making changes to ensure all issues are resolved.
+ 5. **Re-run actionlint** after making changes to ensure all issues are resolved.
 
 This ensures your workflow changes follow GitHub Actions best practices and will execute correctly.
+
+## Code comments
+
+Comments in source code explain *why* this code is shaped the way it is. They are not the place to narrate the path taken during development — what was tried first, what didn't work, what's "more reliable" or "cleaner" than some alternative. That framing is noise to later readers: the rejected alternative is nowhere in the file, so the comparison is meaningless.
+
+- Avoid phrasings like "we used to … but …", "after trying X, we found Y", or "X rather than Y" where Y is what the code did before the change.
+- The iteration story sometimes belongs in the commit message — the durable record of *why* a change was made — not in the code comment.
+- The check to apply: would you have written this comment if you were writing the file from scratch, with no diff in mind? If not, the sentence belongs in the commit message.
+- If the codebase calls a helper in many places without explanation, your new call site doesn't need one either. A comment there says "something here is unusual"; when nothing is, it's noise.
+
+## Engineering judgment
+
+### Surface decisions
+When a decision surfaces while implementing — a design choice, a tradeoff, a scope cut, an "this turned out harder than expected, so maybe X" — don't quietly make the call and keep going, even if you have a clear recommendation. Stop, lay out the options and your recommendation, and let the user weigh in. Obvious mechanical choices with one sensible answer don't need a checkpoint, but genuine forks — where a reasonable person might pick differently, or where you'd trade away something the plan assumed — do. This applies to unforeseen discoveries (a latent bug, a race, a wrong assumption) too: stop and raise them before designing or writing a fix.
+
+### Don't present "live with the bug" as an option
+When investigating a defect and laying out fix options, "accept the race / leave it as-is / document it and move on" is not one of them. A known race, data corruption, or correctness violation is a bug that needs a real fix. If a real fix is genuinely out of reach, say so plainly; don't dress "no fix" up as a viable option alongside real ones.
+
+### Prefer the cleaner design over the smaller diff
+When a task could be done by tacking onto existing code or by first restructuring it slightly, choose the restructuring. "Minimal change" is not a goal in itself; a readable final state is. The prep-refactor-then-behavior-change pattern exists for exactly this. This is not license for speculative abstraction, but if the current change would be clearer after extracting a method, splitting a function, or adjusting names, that refactor is part of the task.
 
 ## Common Pitfalls to Avoid
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,7 @@ cd src-tauri && cargo fmt -- --check && \
 cd .. && \
 leptosfmt --check src && \
 cargo clippy --workspace --tests -- -D warnings && \
+cargo clippy --release --workspace --tests -- -D warnings && \
 cargo nextest run --profile ci --workspace && \
 actionlint .github/workflows/*.yml
 ```


### PR DESCRIPTION
## Summary
Brings `AGENTS.md` in line with the sibling repo `zux` by adopting conventions that `mdns-browser` was missing:

- **GitHub Actions**: pin actions to commit SHAs with a `# vN` comment.
- **Git Conventions**: dedicated section covering when/how to commit, fine-grained history, AI-attribution trailers (`Co-authored-by` / `Assisted-by`), and the `fixup!`/`amend!` iteration workflow.
- **Code comments**: explain *why*, not the development narrative; don't justify routine call sites.
- **Engineering judgment**: surface decisions, never ship a known bug, prefer the cleaner design over the smaller diff.

Rust/Leptos/Tauri-specific content from the existing doc is preserved. The pre-existing "Never amend commits" pitfall is compatible — it forbids `git commit --amend`, whereas the new `amend!`/`fixup!` workflow uses separate commits.

## Testing performed
Documentation-only change; no code/test impact.

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for Git commit timing, structure, AI attribution, and fixup/amend workflows.
  - Expanded pre-commit check instructions and actionlint guidance.
  - Added recommendations for pinning GitHub Actions to commit SHAs.
  - Included guidelines for code comments and engineering judgment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->