### PR TITLE
feat: gzip the SBOM workflow artifacts on publish

### DIFF
--- a/.github/actions/sbom/action.yml
+++ b/.github/actions/sbom/action.yml
@@ -23,7 +23,18 @@ runs:
       with:
         format: "spdx-json"
         output-file: "sbom.spdx.json"
-        artifact-name: ${{ inputs.artifact-name }}
+        upload-artifact: false
+        upload-release-assets: false
+
+    - name: 🗜️ Compress SBOM
+      shell: bash
+      run: gzip -c sbom.spdx.json > sbom.spdx.json.gz
+
+    - name: 📤 Upload SBOM artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: sbom.spdx.json.gz
 
     - name: 🔍 Scan SBOM
       id: scan

--- a/.github/workflows/android-reusable.yml
+++ b/.github/workflows/android-reusable.yml
@@ -57,7 +57,7 @@ jobs:
       - name: 📜 Create and 🔍 scan SBOM for vulnerabilities
         uses: ./.github/actions/sbom
         with:
-          artifact-name: "sbom.android.spdx.json"
+          artifact-name: "sbom.android.spdx.json.gz"
           current-version: ${{ steps.get-version.outputs.current-version }}
 
       - name: 🛠️🐂

--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -91,7 +91,7 @@ jobs:
       - name: 📜 Create and 🔍 scan SBOM for vulnerabilities
         uses: ./.github/actions/sbom
         with:
-          artifact-name: "sbom.${{ matrix.platform }}.spdx.json"
+          artifact-name: "sbom.${{ matrix.platform }}.spdx.json.gz"
           current-version: ${{ steps.get-version.outputs.current-version }}
 
       - name: 🛠️🐂


### PR DESCRIPTION
## Summary
- Mirrors the SBOM compression recently added in mdns-tui-browser (`8c1fdf3`) for mdns-browser.
- The SBOM action now gzips the published artifact (`sbom.<platform>.spdx.json.gz`, `sbom.android.spdx.json.gz`) via `gzip -c`, keeping the workspace `sbom.spdx.json` uncompressed so the downstream attestation steps that read it at the workspace root are unaffected.

## Testing
- `actionlint .github/workflows/*.yml` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * SBOM files are now compressed to reduce artifact size.
  * SBOMs are uploaded as downloadable workflow artifacts with updated `.spdx.json.gz` filenames across Android and desktop builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->