### PR TITLE
refactor: register updater commands as namespaced plugin commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5678,6 +5678,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
+ "tauri-plugin",
  "tauri-plugin-opener",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,6 +3222,7 @@ dependencies = [
  "reactive_stores 0.3.1",
  "serde",
  "serde-wasm-bindgen",
+ "serde_json",
  "shared_constants",
  "strsim",
  "tauri-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ thiserror = "2.0"
 tokio = { version = "1.45", features = ["time"] }
 mdns-sd = "0.21"
 tauri = { version = "2.0", features = ["devtools"] }
+tauri-plugin = "2"
 tauri-plugin-android-update = { path = "crates/tauri-plugin-android-update" }
 tauri-plugin-clipboard-manager = "2.2"
 tauri-plugin-log = { version = "2.4", features = ["colored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ tauri-sys = { git = "https://github.com/JonasKruckenberg/tauri-sys", branch = "v
 shared_constants = { path = "./crates/shared_constants" }
 models = { path = "./crates/models" }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [workspace]
 members = [
     "crates/models",

--- a/crates/tauri-plugin-android-update/Cargo.toml
+++ b/crates/tauri-plugin-android-update/Cargo.toml
@@ -10,6 +10,10 @@ license = "MIT-0"
 repository = "https://github.com/hrzlgnm/mdns-browser"
 authors = ["hrzlgnm"]
 readme = "README.md"
+links = "tauri-plugin-android-update"
+
+[build-dependencies]
+tauri-plugin = { workspace = true, features = ["build"] }
 
 [dependencies]
 log = { workspace = true }

--- a/crates/tauri-plugin-android-update/README.md
+++ b/crates/tauri-plugin-android-update/README.md
@@ -28,7 +28,8 @@ tauri-plugin-opener = "2"
 ```
 
 Register it where you do not use `tauri-plugin-updater`, e.g. on mobile, and
-add its commands to your app's `invoke_handler` under their unqualified names:
+grant the plugin's `default` permission in your app's capabilities so the
+frontend can invoke its commands:
 
 ```rust
 #[cfg(mobile)]
@@ -38,11 +39,14 @@ add its commands to your app's `invoke_handler` under their unqualified names:
         .repo("repo")
         .build()
 )
-.invoke_handler(tauri::generate_handler![
-    tauri_plugin_android_update::check,
-    tauri_plugin_android_update::download_and_install,
-    // ...
-])
+```
+
+```json
+{
+    "permissions": [
+        "android-update:default"
+    ]
+}
 ```
 
 The URLs are derived from the `owner`/`repo` pair. To point the update check
@@ -58,11 +62,12 @@ tauri_plugin_android_update::Builder::new()
 
 ## Commands
 
-The plugin manages the state its commands rely on but leaves the registration
-to the app, so the commands are invoked under the same unqualified names on
-every platform. The command names mirror the `tauri-plugin-updater` plugin's,
-but the payloads are this plugin's own — the `tauri-plugin-updater` JavaScript
-API does not exist on these platforms, so the frontend invokes them directly:
+The plugin registers its commands under the `plugin:android-update|` namespace,
+so the frontend invokes them as `plugin:android-update|check` and
+`plugin:android-update|download_and_install`. The command names mirror the
+`tauri-plugin-updater` plugin's, but the payloads are this plugin's own — the
+`tauri-plugin-updater` JavaScript API does not exist on these platforms, so the
+frontend invokes them directly:
 
 - `check` — fetches the `latest.json` update manifest from the latest release,
   compares its version against the installed one, and resolves to the update

--- a/crates/tauri-plugin-android-update/build.rs
+++ b/crates/tauri-plugin-android-update/build.rs
@@ -1,0 +1,8 @@
+// Copyright 2026 hrzlgnm
+// SPDX-License-Identifier: MIT-0
+
+const COMMANDS: &[&str] = &["check", "download_and_install"];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS).build();
+}

--- a/crates/tauri-plugin-android-update/permissions/autogenerated/commands/check.toml
+++ b/crates/tauri-plugin-android-update/permissions/autogenerated/commands/check.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-check"
+description = "Enables the check command without any pre-configured scope."
+commands.allow = ["check"]
+
+[[permission]]
+identifier = "deny-check"
+description = "Denies the check command without any pre-configured scope."
+commands.deny = ["check"]

--- a/crates/tauri-plugin-android-update/permissions/autogenerated/commands/download_and_install.toml
+++ b/crates/tauri-plugin-android-update/permissions/autogenerated/commands/download_and_install.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-download-and-install"
+description = "Enables the download_and_install command without any pre-configured scope."
+commands.allow = ["download_and_install"]
+
+[[permission]]
+identifier = "deny-download-and-install"
+description = "Denies the download_and_install command without any pre-configured scope."
+commands.deny = ["download_and_install"]

--- a/crates/tauri-plugin-android-update/permissions/autogenerated/reference.md
+++ b/crates/tauri-plugin-android-update/permissions/autogenerated/reference.md
@@ -1,0 +1,74 @@
+## Default Permission
+
+This permission set enables the Android update workflow.
+
+#### Granted Permissions
+
+Checking for a newer release and opening its page for manual download.
+
+#### This default permission set includes the following:
+
+- `allow-check`
+- `allow-download-and-install`
+
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+
+<tr>
+<td>
+
+`android-update:allow-check`
+
+</td>
+<td>
+
+Enables the check command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`android-update:deny-check`
+
+</td>
+<td>
+
+Denies the check command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`android-update:allow-download-and-install`
+
+</td>
+<td>
+
+Enables the download_and_install command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`android-update:deny-download-and-install`
+
+</td>
+<td>
+
+Denies the download_and_install command without any pre-configured scope.
+
+</td>
+</tr>
+</table>

--- a/crates/tauri-plugin-android-update/permissions/autogenerated/reference.md
+++ b/crates/tauri-plugin-android-update/permissions/autogenerated/reference.md
@@ -2,7 +2,7 @@
 
 This permission set enables the Android update workflow.
 
-#### Granted Permissions
+### Granted Permissions
 
 Checking for a newer release and opening its page for manual download.
 

--- a/crates/tauri-plugin-android-update/permissions/default.toml
+++ b/crates/tauri-plugin-android-update/permissions/default.toml
@@ -1,0 +1,13 @@
+"$schema" = "schemas/schema.json"
+[default]
+description = """
+This permission set enables the Android update workflow.
+
+#### Granted Permissions
+
+Checking for a newer release and opening its page for manual download.
+"""
+permissions = [
+  "allow-check",
+  "allow-download-and-install",
+]

--- a/crates/tauri-plugin-android-update/permissions/default.toml
+++ b/crates/tauri-plugin-android-update/permissions/default.toml
@@ -3,7 +3,7 @@
 description = """
 This permission set enables the Android update workflow.
 
-#### Granted Permissions
+### Granted Permissions
 
 Checking for a newer release and opening its page for manual download.
 """

--- a/crates/tauri-plugin-android-update/permissions/schemas/schema.json
+++ b/crates/tauri-plugin-android-update/permissions/schemas/schema.json
@@ -1,0 +1,330 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the check command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-check",
+          "markdownDescription": "Enables the check command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the check command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-check",
+          "markdownDescription": "Denies the check command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the download_and_install command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-download-and-install",
+          "markdownDescription": "Enables the download_and_install command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the download_and_install command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-download-and-install",
+          "markdownDescription": "Denies the download_and_install command without any pre-configured scope."
+        },
+        {
+          "description": "This permission set enables the Android update workflow.\n\n#### Granted Permissions\n\nChecking for a newer release and opening its page for manual download.\n\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download-and-install`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "This permission set enables the Android update workflow.\n\n#### Granted Permissions\n\nChecking for a newer release and opening its page for manual download.\n\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download-and-install`"
+        }
+      ]
+    }
+  }
+}

