### PR TITLE
fix: route workflow run inputs and secrets via env

### DIFF
--- a/.github/workflows/publish-webkit2gtk-nvidia-quirk.yml
+++ b/.github/workflows/publish-webkit2gtk-nvidia-quirk.yml
@@ -51,9 +51,11 @@ jobs:
           fetch-depth: 0
 
       - name: 🛡️ Verify RULESET_ID secret is configured
+        env:
+          RULESET_ID: ${{ secrets.RULESET_ID }}
         run: |
-          if [ -z "${{ secrets.RULESET_ID }}" ]; then
-            echo "Error: secrets.RULESET_ID is not set. Please configure the RULESET_ID secret in repository settings."
+          if [ -z "$RULESET_ID" ]; then
+            echo "Error: RULESET_ID secret is not set. Please configure the RULESET_ID secret in repository settings."
             echo "This secret should contain the ID of the ruleset used to disable enforcement during version bump."
             exit 1
           fi
@@ -74,14 +76,17 @@ jobs:
       - name: 🔢 Bump semantic version
         id: version
         shell: bash
+        env:
+          BUMP_VERSION: ${{ inputs.bump_version }}
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "webkit2gtk-nvidia-quirk") | .version')
-          if [ "${{ inputs.dry-run }}" = "true" ]; then
-            if [ "${{ inputs.bump_version }}" = "none" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
+            if [ "$BUMP_VERSION" = "none" ]; then
               NEW_VERSION="$CURRENT_VERSION"
             else
               IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-              case "${{ inputs.bump_version }}" in
+              case "$BUMP_VERSION" in
                 "patch")
                   NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
                   ;;
@@ -96,8 +101,8 @@ jobs:
             echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
             echo "Dry run: would bump from $CURRENT_VERSION to $NEW_VERSION"
           else
-            if [ "${{ inputs.bump_version }}" != "none" ]; then
-              cargo set-version --package webkit2gtk-nvidia-quirk --bump "${{ inputs.bump_version }}"
+            if [ "$BUMP_VERSION" != "none" ]; then
+              cargo set-version --package webkit2gtk-nvidia-quirk --bump "$BUMP_VERSION"
               CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "webkit2gtk-nvidia-quirk") | .version')
             fi
             echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
@@ -145,10 +150,12 @@ jobs:
 
       - name: 💾🏷️⬆️ Commit, tag and push
         if: (!inputs.dry-run)
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           git add -A
-          git commit -S -m "chore(webkit2gtk-nvidia-quirk): Bump webkit2gtk-nvidia-quirk to ${{ steps.version.outputs.version }}"
-          git tag -s -a webkit2gtk-nvidia-quirk-v${{ steps.version.outputs.version }} -m "webkit2gtk-nvidia-quirk Release v${{ steps.version.outputs.version }}"
+          git commit -S -m "chore(webkit2gtk-nvidia-quirk): Bump webkit2gtk-nvidia-quirk to ${VERSION}"
+          git tag -s -a "webkit2gtk-nvidia-quirk-v${VERSION}" -m "webkit2gtk-nvidia-quirk Release v${VERSION}"
           git push --follow-tags
 
       - name: 👮 Re-enable enforcement of rules


### PR DESCRIPTION
Fixes the AGENTS.md violation flagged in review of #2504: `${{ }}` expansion inside `run:` blocks (template-injection risk) in the `publish-webkit2gtk-nvidia-quirk.yml` workflow.

Changes:
- `Bump semantic version`: `inputs.bump_version` / `inputs.dry-run` now arrive via `env:` as `BUMP_VERSION` / `DRY_RUN`
- `Verify RULESET_ID`: `secrets.RULESET_ID` now arrives via `env:` as `RULESET_ID`
- `Commit, tag and push`: `steps.version.outputs.version` now arrives via `env:` as `VERSION` (tag arg quoted to satisfy shellcheck SC2086)

The sibling `publish-tauri-plugin-android-update.yml` gets the identical fix in #2504. Verified `actionlint .github/workflows/*.yml` passes and the two publish workflows remain consistent after normalization.