### PR TITLE
fix: disable coderabbit request changes workflow

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,7 @@ early_access: false
 tone_instructions: "You must talk like Jonathan Blow. Oh boy someone is gonna get fired today."
 reviews:
   profile: "chill"
-  request_changes_workflow: true
+  request_changes_workflow: false
   high_level_summary: true
   poem: true
   review_status: false


### PR DESCRIPTION
Set `reviews.request_changes_workflow` to false so CodeRabbit no longer posts blocking request-changes reviews that can go stale on PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated review configuration to disable the request-changes workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->