### PR TITLE
fix(tauri-plugin-android-update): render MIT-0 license badge correctly

### DIFF
--- a/crates/tauri-plugin-android-update/README.md
+++ b/crates/tauri-plugin-android-update/README.md
@@ -1,7 +1,7 @@
 # tauri-plugin-android-update
 
 [![Crates.io](https://img.shields.io/crates/v/tauri-plugin-android-update)](https://crates.io/crates/tauri-plugin-android-update)
-[![License: MIT-0](https://img.shields.io/badge/License-MIT%2D0-blue.svg)](https://opensource.org/license/mit-0/)
+[![License: MIT-0](https://img.shields.io/badge/License-MIT--0-blue.svg)](https://opensource.org/license/mit-0)
 
 A Tauri plugin that surfaces new GitHub releases for manual download on
 platforms where `tauri-plugin-updater` cannot be used.


### PR DESCRIPTION
## Summary
The license badge in the tauri-plugin-android-update README rendered as a shield.io 404. The badge URL used `%2D` (URL-encoded dash), but shield.io treats a dash in the path as a field separator, so the badge was parsed as an invalid color field and returned `404: badge not found`.

## Changes
- Use the `--` doubling that shield.io renders as a literal dash: `License-MIT--0-blue.svg` (verified to return 200)
- Link the canonical `opensource.org/license/mit-0` URL instead of the variant that 301-redirects

## Testing
- `curl` of the new badge URL returns 200 (was 404)
- `curl -L` of the license link returns 200