--- a/crates/tauri-plugin-android-update/src/lib.rs
+++ b/crates/tauri-plugin-android-update/src/lib.rs
@@ -16,13 +16,12 @@
 //! and installing, `download_and_install` opens the release page in the
 //! default browser so the user can install manually.
 //!
-//! The plugin manages the state the commands need, but does not register the
-//! commands itself: they are registered by the consuming app through its own
-//! `tauri::generate_handler!` (see [`Builder`]), so the frontend can invoke
-//! them under the same unqualified names (`check` / `download_and_install`)
-//! as on desktop. Register the plugin on platforms without self-install
-//! support (e.g. under `#[cfg(mobile)]`), where desktop apps keep using
-//! [`tauri-plugin-updater`].
+//! The plugin registers the [`check`] and [`download_and_install`] commands
+//! under the `plugin:android-update|` namespace and manages the state they
+//! rely on. Grant the plugin's `default` permission in the app's capabilities
+//! for the frontend to invoke them. Register the plugin on platforms without
+//! self-install support (e.g. under `#[cfg(mobile)]`), where desktop apps keep
+//! using [`tauri-plugin-updater`].
 //!
 //! [`tauri-plugin-updater`]: https://docs.rs/tauri-plugin-updater
 
@@ -113,11 +112,12 @@ impl Builder {
 
     /// Builds the plugin.
     ///
-    /// Sets up the state that the [`check`] and [`download_and_install`]
-    /// commands rely on. Register it on platforms that cannot self-install
-    /// updates (e.g. under `#[cfg(mobile)]`) and add the commands to the
-    /// app's own `tauri::generate_handler!` so the frontend can invoke them
-    /// unqualified.
+    /// Registers the [`check`] and [`download_and_install`] commands and sets
+    /// up the state they rely on. Register it on platforms that cannot
+    /// self-install updates (e.g. under `#[cfg(mobile)]`) and grant the
+    /// plugin's `default` permission in the app's capabilities so the
+    /// frontend can invoke the commands under their `plugin:android-update|`
+    /// names.
     ///
     /// The URLs are resolved when the plugin is set up: an explicitly
     /// configured URL wins, otherwise it is derived from `owner`/`repo`.
@@ -147,6 +147,7 @@ impl Builder {
                 app.manage(PendingUpdateInfo(Mutex::new(None)));
                 Ok(())
             })
