### PR TITLE
fix: regenerate stale permissions schema for tauri-plugin-android-update

### DIFF
--- a/crates/tauri-plugin-android-update/permissions/schemas/schema.json
+++ b/crates/tauri-plugin-android-update/permissions/schemas/schema.json
@@ -319,10 +319,10 @@
           "markdownDescription": "Denies the download_and_install command without any pre-configured scope."
         },
         {
-          "description": "This permission set enables the Android update workflow.\n\n#### Granted Permissions\n\nChecking for a newer release and opening its page for manual download.\n\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download-and-install`",
+          "description": "This permission set enables the Android update workflow.\n\n### Granted Permissions\n\nChecking for a newer release and opening its page for manual download.\n\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download-and-install`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "This permission set enables the Android update workflow.\n\n#### Granted Permissions\n\nChecking for a newer release and opening its page for manual download.\n\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download-and-install`"
+          "markdownDescription": "This permission set enables the Android update workflow.\n\n### Granted Permissions\n\nChecking for a newer release and opening its page for manual download.\n\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download-and-install`"
         }
       ]
     }


### PR DESCRIPTION
Fixes the failed first publish of `tauri-plugin-android-update` (workflow run [32422886625](https://github.com/hrzlgnm/mdns-browser/actions/runs/32422886625)).

**Root cause**

`cargo publish`'s verify step failed:

```
Source directory was modified by build.rs during cargo publish.
Changed: .../permissions/schemas/schema.json
```

The `tauri-plugin` build script regenerates `permissions/schemas/schema.json` (via `tauri_utils::acl::schema::generate_permissions_schema`, which writes only on content change). The committed file was stale — generated by an older `tauri-utils` that emitted `#### Granted Permissions`, while the current lockfile generates `### Granted Permissions` (matching `default.toml`). In the packed copy used for verification, build.rs rewrote the file, tripping cargo's source-modification check.

**Fix**

Regenerated `crates/tauri-plugin-android-update/permissions/schemas/schema.json` (only 2-line heading-level diff). Verified `cargo package -p tauri-plugin-android-update` now completes its verification step successfully, so `cargo publish` will pass.

**Follow-up after merge:** re-dispatch `publish-tauri-plugin-android-update` with `bump_version=none, publish=true` (tag `tauri-plugin-android-update-v0.1.1` already exists) to publish 0.1.1.