### PR TITLE
ci: add publish workflow for tauri-plugin-android-update crate

### DIFF
--- a/.github/workflows/publish-tauri-plugin-android-update.yml
+++ b/.github/workflows/publish-tauri-plugin-android-update.yml
@@ -51,9 +51,11 @@ jobs:
           fetch-depth: 0
 
       - name: 🛡️ Verify RULESET_ID secret is configured
+        env:
+          RULESET_ID: ${{ secrets.RULESET_ID }}
         run: |
-          if [ -z "${{ secrets.RULESET_ID }}" ]; then
-            echo "Error: secrets.RULESET_ID is not set. Please configure the RULESET_ID secret in repository settings."
+          if [ -z "$RULESET_ID" ]; then
+            echo "Error: RULESET_ID secret is not set. Please configure the RULESET_ID secret in repository settings."
             echo "This secret should contain the ID of the ruleset used to disable enforcement during version bump."
             exit 1
           fi
@@ -74,14 +76,17 @@ jobs:
       - name: 🔢 Bump semantic version
         id: version
         shell: bash
+        env:
+          BUMP_VERSION: ${{ inputs.bump_version }}
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "tauri-plugin-android-update") | .version')
-          if [ "${{ inputs.dry-run }}" = "true" ]; then
-            if [ "${{ inputs.bump_version }}" = "none" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
+            if [ "$BUMP_VERSION" = "none" ]; then
               NEW_VERSION="$CURRENT_VERSION"
             else
               IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-              case "${{ inputs.bump_version }}" in
+              case "$BUMP_VERSION" in
                 "patch")
                   NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
                   ;;
@@ -96,8 +101,8 @@ jobs:
             echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
             echo "Dry run: would bump from $CURRENT_VERSION to $NEW_VERSION"
           else
-            if [ "${{ inputs.bump_version }}" != "none" ]; then
-              cargo set-version --package tauri-plugin-android-update --bump "${{ inputs.bump_version }}"
+            if [ "$BUMP_VERSION" != "none" ]; then
+              cargo set-version --package tauri-plugin-android-update --bump "$BUMP_VERSION"
               CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "tauri-plugin-android-update") | .version')
             fi
             echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
@@ -145,10 +150,12 @@ jobs:
 
       - name: 💾🏷️⬆️ Commit, tag and push
         if: (!inputs.dry-run)
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           git add -A
-          git commit -S -m "chore(tauri-plugin-android-update): Bump tauri-plugin-android-update to ${{ steps.version.outputs.version }}"
-          git tag -s -a tauri-plugin-android-update-v${{ steps.version.outputs.version }} -m "tauri-plugin-android-update Release v${{ steps.version.outputs.version }}"
+          git commit -S -m "chore(tauri-plugin-android-update): Bump tauri-plugin-android-update to ${VERSION}"
+          git tag -s -a "tauri-plugin-android-update-v${VERSION}" -m "tauri-plugin-android-update Release v${VERSION}"
           git push --follow-tags
 
       - name: 👮 Re-enable enforcement of rules