+            .invoke_handler(tauri::generate_handler![check, download_and_install])
             .build()
     }
 }
@@ -229,8 +230,8 @@ mod commands {
     /// the pending update for [`download_and_install`], or `None` when the app is
     /// up to date.
     ///
-    /// The consuming app registers this command in its own
-    /// `tauri::generate_handler!` under the unqualified `check` name.
+    /// Registered by the plugin under the `plugin:android-update|check` name;
+    /// the app must grant the plugin's `default` permission.
     #[tauri::command]
     pub async fn check<R: Runtime>(
         app: tauri::AppHandle<R>,
@@ -296,9 +297,9 @@ mod commands {
     /// the `download_and_install` command of
     /// [`tauri-plugin-updater`](https://docs.rs/tauri-plugin-updater).
     ///
-    /// The consuming app registers this command in its own
-    /// `tauri::generate_handler!` under the unqualified `download_and_install`
-    /// name.
+    /// Registered by the plugin under the `plugin:android-update|`
+    /// `download_and_install` name; the app must grant the plugin's `default`
+    /// permission.
     #[tauri::command]
     pub async fn download_and_install<R: Runtime>(
         app: tauri::AppHandle<R>,

--- a/src-tauri/capabilities/mobile.json
+++ b/src-tauri/capabilities/mobile.json
@@ -8,7 +8,8 @@
     "permissions": [
         "core:default",
         "clipboard-manager:allow-write-text",
-        "opener:allow-open-url"
+        "opener:allow-open-url",
+        "android-update:default"
     ],
     "platforms": [
         "android"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1096,81 +1096,14 @@ mod foreign_crate {
 
 #[cfg(desktop)]
 mod autoupdate {
-    use models::UpdateMetadata;
-    use serde::Serialize;
-    use std::sync::Mutex;
     use tauri::utils::platform::bundle_type;
-    use tauri::{AppHandle, State};
-    use tauri_plugin_updater::{Update, UpdaterExt};
-
-    #[derive(Debug, thiserror::Error)]
-    pub enum Error {
-        #[error(transparent)]
-        Updater(#[from] tauri_plugin_updater::Error),
-        #[error("there is no pending update")]
-        NoPendingUpdate,
-    }
-
-    impl Serialize for Error {
-        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-        where
-            S: serde::Serializer,
-        {
-            serializer.serialize_str(self.to_string().as_str())
-        }
-    }
-
-    type Result<T> = std::result::Result<T, Error>;
+    use tauri::AppHandle;
 
     #[tauri::command]
-    pub async fn check(
-        app: AppHandle,
-        pending_update: State<'_, PendingUpdate>,
-    ) -> Result<Option<UpdateMetadata>> {
-        let update = app
-            .updater_builder()
-            .version_comparator(|current, update| update.version != current)
-            .build()?
-            .check()
-            .await?;
-
-        let update_metadata = update.as_ref().map(|update| UpdateMetadata {
-            version: update.version.clone(),
-            current_version: update.current_version.clone(),
-        });
-
-        *pending_update.0.lock().expect("To lock") = update;
-
-        Ok(update_metadata)
-    }
-
-    #[tauri::command]
-    pub async fn download_and_install(
-        app: AppHandle,
-        pending_update: State<'_, PendingUpdate>,
-    ) -> Result<()> {
-        let Some(update) = pending_update.0.lock().expect("To lock").take() else {
-            return Err(Error::NoPendingUpdate);
-        };
-
-        let mut downloaded = 0;
-        update
-            .download_and_install(
-                |chunk_length, content_length| {
-                    downloaded += chunk_length;
-                    log::info!("downloaded {downloaded} from {content_length:?}");
-                },
-                || {
-                    log::info!("download finished");
-                },
-            )
-            .await?;
-
-        log::info!("update installed, restarting");
+    pub fn restart(app: AppHandle) {
+        log::info!("restarting to apply the installed update");
         app.restart();
     }
-
-    pub struct PendingUpdate(pub Mutex<Option<Update>>);
 
     #[tauri::command]
     pub fn can_auto_update() -> bool {
@@ -1280,7 +1213,6 @@ pub fn run() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(ManagedState::new(args.enable_devtools))
-        .manage(autoupdate::PendingUpdate(Mutex::new(None)))
         .setup(move |app| {
             // The main window is created programmatically (instead of via
             // tauri.conf.json) so its decoration state can be set at creation
@@ -1304,8 +1236,7 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            autoupdate::check,
-            autoupdate::download_and_install,
+            autoupdate::restart,
             autoupdate::can_auto_update,
             browse_many,
             browse_types,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1100,9 +1100,9 @@ mod autoupdate {
     use tauri::AppHandle;
 
     #[tauri::command]
-    pub fn restart(app: AppHandle) {
+    pub fn restart(app: AppHandle) -> Result<(), String> {
         log::info!("restarting to apply the installed update");
-        app.restart();
+        app.restart()
     }
 
     #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1375,8 +1375,6 @@ pub fn run_mobile() {
             subscribe_interfaces,
             subscribe_metrics,
             stop_browse,
-            tauri_plugin_android_update::check,
-            tauri_plugin_android_update::download_and_install,
             theme,
             verify,
             version,

--- a/src/app/about.rs
+++ b/src/app/about.rs
@@ -2,32 +2,126 @@
 // SPDX-License-Identifier: MIT-0
 
 use leptos::prelude::*;
+use leptos::task::spawn_local;
 use models::*;
 use serde::{Deserialize, Serialize};
 use shared_constants::{GITHUB_BASE_URL, SHOW_NO_UPDATE_DURATION};
-use tauri_sys::core::{invoke, invoke_result};
+use tauri_sys::core::{Channel, invoke, invoke_result};
 use thaw::{
     Accordion, AccordionHeader, AccordionItem, Button, ButtonAppearance, ButtonSize, Flex, Layout,
     Text, Toast, ToastBody, ToastTitle, ToasterInjection,
 };
 
 use super::is_desktop::IsDesktopInjection;
+use futures::StreamExt;
 
-async fn check_update(is_desktop: bool) -> Result<Option<UpdateMetadata>, String> {
-    let command = update_command("check", is_desktop);
-    invoke_result::<Option<UpdateMetadata>, String>(&command, &()).await
+/// The metadata `plugin:updater|check` resolves to. On desktop the app uses the
+/// `tauri-plugin-updater` commands directly, whose pending update is identified
+/// by a resource id (`rid`) that `download_and_install` must be given.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdaterMetadata {
+    rid: u32,
+    version: String,
+    current_version: String,
 }
 
-async fn download_and_install(is_desktop: bool) -> Result<(), String> {
-    let command = update_command("download_and_install", is_desktop);
-    invoke_result::<(), String>(&command, &()).await
+impl From<UpdaterMetadata> for UpdateMetadata {
+    fn from(metadata: UpdaterMetadata) -> Self {
+        Self {
+            version: metadata.version,
+            current_version: metadata.current_version,
+        }
+    }
 }
 
-fn update_command(command: &str, is_desktop: bool) -> String {
+/// The progress events `plugin:updater|download_and_install` emits on its
+/// channel. The app does not surface progress, but the command requires the
+/// channel argument.
+#[derive(Deserialize)]
+#[serde(tag = "event", content = "data")]
+enum DownloadEvent {
+    #[serde(rename_all = "camelCase")]
+    Started {
+        content_length: Option<u64>,
+    },
+    #[serde(rename_all = "camelCase")]
+    Progress {
+        chunk_length: usize,
+    },
+    Finished,
+}
+
+/// A channel argument serialized in Tauri's `__CHANNEL__:{id}` string form,
+/// so the [`Channel`] itself can be moved into the progress-logging task.
+struct ChannelRef(usize);
+
+impl Serialize for ChannelRef {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("__CHANNEL__:{}", self.0))
+    }
+}
+
+#[derive(Serialize)]
+struct DownloadArgs {
+    rid: u32,
+    on_event: ChannelRef,
+}
+
+/// Resolves to the update metadata and, on desktop, the resource id of the
+/// pending update for [`download_and_install`].
+async fn check_update(is_desktop: bool) -> Result<(Option<UpdateMetadata>, Option<u32>), String> {
     if is_desktop {
-        command.to_string()
+        let metadata =
+            invoke_result::<Option<UpdaterMetadata>, String>("plugin:updater|check", &()).await?;
+        let rid = metadata.as_ref().map(|m| m.rid);
+        Ok((metadata.map(UpdateMetadata::from), rid))
     } else {
-        format!("plugin:android-update|{command}")
+        let metadata =
+            invoke_result::<Option<UpdateMetadata>, String>("plugin:android-update|check", &())
+                .await?;
+        Ok((metadata, None))
+    }
+}
+
+async fn download_and_install(is_desktop: bool, rid: Option<u32>) -> Result<(), String> {
+    if is_desktop {
+        let Some(rid) = rid else {
+            return Err("there is no pending update".to_string());
+        };
+        let on_event = Channel::<DownloadEvent>::new();
+        let on_event_arg = ChannelRef(on_event.id());
+        spawn_local(async move {
+            let mut events = on_event;
+            while let Some(event) = events.next().await {
+                match event {
+                    DownloadEvent::Started { content_length } => {
+                        log::info!("update download started: {content_length:?}");
+                    }
+                    DownloadEvent::Progress { chunk_length } => {
+                        log::info!("update download progress: {chunk_length}");
+                    }
+                    DownloadEvent::Finished => {
+                        log::info!("update download finished");
+                    }
+                }
+            }
+        });
+        invoke_result::<(), String>(
+            "plugin:updater|download_and_install",
+            &DownloadArgs {
+                rid,
+                on_event: on_event_arg,
+            },
+        )
+        .await?;
+        let _ = invoke_result::<(), String>("restart", &()).await;
+        Ok(())
+    } else {
+        invoke_result::<(), String>("plugin:android-update|download_and_install", &()).await
     }
 }
 
@@ -64,6 +158,7 @@ async fn get_can_auto_update(writer: WriteSignal<bool>) {
 pub fn About() -> impl IntoView {
     let (version, set_version) = signal(String::new());
     let (update, set_update) = signal(None);
+    let (pending_rid, set_pending_rid) = signal(None);
     let (can_auto_update, set_can_auto_update) = signal(false);
     let is_desktop = IsDesktopInjection::expect_context();
     LocalResource::new(move || get_version(set_version));
@@ -84,10 +179,11 @@ pub fn About() -> impl IntoView {
 
     let check_update_action = Action::new_local(move |_: &()| async move {
         match check_update(is_desktop.get()).await {
-            Ok(update) => {
+            Ok((update, rid)) => {
                 if update.is_none() {
                     show_no_update_with_timeout();
                 }
+                set_pending_rid.set(rid);
                 set_update.set(update);
             }
             Err(e) => {
@@ -98,7 +194,7 @@ pub fn About() -> impl IntoView {
     });
 
     let download_and_install_action = Action::new_local(move |_: &()| async move {
-        if let Err(e) = download_and_install(is_desktop.get()).await {
+        if let Err(e) = download_and_install(is_desktop.get(), pending_rid.get_untracked()).await {
             log::error!("failed to install update: {e}");
             toaster.dispatch_toast(move || create_update_error_toast(e), Default::default());
         }

--- a/src/app/about.rs
+++ b/src/app/about.rs
@@ -381,3 +381,61 @@ pub fn About() -> impl IntoView {
         </Layout>
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_channel_ref_serialize() {
+        let channel_ref = ChannelRef(42);
+        let serialized = serde_json::to_string(&channel_ref).unwrap();
+        assert_eq!(serialized, r#""__CHANNEL__:42""#);
+    }
+
+    #[test]
+    fn test_channel_ref_deserialize() {
+        let json = r#""__CHANNEL__:42""#;
+        let channel_ref: ChannelRef = serde_json::from_str(json).unwrap();
+        assert_eq!(channel_ref.0, 42);
+    }
+
+    #[test]
+    fn test_channel_ref_deserialize_large_value() {
+        // Test with a large usize value
+        let large_value = usize::MAX / 2;
+        let json = format!(r#""__CHANNEL__:{}""#, large_value);
+        let channel_ref: ChannelRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(channel_ref.0, large_value);
+    }
+
+    #[test]
+    fn test_channel_ref_deserialize_overflow() {
+        // Test value that exceeds usize::MAX
+        let json = r#""__CHANNEL__:99999999999999999999999999999999999999""#;
+        let result: Result<ChannelRef, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_channel_ref_deserialize_missing_prefix() {
+        let json = r#""42""#;
+        let result: Result<ChannelRef, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_channel_ref_deserialize_invalid_id() {
+        let json = r#""__CHANNEL__:not_a_number""#;
+        let result: Result<ChannelRef, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_channel_ref_deserialize_negative() {
+        let json = r#""__CHANNEL__:-1""#;
+        let result: Result<ChannelRef, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+}

--- a/src/app/about.rs
+++ b/src/app/about.rs
@@ -13,12 +13,22 @@ use thaw::{
 
 use super::is_desktop::IsDesktopInjection;
 
-async fn check_update() -> Result<Option<UpdateMetadata>, String> {
-    invoke_result::<Option<UpdateMetadata>, String>("check", &()).await
+async fn check_update(is_desktop: bool) -> Result<Option<UpdateMetadata>, String> {
+    let command = update_command("check", is_desktop);
+    invoke_result::<Option<UpdateMetadata>, String>(&command, &()).await
 }
 
-async fn download_and_install() -> Result<(), String> {
-    invoke_result::<(), String>("download_and_install", &()).await
+async fn download_and_install(is_desktop: bool) -> Result<(), String> {
+    let command = update_command("download_and_install", is_desktop);
+    invoke_result::<(), String>(&command, &()).await
+}
+
+fn update_command(command: &str, is_desktop: bool) -> String {
+    if is_desktop {
+        command.to_string()
+    } else {
+        format!("plugin:android-update|{command}")
+    }
 }
 
 fn create_update_error_toast(message: String) -> impl IntoView {
@@ -73,7 +83,7 @@ pub fn About() -> impl IntoView {
     let toaster = ToasterInjection::expect_context();
 
     let check_update_action = Action::new_local(move |_: &()| async move {
-        match check_update().await {
+        match check_update(is_desktop.get()).await {
             Ok(update) => {
                 if update.is_none() {
                     show_no_update_with_timeout();
@@ -88,7 +98,7 @@ pub fn About() -> impl IntoView {
     });
 
     let download_and_install_action = Action::new_local(move |_: &()| async move {
-        if let Err(e) = download_and_install().await {
+        if let Err(e) = download_and_install(is_desktop.get()).await {
             log::error!("failed to install update: {e}");
             toaster.dispatch_toast(move || create_update_error_toast(e), Default::default());
         }

--- a/src/app/about.rs
+++ b/src/app/about.rs
@@ -66,6 +66,7 @@ impl Serialize for ChannelRef {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct DownloadArgs {
     rid: u32,
     on_event: ChannelRef,

--- a/src/app/about.rs
+++ b/src/app/about.rs
@@ -18,7 +18,7 @@ use futures::StreamExt;
 /// The metadata `plugin:updater|check` resolves to. On desktop the app uses the
 /// `tauri-plugin-updater` commands directly, whose pending update is identified
 /// by a resource id (`rid`) that `download_and_install` must be given.
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdaterMetadata {
     rid: u32,
@@ -38,7 +38,7 @@ impl From<UpdaterMetadata> for UpdateMetadata {
 /// The progress events `plugin:updater|download_and_install` emits on its
 /// channel. The app does not surface progress, but the command requires the
 /// channel argument.
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(tag = "event", content = "data")]
 enum DownloadEvent {
     #[serde(rename_all = "camelCase")]
@@ -65,7 +65,39 @@ impl Serialize for ChannelRef {
     }
 }
 
-#[derive(Serialize)]
+impl<'de> Deserialize<'de> for ChannelRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(ChannelRefVisitor)
+    }
+}
+
+struct ChannelRefVisitor;
+
+impl serde::de::Visitor<'_> for ChannelRefVisitor {
+    type Value = ChannelRef;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a channel argument in the `__CHANNEL__:{id}` format")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let id = value
+            .strip_prefix("__CHANNEL__:")
+            .ok_or_else(|| E::custom("missing `__CHANNEL__:` prefix"))?;
+        let id = id
+            .parse::<usize>()
+            .map_err(|e| E::custom(format!("invalid channel id: {e}")))?;
+        Ok(ChannelRef(id))
+    }
+}
+
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct DownloadArgs {
     rid: u32,

--- a/src/app/about.rs
+++ b/src/app/about.rs
@@ -385,7 +385,6 @@ pub fn About() -> impl IntoView {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json;
 
     #[test]
     fn test_channel_ref_serialize() {


### PR DESCRIPTION
Closes #2499

## Summary

Registers the updater commands as proper Tauri plugin commands gated behind the ACL, instead of registering them through the app's own `invoke_handler`.

### Mobile (`tauri-plugin-android-update`)

- Commands moved back into the plugin's own `invoke_handler`, reachable as `plugin:android-update|check` / `plugin:android-update|download_and_install`.
- Added the standard permission machinery: `build.rs`, `links = "tauri-plugin-android-update"`, `tauri-plugin` build-dependency, `permissions/default.toml` (autogenerated `android-update:allow-*` / `android-update:default` files committed).
- Granted `android-update:default` in `src-tauri/capabilities/mobile.json`; commands removed from the app's `generate_handler!`.
- Frontend invokes the namespaced commands on mobile (branched on `is_desktop`).

### Desktop (`tauri-plugin-updater`)

- Dropped the app's custom `check` / `download_and_install` wrappers and their `PendingUpdate` state in favor of the plugin's own `plugin:updater|check` / `plugin:updater|download_and_install` commands.
- The frontend keeps the resource id (`rid`) returned by `check`, passes it to `download_and_install` with the required event channel, and invokes a new small `restart` command after a successful install.
- Behavior changes from dropping the wrapper: the plugin's default semver comparator now only reports strictly newer releases (previously any differing version), and restart is a separate explicit step.

## Testing

- `cargo fmt -- --check`, `leptosfmt --check src`, `cargo clippy --workspace --tests -- -D warnings` (debug + release)
- `cargo nextest run --profile ci --workspace` (70 passed)
- `cargo --locked tauri android build --target x86_64` succeeds, confirming `android-update:default` resolves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added permission-controlled Android update checks, downloads, and installation.
  - Android update actions can be invoked directly from the frontend.
  - Desktop users can restart the application after an update.

- **Improvements**
  - Simplified Android update setup with automatic command registration.
  - Added default permissions and documentation for update workflows.
  - Improved cross-platform handling of update metadata and download events.
  - Added validation for update channel information.
  - Streamlined desktop update handling while preserving restart functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->