### PR TITLE
refactor/dedup crate publish workflows

### DIFF
--- a/.github/workflows/publish-crate-reusable.yml
+++ b/.github/workflows/publish-crate-reusable.yml
@@ -1,0 +1,217 @@
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT-0
+
+name: Publish Crate (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      bump_version:
+        description: Version bump type (none/patch/minor/major)
+        required: false
+        type: string
+        default: patch
+      dry_run:
+        description: Dry run (no commits/tags/releases)
+        required: false
+        type: boolean
+        default: false
+      publish:
+        description: Publish to crates.io after version bump
+        required: false
+        type: boolean
+        default: true
+      crate_name:
+        description: Cargo package name to bump and publish
+        required: true
+        type: string
+      tag_prefix:
+        description: Git tag prefix, e.g. webkit2gtk-nvidia-quirk-v
+        required: true
+        type: string
+      git_cliff_config:
+        description: git-cliff config file for the crate CHANGELOG
+        required: true
+        type: string
+    secrets:
+      GH_ADMIN_TOKEN:
+        required: true
+      RULESET_ID:
+        required: true
+      SSH_SIGNING_KEY:
+        required: true
+      CARGO_REGISTRY_TOKEN:
+        required: true
+
+concurrency:
+  group: ruleset-modification
+  cancel-in-progress: false
+
+jobs:
+  bump_version:
+    permissions:
+      actions: write
+      contents: write
+    runs-on: ubuntu-latest
+    name: ⬆️ Bump version
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    env:
+      GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+      RULESET: repos/${{github.repository}}/rulesets/${{ secrets.RULESET_ID }}
+    steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: 🛡️ Verify RULESET_ID secret is configured
+        env:
+          RULESET_ID: ${{ secrets.RULESET_ID }}
+        run: |
+          if [ -z "$RULESET_ID" ]; then
+            echo "Error: RULESET_ID secret is not set. Please configure the RULESET_ID secret in repository settings."
+            echo "This secret should contain the ID of the ruleset used to disable enforcement during version bump."
+            exit 1
+          fi
+          echo "RULESET_ID secret is configured"
+
+      - name: 🦀🚀
+        uses: ./.github/actions/setup-rust-cache
+        with:
+          save-cache: false
+
+      - name: 🔧 Install cargo-edit
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+        with:
+          crate: cargo-edit
+          version: 0.13.13
+          locked: true
+
+      - name: 🔢 Bump semantic version
+        id: version
+        shell: bash
+        env:
+          BUMP_VERSION: ${{ inputs.bump_version }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          CRATE_NAME: ${{ inputs.crate_name }}
+        run: |
+          set -euo pipefail
+          CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r --arg name "$CRATE_NAME" '.packages[] | select(.name == $name) | .version')
+          if [ "$DRY_RUN" = "true" ]; then
+            if [ "$BUMP_VERSION" = "none" ]; then
+              NEW_VERSION="$CURRENT_VERSION"
+            else
+              IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+              case "$BUMP_VERSION" in
+                "patch")
+                  NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+                  ;;
+                "minor")
+                  NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
+                  ;;
+                "major")
+                  NEW_VERSION="$((MAJOR + 1)).0.0"
+                  ;;
+              esac
+            fi
+            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+            echo "Dry run: would bump from $CURRENT_VERSION to $NEW_VERSION"
+          else
+            if [ "$BUMP_VERSION" != "none" ]; then
+              cargo set-version --package "$CRATE_NAME" --bump "$BUMP_VERSION"
+              CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r --arg name "$CRATE_NAME" '.packages[] | select(.name == $name) | .version')
+            fi
+            echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+            echo "Version: $CURRENT_VERSION"
+          fi
+
+      - name: 🔑 Set up SSH signing key
+        if: (!inputs.dry_run)
+        env:
+          SSH_SIGNING_KEY: ${{ secrets.SSH_SIGNING_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_SIGNING_KEY" > ~/.ssh/id_ed25519_signing
+          chmod 600 ~/.ssh/id_ed25519_signing
+          git config --global gpg.format ssh
+          git config --global user.signingKey ~/.ssh/id_ed25519_signing
+          git config --global user.name "hrzlgnm"
+          git config --global user.email "hrzlgnm@users.noreply.github.com"
+
+      - name: ⏳ Temporary disable ruleset enforcement
+        if: (always() && !inputs.dry_run)
+        run: |
+          gh api \
+          -H "Accept: application/vnd.github+json" \
+          "${RULESET}" | jq '.enforcement = "disabled"' | \
+          gh api \
+          --method PUT \
+          -H "Accept: application/vnd.github+json" \
+          "${RULESET}" \
+          --input -
+
+      - name: 🔧 Install git-cliff
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+        with:
+          crate: git-cliff
+          version: 2.13.1
+          locked: true
+
+      - name: 📝 Update CHANGELOG.md
+        if: ${{ !inputs.dry_run }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          CRATE_NAME: ${{ inputs.crate_name }}
+          GIT_CLIFF_CONFIG: ${{ inputs.git_cliff_config }}
+          TAG: ${{ inputs.tag_prefix }}${{ steps.version.outputs.version }}
+        run: |
+          git-cliff --config "$GIT_CLIFF_CONFIG" --tag "$TAG" --output "crates/${CRATE_NAME}/CHANGELOG.md"
+
+      - name: 💾🏷️⬆️ Commit, tag and push
+        if: (!inputs.dry_run)
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          CRATE_NAME: ${{ inputs.crate_name }}
+          TAG: ${{ inputs.tag_prefix }}${{ steps.version.outputs.version }}
+        run: |
+          git add -A
+          git commit -S -m "chore(${CRATE_NAME}): Bump ${CRATE_NAME} to ${VERSION}"
+          git tag -s -a "$TAG" -m "${CRATE_NAME} Release v${VERSION}"
+          git push --follow-tags
+
+      - name: 👮 Re-enable enforcement of rules
+        if: (always() && !inputs.dry_run)
+        run: |
+          gh api \
+          -H "Accept: application/vnd.github+json" \
+          "${RULESET}" | jq '.enforcement = "active"' | \
+          gh api \
+          --method PUT \
+          -H "Accept: application/vnd.github+json" \
+          "${RULESET}" \
+          --input -
+
+  publish_crate:
+    needs: [bump_version]
+    if: (inputs.publish && !inputs.dry_run)
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    container: ghcr.io/hrzlgnm/mdns-browser-ubuntu-builder:v1@sha256:ac1df04c169958f2f1caf4ba49ed187ddbb54d062ba5fabd342f98d2e9e5c319
+    name: 📦 Publish to crates.io
+    steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.bump_version == 'none' && github.ref_name || format('{0}{1}', inputs.tag_prefix, needs.bump_version.outputs.version) }}
+
+      - name: 🦀🚀
+        uses: ./.github/actions/setup-rust-cache
+
+      - name: 📦 Publish to crates.io
+        run: |
+          cargo publish --package ${{ inputs.crate_name }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-tauri-plugin-android-update.yml
+++ b/.github/workflows/publish-tauri-plugin-android-update.yml
@@ -27,168 +27,18 @@ on:
         type: boolean
         default: true
 
-concurrency:
-  group: ruleset-modification
-  cancel-in-progress: false
-
 jobs:
-  bump_version:
-    permissions:
-      actions: write
-      contents: write
-    runs-on: ubuntu-latest
-    name: ⬆️ Bump version
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-    env:
-      GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
-      RULESET: repos/${{github.repository}}/rulesets/${{ secrets.RULESET_ID }}
-    steps:
-      - name: 🔄 Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-
-      - name: 🛡️ Verify RULESET_ID secret is configured
-        env:
-          RULESET_ID: ${{ secrets.RULESET_ID }}
-        run: |
-          if [ -z "$RULESET_ID" ]; then
-            echo "Error: RULESET_ID secret is not set. Please configure the RULESET_ID secret in repository settings."
-            echo "This secret should contain the ID of the ruleset used to disable enforcement during version bump."
-            exit 1
-          fi
-          echo "RULESET_ID secret is configured"
-
-      - name: 🦀🚀
-        uses: ./.github/actions/setup-rust-cache
-        with:
-          save-cache: false
-
-      - name: 🔧 Install cargo-edit
-        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
-        with:
-          crate: cargo-edit
-          version: 0.13.13
-          locked: true
-
-      - name: 🔢 Bump semantic version
-        id: version
-        shell: bash
-        env:
-          BUMP_VERSION: ${{ inputs.bump_version }}
-          DRY_RUN: ${{ inputs.dry-run }}
-        run: |
-          CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "tauri-plugin-android-update") | .version')
-          if [ "$DRY_RUN" = "true" ]; then
-            if [ "$BUMP_VERSION" = "none" ]; then
-              NEW_VERSION="$CURRENT_VERSION"
-            else
-              IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-              case "$BUMP_VERSION" in
-                "patch")
-                  NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
-                  ;;
-                "minor")
-                  NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
-                  ;;
-                "major")
-                  NEW_VERSION="$((MAJOR + 1)).0.0"
-                  ;;
-              esac
-            fi
-            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-            echo "Dry run: would bump from $CURRENT_VERSION to $NEW_VERSION"
-          else
-            if [ "$BUMP_VERSION" != "none" ]; then
-              cargo set-version --package tauri-plugin-android-update --bump "$BUMP_VERSION"
-              CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "tauri-plugin-android-update") | .version')
-            fi
-            echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-            echo "Version: $CURRENT_VERSION"
-          fi
-
-      - name: 🔑 Set up SSH signing key
-        if: (!inputs.dry-run)
-        env:
-          SSH_SIGNING_KEY: ${{ secrets.SSH_SIGNING_KEY }}
-        run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_SIGNING_KEY" > ~/.ssh/id_ed25519_signing
-          chmod 600 ~/.ssh/id_ed25519_signing
-          git config --global gpg.format ssh
-          git config --global user.signingKey ~/.ssh/id_ed25519_signing
-          git config --global user.name "hrzlgnm"
-          git config --global user.email "hrzlgnm@users.noreply.github.com"
-
-      - name: ⏳ Temporary disable ruleset enforcement
-        if: (!inputs.dry-run)
-        run: |
-          gh api \
-          -H "Accept: application/vnd.github+json" \
-          "${RULESET}" | jq '.enforcement = "disabled"' | \
-          gh api \
-          --method PUT \
-          -H "Accept: application/vnd.github+json" \
-          "${RULESET}" \
-          --input -
-
-      - name: 🔧 Install git-cliff
-        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
-        with:
-          crate: git-cliff
-          version: 2.13.1
-          locked: true
-
-      - name: 📝 Update CHANGELOG.md
-        if: ${{ !inputs.dry-run }}
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          git-cliff --config cliff-tauri-plugin-android-update.toml --tag "tauri-plugin-android-update-v${VERSION}" --output crates/tauri-plugin-android-update/CHANGELOG.md
-
-      - name: 💾🏷️⬆️ Commit, tag and push
-        if: (!inputs.dry-run)
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          git add -A
-          git commit -S -m "chore(tauri-plugin-android-update): Bump tauri-plugin-android-update to ${VERSION}"
-          git tag -s -a "tauri-plugin-android-update-v${VERSION}" -m "tauri-plugin-android-update Release v${VERSION}"
-          git push --follow-tags
-
-      - name: 👮 Re-enable enforcement of rules
-        if: (always() && !inputs.dry-run)
-        run: |
-          gh api \
-          -H "Accept: application/vnd.github+json" \
-          "${RULESET}" | jq '.enforcement = "active"' | \
-          gh api \
-          --method PUT \
-          -H "Accept: application/vnd.github+json" \
-          "${RULESET}" \
-          --input -
-
-  publish_crate:
-    needs: [bump_version]
-    if: (inputs.publish && !inputs.dry-run)
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    container: ghcr.io/hrzlgnm/mdns-browser-ubuntu-builder:v1@sha256:ac1df04c169958f2f1caf4ba49ed187ddbb54d062ba5fabd342f98d2e9e5c319
-    name: 📦 Publish to crates.io
-    steps:
-      - name: 🔄 Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.bump_version == 'none' && github.ref_name || format('tauri-plugin-android-update-v{0}', needs.bump_version.outputs.version) }}
-
-      - name: 🦀🚀
-        uses: ./.github/actions/setup-rust-cache
-
-      - name: 📦 Publish to crates.io
-        run: |
-          cargo publish --package tauri-plugin-android-update
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  publish:
+    uses: ./.github/workflows/publish-crate-reusable.yml
+    with:
+      bump_version: ${{ inputs.bump_version }}
+      dry_run: ${{ inputs.dry-run }}
+      publish: ${{ inputs.publish }}
+      crate_name: tauri-plugin-android-update
+      tag_prefix: tauri-plugin-android-update-v
+      git_cliff_config: cliff-tauri-plugin-android-update.toml
+    secrets:
+      GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+      RULESET_ID: ${{ secrets.RULESET_ID }}
+      SSH_SIGNING_KEY: ${{ secrets.SSH_SIGNING_KEY }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-webkit2gtk-nvidia-quirk.yml
+++ b/.github/workflows/publish-webkit2gtk-nvidia-quirk.yml
@@ -27,168 +27,18 @@ on:
         type: boolean
         default: true
 
-concurrency:
-  group: ruleset-modification
-  cancel-in-progress: false
-
 jobs:
-  bump_version:
-    permissions:
-      actions: write
-      contents: write
-    runs-on: ubuntu-latest
-    name: ⬆️ Bump version
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-    env:
-      GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
-      RULESET: repos/${{github.repository}}/rulesets/${{ secrets.RULESET_ID }}
-    steps:
-      - name: 🔄 Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-
-      - name: 🛡️ Verify RULESET_ID secret is configured
-        env:
-          RULESET_ID: ${{ secrets.RULESET_ID }}
-        run: |
-          if [ -z "$RULESET_ID" ]; then
-            echo "Error: RULESET_ID secret is not set. Please configure the RULESET_ID secret in repository settings."
-            echo "This secret should contain the ID of the ruleset used to disable enforcement during version bump."
-            exit 1
-          fi
-          echo "RULESET_ID secret is configured"
-
-      - name: 🦀🚀
-        uses: ./.github/actions/setup-rust-cache
-        with:
-          save-cache: false
-
-      - name: 🔧 Install cargo-edit
-        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
-        with:
-          crate: cargo-edit
-          version: 0.13.13
-          locked: true
-
-      - name: 🔢 Bump semantic version
-        id: version
-        shell: bash
-        env:
-          BUMP_VERSION: ${{ inputs.bump_version }}
-          DRY_RUN: ${{ inputs.dry-run }}
-        run: |
-          CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "webkit2gtk-nvidia-quirk") | .version')
-          if [ "$DRY_RUN" = "true" ]; then
-            if [ "$BUMP_VERSION" = "none" ]; then
-              NEW_VERSION="$CURRENT_VERSION"
-            else
-              IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-              case "$BUMP_VERSION" in
-                "patch")
-                  NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
-                  ;;
-                "minor")
-                  NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
-                  ;;
-                "major")
-                  NEW_VERSION="$((MAJOR + 1)).0.0"
-                  ;;
-              esac
-            fi
-            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-            echo "Dry run: would bump from $CURRENT_VERSION to $NEW_VERSION"
-          else
-            if [ "$BUMP_VERSION" != "none" ]; then
-              cargo set-version --package webkit2gtk-nvidia-quirk --bump "$BUMP_VERSION"
-              CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "webkit2gtk-nvidia-quirk") | .version')
-            fi
-            echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-            echo "Version: $CURRENT_VERSION"
-          fi
-
-      - name: 🔑 Set up SSH signing key
-        if: (!inputs.dry-run)
-        env:
-          SSH_SIGNING_KEY: ${{ secrets.SSH_SIGNING_KEY }}
-        run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_SIGNING_KEY" > ~/.ssh/id_ed25519_signing
-          chmod 600 ~/.ssh/id_ed25519_signing
-          git config --global gpg.format ssh
-          git config --global user.signingKey ~/.ssh/id_ed25519_signing
-          git config --global user.name "hrzlgnm"
-          git config --global user.email "hrzlgnm@users.noreply.github.com"
-
-      - name: ⏳ Temporary disable ruleset enforcement
-        if: (!inputs.dry-run)
-        run: |
-          gh api \
-          -H "Accept: application/vnd.github+json" \
-          "${RULESET}" | jq '.enforcement = "disabled"' | \
-          gh api \
-          --method PUT \
-          -H "Accept: application/vnd.github+json" \
-          "${RULESET}" \
-          --input -
-
-      - name: 🔧 Install git-cliff
-        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
-        with:
-          crate: git-cliff
-          version: 2.13.1
-          locked: true
-
-      - name: 📝 Update CHANGELOG.md
-        if: ${{ !inputs.dry-run }}
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          git-cliff --config cliff-webkit2gtk.toml --tag "webkit2gtk-nvidia-quirk-v${VERSION}" --output crates/webkit2gtk-nvidia-quirk/CHANGELOG.md
-
-      - name: 💾🏷️⬆️ Commit, tag and push
-        if: (!inputs.dry-run)
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          git add -A
-          git commit -S -m "chore(webkit2gtk-nvidia-quirk): Bump webkit2gtk-nvidia-quirk to ${VERSION}"
-          git tag -s -a "webkit2gtk-nvidia-quirk-v${VERSION}" -m "webkit2gtk-nvidia-quirk Release v${VERSION}"
-          git push --follow-tags
-
-      - name: 👮 Re-enable enforcement of rules
-        if: (always() && !inputs.dry-run)
-        run: |
-          gh api \
-          -H "Accept: application/vnd.github+json" \
-          "${RULESET}" | jq '.enforcement = "active"' | \
-          gh api \
-          --method PUT \
-          -H "Accept: application/vnd.github+json" \
-          "${RULESET}" \
-          --input -
-
-  publish_crate:
-    needs: [bump_version]
-    if: (inputs.publish && !inputs.dry-run)
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    container: ghcr.io/hrzlgnm/mdns-browser-ubuntu-builder:v1@sha256:ac1df04c169958f2f1caf4ba49ed187ddbb54d062ba5fabd342f98d2e9e5c319
-    name: 📦 Publish to crates.io
-    steps:
-      - name: 🔄 Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.bump_version == 'none' && github.ref_name || format('webkit2gtk-nvidia-quirk-v{0}', needs.bump_version.outputs.version) }}
-
-      - name: 🦀🚀
-        uses: ./.github/actions/setup-rust-cache
-
-      - name: 📦 Publish to crates.io
-        run: |
-          cargo publish --package webkit2gtk-nvidia-quirk
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  publish:
+    uses: ./.github/workflows/publish-crate-reusable.yml
+    with:
+      bump_version: ${{ inputs.bump_version }}
+      dry_run: ${{ inputs.dry-run }}
+      publish: ${{ inputs.publish }}
+      crate_name: webkit2gtk-nvidia-quirk
+      tag_prefix: webkit2gtk-nvidia-quirk-v
+      git_cliff_config: cliff-webkit2gtk.toml
+    secrets:
+      GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+      RULESET_ID: ${{ secrets.RULESET_ID }}
+      SSH_SIGNING_KEY: ${{ secrets.SSH_SIGNING_KEY }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
- **chore(ci): drop unused tagName output from crate publish workflows**
- **refactor(ci): extract shared crate-publish sequence into reusable workflow**
- **refactor(ci): replace publish wrappers with calls to reusable workflow**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reusable release workflow for Rust crates.
  - Supports semantic version bumps, dry runs, changelog updates, signed tags, and optional registry publishing.
  - Added configurable crate names, tag prefixes, and changelog settings.
- **Improvements**
  - Updated crate release processes to use the shared workflow, providing consistent versioning and publishing behavior across projects.
  - Release automation now manages repository protections during publishing and restores them afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->