### PR TITLE
fix(ci): set up Rust toolchain before cargo-install git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 🦀 Install Rust toolchain for git-cliff build fallback
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+
       - name: 🔧 Install git-cliff
         uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
         with:

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: 🦀 Install Rust toolchain for git-cliff build fallback
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+
       - name: 🔧 Install git-cliff
         uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
         with:


### PR DESCRIPTION
The release and changelog jobs install git-cliff via cargo-install on
ubuntu-slim but never set up a Rust toolchain. They only succeeded
while the nightly cache-tools pre-warm produced a cache hit; on a
rate-limited cache restore the action falls back to `cargo install`,
which then fails because cargo is absent. Add the stable Rust
toolchain so the fallback build can succeed.

Co-authored-by: opencode <noreply@opencode.ai>
Assisted-by: opencode (hy3-free)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated release and changelog generation reliability by adding a stable Rust toolchain setup.
  * Ensured fallback builds for changelog tooling can complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->