### PR TITLE
ci: drop unneeded actions: write from release draft job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,7 @@ concurrency:
 jobs:
   create_release_draft:
     permissions:
-      actions: write # to upload the generated changelog artifact
-      contents: write # to create and update releases and drafts
+      contents: write # to create and update releases and drafts and upload the changelog artifact
     runs-on: ubuntu-slim
     name: 📝 Draft a new release
     steps:


### PR DESCRIPTION
## Summary
- Removes the `actions: write` permission from the `create_release_draft` job in `.github/workflows/release.yml`.
- `actions/upload-artifact@v7.0.1` (used for the changelog artifact) does not require `actions: write` for same-run uploads — it uses an internal token-independent mechanism. The job only needs `contents: write` to create the draft release and upload the artifact.

Mirrors the fix already applied to zux (PR #192).

## Test plan
- [x] `release.yml` is valid YAML
- [x] Confirmed the changelog upload uses `actions/upload-artifact@...# v7.0.1`
- CI release run will exercise the changelog artifact upload without `actions: write`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation permissions to follow least-privilege practices.
  * Release creation and changelog artifact handling continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->