### PR TITLE
docs: point README to webkit2gtk-nvidia-quirk tracing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ It only affects diagnostic output and does not change any behavior.
 
 This option has been added with release [v1.18.0](https://github.com/hrzlgnm/mdns-browser/releases/tag/v1.18.0)
 
+The shared [`webkit2gtk-nvidia-quirk`](https://docs.rs/webkit2gtk-nvidia-quirk) crate (also used by other
+applications such as zux) provides additional tracing through the `WEBKIT2GTK_NVIDIA_QUIRK_VERBOSE`
+environment variable. Set it to `debug` (or `trace`/`verbose`/`2`) to print a full detection summary —
+session type, whether the primary GPU and NVIDIA driver are in use, the detected compositor, and the
+chosen workaround — in addition to the per-workaround note above. See the crate's
+[documentation](https://docs.rs/webkit2gtk-nvidia-quirk) for the full list of accepted values.
+
 ## Where to find the executables?
 
 ### GitHub Releases

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ The shared [`webkit2gtk-nvidia-quirk`](https://docs.rs/webkit2gtk-nvidia-quirk) 
 applications such as zux) provides additional tracing through the `WEBKIT2GTK_NVIDIA_QUIRK_VERBOSE`
 environment variable. Set it to `debug` (or `trace`/`verbose`/`2`) to print a full detection summary —
 session type, whether the primary GPU and NVIDIA driver are in use, the detected compositor, and the
-chosen workaround — in addition to the per-workaround note above. See the crate's
+chosen workaround — in addition to the per-workaround note above. This crate is Linux-only, so the
+environment variable has no effect on other platforms. See the crate's
 [documentation](https://docs.rs/webkit2gtk-nvidia-quirk) for the full list of accepted values.
 
 ## Where to find the executables?

--- a/docs/mdns-browser.1
+++ b/docs/mdns-browser.1
@@ -41,5 +41,23 @@ Linux: $XDG_DATA_HOME/com.github.hrzlgnm.mdns-browser/logs or $HOME/.local/share
 macOS: ~/Library/Logs/com.github.hrzlgnm.mdns-browser
 .fi
 The log file will be named mdns-browser.log and will contain log messages with a log-level having at least a level specified by the log-level option.
+.SH ENVIRONMENT
+.TP
+.B WEBKIT2GTK_NVIDIA_QUIRK_VERBOSE
+Controls diagnostic output of the underlying
+.B webkit2gtk\-nvidia\-quirk
+crate (Linux only).
+Set it to
+.B debug
+(or
+.BR trace ,
+.BR verbose ,
+or
+.B 2 )
+to print a full detection summary \(em session type, whether the primary GPU
+and NVIDIA driver are in use, the detected compositor, and the chosen
+workaround \(em in addition to the per\-workaround note printed by
+.B \-v /\-\-nvidia\-workaround\-verbose .
+See https://docs.rs/webkit2gtk-nvidia-quirk for the full list of accepted values.
 .SH REPORTING ISSUES
 Report bugs or issues at https://github.com/hrzlgnm/mdns-browser/issues


### PR DESCRIPTION
## Summary
- Add a note to `README.md` under the `nvidia-workaround-verbose` option pointing out that the shared `webkit2gtk-nvidia-quirk` crate (also used by zux) offers extra tracing via the `WEBKIT2GTK_NVIDIA_QUIRK_VERBOSE` env var (`debug` level prints a full detection summary).
- Link to the crate's docs.rs documentation.

## Testing
- Documentation-only change; no code/test impact.

🤖 Generated with [opencode](https://opencode.ai)