### PR TITLE
feat: trigger snap release after a release is published

### DIFF
--- a/.github/workflows/snap-reusable.yml
+++ b/.github/workflows/snap-reusable.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: 🏷️ Get latest release info
         id: release-info

--- a/.github/workflows/snap-reusable.yml
+++ b/.github/workflows/snap-reusable.yml
@@ -1,0 +1,36 @@
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT-0
+
+name: Update Snap
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  release:
+    types: [released]
+
+jobs:
+  trigger-snap-release:
+    permissions:
+      contents: read # needed to checkout repository for release info
+    runs-on: ubuntu-slim
+    steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+
+      - name: 🏷️ Get latest release info
+        id: release-info
+        uses: ./.github/actions/latest-release-info
+
+      - name: 🚀 Dispatch Release snap in hrzlgnm/mdns-browser-snap
+        env:
+          GH_TOKEN: ${{ secrets.SNAP_REPO_TOKEN }}
+          TAG_NAME: ${{ steps.release-info.outputs.tagName }}
+        run: |
+          echo "Dispatching Release snap for ${TAG_NAME}"
+          gh workflow run release.yml \
+            --repo hrzlgnm/mdns-browser-snap \
+            --ref main \
+            -f tagName="${TAG_NAME}"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/snap-reusable.yml` which fires on `release: released` (plus manual dispatch and workflow_call, matching winget/homebrew/aur workflows)
- It resolves the latest release tag via the existing `latest-release-info` action and dispatches the `Release snap` workflow in hrzlgnm/mdns-browser-snap with that tag; that workflow already pins the snapcraft source-tag, builds, smoke-tests, and publishes to the stable channel

## Setup required
- A fine-grained PAT with **Actions: read/write** on `hrzlgnm/mdns-browser-snap` stored as the repository secret `SNAP_REPO_TOKEN`

## Testing
- `actionlint .github/workflows/*.yml` passes
- End-to-end verification requires a published release once `SNAP_REPO_TOKEN` is configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to trigger Snap package releases manually, from reusable workflows, or when a new release is published.
  * Snap releases now use the latest release tag and are dispatched to the downstream packaging workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->