### PR TITLE
fix: disable grype DB caching in sbom composite

### DIFF
--- a/.github/actions/sbom/action.yml
+++ b/.github/actions/sbom/action.yml
@@ -42,7 +42,7 @@ runs:
       with:
         sbom: "sbom.spdx.json"
         severity-cutoff: medium
-        cache-db: ${{ github.ref == 'refs/heads/main' }}
+        cache-db: false
 
     - name: 🔍 Inspect SARIF report
       if: ${{ runner.os != 'Windows' }}


### PR DESCRIPTION
## Summary
- `anchore/scan-action` in the `sbom` composite saves the fixed key `grype-db-v0.110.0` on `main` from every build-matrix job plus `cache-tools`, producing benign `##[warning] Unable to reserve cache` annotations.
- `scan-action` exposes no `cache-key` override, so the only way to stop the collision is to disable its DB caching (`cache-db: false`). Scans stay correct; they simply re-download the database on `main`.

## Test plan
- `actionlint` on the touched workflow files passes.
- After merge, confirm no `Unable to reserve cache` warning for `grype-db-v0.110.0` on the next `main` run.

🤖 Generated with [opencode](https://opencode.ai)