### PR TITLE
chore(ci): drop unused tagName output from crate publish workflows

### DIFF
--- a/.github/workflows/publish-tauri-plugin-android-update.yml
+++ b/.github/workflows/publish-tauri-plugin-android-update.yml
@@ -40,7 +40,6 @@ jobs:
     name: ⬆️ Bump version
     outputs:
       version: ${{ steps.version.outputs.version }}
-      tagName: tauri-plugin-android-update-v${{ steps.version.outputs.version}}
     env:
       GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
       RULESET: repos/${{github.repository}}/rulesets/${{ secrets.RULESET_ID }}

--- a/.github/workflows/publish-webkit2gtk-nvidia-quirk.yml
+++ b/.github/workflows/publish-webkit2gtk-nvidia-quirk.yml
@@ -40,7 +40,6 @@ jobs:
     name: ⬆️ Bump version
     outputs:
       version: ${{ steps.version.outputs.version }}
-      tagName: webkit2gtk-nvidia-quirk-v${{ steps.version.outputs.version}}
     env:
       GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
       RULESET: repos/${{github.repository}}/rulesets/${{ secrets.RULESET_ID }}


### PR DESCRIPTION
The tagName job output in the webkit2gtk-nvidia-quirk and
tauri-plugin-android-update publish workflows is never consumed;
publish_crate recomputes the ref from bump_version.outputs.version.
Remove the dead output. Closes #2506

Co-authored-by: opencode <noreply@opencode.ai>
Assisted-by: opencode (hy3-free)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified release automation workflows by removing unused release tag outputs.
  * Version information remains available for automated publishing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->