--- a/.github/workflows/publish-tauri-plugin-android-update.yml
+++ b/.github/workflows/publish-tauri-plugin-android-update.yml
@@ -1,0 +1,188 @@
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT-0
+
+name: Publish tauri-plugin-android-update
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_version:
+        description: Version bump type
+        required: true
+        type: choice
+        options:
+          - none
+          - patch
+          - minor
+          - major
+        default: patch
+      dry-run:
+        description: Dry run (no commits/tags/releases)
+        required: true
+        type: boolean
+        default: false
+      publish:
+        description: Publish to crates.io after version bump
+        required: true
+        type: boolean
+        default: true
+
+concurrency:
+  group: ruleset-modification
+  cancel-in-progress: false
+
+jobs:
+  bump_version:
+    permissions:
+      actions: write
+      contents: write
+    runs-on: ubuntu-latest
+    name: ⬆️ Bump version
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tagName: tauri-plugin-android-update-v${{ steps.version.outputs.version}}
+    env:
+      GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+      RULESET: repos/${{github.repository}}/rulesets/${{ secrets.RULESET_ID }}
+    steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: 🛡️ Verify RULESET_ID secret is configured
+        run: |
+          if [ -z "${{ secrets.RULESET_ID }}" ]; then
+            echo "Error: secrets.RULESET_ID is not set. Please configure the RULESET_ID secret in repository settings."
+            echo "This secret should contain the ID of the ruleset used to disable enforcement during version bump."
+            exit 1
+          fi
+          echo "RULESET_ID secret is configured"
+
+      - name: 🦀🚀
+        uses: ./.github/actions/setup-rust-cache
+        with:
+          save-cache: false
+
+      - name: 🔧 Install cargo-edit
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+        with:
+          crate: cargo-edit
+          version: 0.13.13
+          locked: true
+
+      - name: 🔢 Bump semantic version
+        id: version
+        shell: bash
+        run: |
+          CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "tauri-plugin-android-update") | .version')
+          if [ "${{ inputs.dry-run }}" = "true" ]; then
+            if [ "${{ inputs.bump_version }}" = "none" ]; then
+              NEW_VERSION="$CURRENT_VERSION"
+            else
+              IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+              case "${{ inputs.bump_version }}" in
+                "patch")
+                  NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+                  ;;
+                "minor")
+                  NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
+                  ;;
+                "major")
+                  NEW_VERSION="$((MAJOR + 1)).0.0"
+                  ;;
+              esac
+            fi
+            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+            echo "Dry run: would bump from $CURRENT_VERSION to $NEW_VERSION"
+          else
+            if [ "${{ inputs.bump_version }}" != "none" ]; then
+              cargo set-version --package tauri-plugin-android-update --bump "${{ inputs.bump_version }}"
+              CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "tauri-plugin-android-update") | .version')
+            fi
+            echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+            echo "Version: $CURRENT_VERSION"
+          fi
+
+      - name: 🔑 Set up SSH signing key
+        if: (!inputs.dry-run)
+        env:
+          SSH_SIGNING_KEY: ${{ secrets.SSH_SIGNING_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_SIGNING_KEY" > ~/.ssh/id_ed25519_signing
+          chmod 600 ~/.ssh/id_ed25519_signing
+          git config --global gpg.format ssh
+          git config --global user.signingKey ~/.ssh/id_ed25519_signing
+          git config --global user.name "hrzlgnm"
+          git config --global user.email "hrzlgnm@users.noreply.github.com"
+
+      - name: ⏳ Temporary disable ruleset enforcement
+        if: (!inputs.dry-run)
+        run: |
+          gh api \
+          -H "Accept: application/vnd.github+json" \
+          "${RULESET}" | jq '.enforcement = "disabled"' | \
+          gh api \
+          --method PUT \
+          -H "Accept: application/vnd.github+json" \
+          "${RULESET}" \
+          --input -
+
+      - name: 🔧 Install git-cliff
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+        with:
+          crate: git-cliff
+          version: 2.13.1
+          locked: true
+
+      - name: 📝 Update CHANGELOG.md
+        if: ${{ !inputs.dry-run }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git-cliff --config cliff-tauri-plugin-android-update.toml --tag "tauri-plugin-android-update-v${VERSION}" --output crates/tauri-plugin-android-update/CHANGELOG.md
+
+      - name: 💾🏷️⬆️ Commit, tag and push
+        if: (!inputs.dry-run)
+        run: |
+          git add -A
+          git commit -S -m "chore(tauri-plugin-android-update): Bump tauri-plugin-android-update to ${{ steps.version.outputs.version }}"
+          git tag -s -a tauri-plugin-android-update-v${{ steps.version.outputs.version }} -m "tauri-plugin-android-update Release v${{ steps.version.outputs.version }}"
+          git push --follow-tags
+
+      - name: 👮 Re-enable enforcement of rules
+        if: (always() && !inputs.dry-run)
+        run: |
+          gh api \
+          -H "Accept: application/vnd.github+json" \
+          "${RULESET}" | jq '.enforcement = "active"' | \
+          gh api \
+          --method PUT \
+          -H "Accept: application/vnd.github+json" \
+          "${RULESET}" \
+          --input -
+
+  publish_crate:
+    needs: [bump_version]
+    if: (inputs.publish && !inputs.dry-run)
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    container: ghcr.io/hrzlgnm/mdns-browser-ubuntu-builder:v1@sha256:ac1df04c169958f2f1caf4ba49ed187ddbb54d062ba5fabd342f98d2e9e5c319
+    name: 📦 Publish to crates.io
+    steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.bump_version == 'none' && github.ref_name || format('tauri-plugin-android-update-v{0}', needs.bump_version.outputs.version) }}
+
+      - name: 🦀🚀
+        uses: ./.github/actions/setup-rust-cache
+
+      - name: 📦 Publish to crates.io
+        run: |
+          cargo publish --package tauri-plugin-android-update
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/cliff-tauri-plugin-android-update.toml
+++ b/cliff-tauri-plugin-android-update.toml
@@ -1,0 +1,130 @@
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT-0
+
+[changelog]
+# changelog header
+header = """
+# Changelog\n
+All notable changes to `tauri-plugin-android-update` will be documented in this file.\n
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This changelog is auto-generated from commits that modify this crate.\n
+"""
+# template for the changelog body
+body = """
+{% if version -%}\
+    ## [{{ version | trim_start_matches(pat="tauri-plugin-android-update-v") }}] - {{ timestamp | date(format="%Y-%m-%d") }} {%- if previous and previous.version %} [compare](https://github.com/hrzlgnm/mdns-browser/compare/{{ previous.version }}...{{ version }}){% endif %}\n
+{% else -%}\
+    ## [Unreleased] {%- if commits and previous and previous.version %} [compare](https://github.com/hrzlgnm/mdns-browser/compare/{{ previous.version }}...HEAD){% endif %}\n
+{% endif -%}\
+{% for group, commits in commits | group_by(attribute="group") %}\
+    {% if group == "Added" -%}\
+        ### Added\n
+    {% elif group == "Fixed" -%}\
+        ### Fixed\n
+    {% elif group == "Changed" -%}\
+        ### Changed\n
+    {% elif group == "Dependencies" -%}\
+        ### Dependencies\n
+    {% elif group == "Security" -%}\
+        ### Security\n
+    {% elif group == "Maintenance" -%}\
+        ### Maintenance\n
+    {% elif group == "Miscellaneous" -%}\
+        ### Miscellaneous\n
+    {% endif -%}\
+    {% for commit in commits -%}\
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif -%}\
+            {{ commit.message | upper_first | trim }}\
+            {% for link in commit.links %} ([{{ link.text }}]({{ link.href }})){% endfor %}\n
+    {% endfor -%}\
+{% endfor %}\
+"""
+# remove the leading and trailing whitespace from the template
+trim = true
+# changelog footer
+footer = ""
+# postprocessors to apply to the changelog
+postprocessors = [
+    { pattern = 'Simlify', replace = 'Simplify' },
+    { pattern = 'hanlding', replace = 'handling' },
+    { pattern = 'verision', replace = 'version' },
+    { pattern = 'compileable', replace = 'compilable' },
+    { pattern = 'thouroughly', replace = 'thoroughly' },
+    { pattern = 'maitained', replace = 'maintained' },
+    { pattern = 'maintainance', replace = 'maintenance' },
+    { pattern = 'maitenance', replace = 'maintenance' },
+    { pattern = 'resovled', replace = 'resolved' },
+    { pattern = 'manully', replace = 'manually' },
+    { pattern = 'manualy', replace = 'manually' },
+    { pattern = 'worflow', replace = 'workflow' },
+    { pattern = 'workfow', replace = 'workflow' },
+    { pattern = 'constanst', replace = 'constants' },
+    { pattern = 'selectin', replace = 'selecting' },
+    { pattern = 'plaforms', replace = 'platforms' },
+    { pattern = 'issuse', replace = 'issues' },
+    { pattern = 'warnins', replace = 'warnings' },
+    { pattern = 'Workaound', replace = 'Workaround' },
+    { pattern = 'bundel', replace = 'bundle' },
+]
+
+[git]
+# parse the commits based on Conventional Commits
+conventional_commits = true
+# filter out unconventional commits
+filter_unconventional = true
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^\\w+\\(ci\\)", group = "Maintenance" },
+    { message = "^feat", group = "Added" },
+    { message = "^fix\\(deps\\)", group = "Dependencies" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^doc", group = "Changed" },
+    { message = "^perf", group = "Changed" },
+    { message = "^refactor", group = "Changed" },
+    { message = "^style", group = "Changed" },
+    { message = "^test", group = "Changed" },
+    { message = "^ci", group = "Maintenance" },
+    { message = "^build", group = "Maintenance" },
+    { message = "^chore\\(deps\\)", group = "Dependencies" },
+    { message = "^chore\\(renovate", skip = true },
+    { message = "^chore\\(arch-aur", skip = true },
+    { message = "^chore\\(void", skip = true },
+    { message = "^chore\\(winget", skip = true },
+    { message = "^chore\\(homebrew", skip = true },
+    { message = "^chore\\(sbom", skip = true },
+    { message = "^chore\\(signing", skip = true },
+    { message = "^chore\\(bundler", skip = true },
+    { message = "^chore\\(publish", skip = true },
+    { message = "^chore\\(version", skip = true },
+    { message = "^chore: update unreleased changelog", skip = true },
+    { message = "^chore\\(android", skip = true },
+    { message = "^chore\\(test", skip = true },
+    { message = "^chore", group = "Changed" },
+    { message = "^security", group = "Security" },
+    { message = "^GHSA-", group = "Security" },
+    { message = "^Bump version", skip = true },
+]
+# protect breaking commits from being skipped
+protect_breaking_commits = true
+# filter out commits that are not matched by a commit_parsers
+filter_commits = true
+# regex for matching tags
+tag_pattern = "tauri-plugin-android-update-v[0-9].*"
+# skip processing the matched tags
+skip_tags = ""
+# ignore processing the matched tags
+ignore_tags = ""
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"
+# regex for extracting issue references
+link_parsers = [
+    { pattern = "#(\\d+)", text = "#${1}", href = "https://github.com/hrzlgnm/mdns-browser/pull/${1}" },
+]
+# glob patterns to include in the changelog
+include_paths = ["crates/tauri-plugin-android-update/**"]
+# glob patterns to exclude from the changelog
+exclude_paths = []

--- a/typos.toml
+++ b/typos.toml
@@ -1,7 +1,7 @@
 [files]
 ignore-files = true
 ignore-hidden = false
-extend-exclude = [".git/", "cliff.toml", "cliff-webkit2gtk.toml", ".github/cliff-release.toml"]
+extend-exclude = [".git/", "cliff.toml", "cliff-webkit2gtk.toml", "cliff-tauri-plugin-android-update.toml", ".github/cliff-release.toml"]
 
 [default]
 check-filename = true


### PR DESCRIPTION
Closes #2492

Adds a `publish-tauri-plugin-android-update.yml` workflow mirroring the existing `publish-webkit2gtk-nvidia-quirk.yml`, so the `tauri-plugin-android-update` crate becomes publishable to crates.io:

- Bumps the crate version (`none`/`patch`/`minor`/`major`) via `cargo set-version`
- Tags it `tauri-plugin-android-update-vX.Y.Z`
- Updates `crates/tauri-plugin-android-update/CHANGELOG.md` via git-cliff
- Publishes to crates.io (with `dry-run`/`publish` toggles)

Adds `cliff-tauri-plugin-android-update.toml` with `tag_pattern = "tauri-plugin-android-update-v[0-9].*"` and `include_paths = ["crates/tauri-plugin-android-update/**"]`.

No manual version bumps or changelog edits per AGENTS.md.

Testing:
- `actionlint .github/workflows/publish-tauri-plugin-android-update.yml` passes
- `git-cliff --config cliff-tauri-plugin-android-update.toml --unreleased` parses and picks up the crate's commits