### PR TITLE
fix: align SPDX identifiers with MIT LICENSE

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Bug Report
 description: File a bug report to help us improve

--- a/.github/actions/latest-release-info/action.yml
+++ b/.github/actions/latest-release-info/action.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Get latest release info
 description: Gets the semantic version and tag name of the latest release

--- a/.github/actions/sbom/action.yml
+++ b/.github/actions/sbom/action.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Create and scan sbom action
 description: Creates and scans the sbom for security vulnerabilities

--- a/.github/actions/setup-rust-cache/action.yml
+++ b/.github/actions/setup-rust-cache/action.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Setup rust cache
 description: Sets up rust cache

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Setup sccache
 description: Sets up sccache

--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Setup tauri
 description: Sets up tauri

--- a/.github/actions/sync-version/action.yml
+++ b/.github/actions/sync-version/action.yml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Sync version from tag
 description: Derives the release version from a tag and syncs it into the workspace Cargo.toml files, the Tauri config and the Cargo.lock. Does not commit anything.

--- a/.github/cliff-release.toml
+++ b/.github/cliff-release.toml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 # git-cliff configuration for generating GitHub release notes in the same
 # format the previous release-drafter setup produced.

--- a/.github/docker/mdns-browser-arch-aur-builder/Dockerfile
+++ b/.github/docker/mdns-browser-arch-aur-builder/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 FROM archlinux:base-devel@sha256:68bfc3b0d277b08a99101dc9b94aaa03e5ae70cf1b4fb965c03b2b87b915760d
 RUN pacman -Syu --noconfirm \

--- a/.github/docker/mdns-browser-ubuntu-builder/Dockerfile
+++ b/.github/docker/mdns-browser-ubuntu-builder/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 FROM ubuntu:latest@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b
 RUN apt-get update \

--- a/.github/workflows/android-reusable.yml
+++ b/.github/workflows/android-reusable.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: "Reusable android workflow"
 

--- a/.github/workflows/aur-reusable.yml
+++ b/.github/workflows/aur-reusable.yml
@@ -1,5 +1,5 @@
 # Copyright 2025-2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Arch linux AUR
 

--- a/.github/workflows/cache-tools-reusable.yml
+++ b/.github/workflows/cache-tools-reusable.yml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: "Reusable cache tools for release workflow"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: "CI"
 

--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: "Reusable desktop tauri build workflow"
 

--- a/.github/workflows/homebrew-reusable.yml
+++ b/.github/workflows/homebrew-reusable.yml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Update Homebrew Tap
 

--- a/.github/workflows/lint-reusable.yml
+++ b/.github/workflows/lint-reusable.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: "Reusable ci lint workflow"
 

--- a/.github/workflows/publish-crate-reusable.yml
+++ b/.github/workflows/publish-crate-reusable.yml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Publish Crate (reusable)
 

--- a/.github/workflows/publish-tauri-plugin-android-update.yml
+++ b/.github/workflows/publish-tauri-plugin-android-update.yml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Publish tauri-plugin-android-update
 

--- a/.github/workflows/publish-webkit2gtk-nvidia-quirk.yml
+++ b/.github/workflows/publish-webkit2gtk-nvidia-quirk.yml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Publish webkit2gtk-nvidia-quirk
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Release
 

--- a/.github/workflows/retry-failed-ci.yml
+++ b/.github/workflows/retry-failed-ci.yml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Retry Failed CI
 

--- a/.github/workflows/snap-reusable.yml
+++ b/.github/workflows/snap-reusable.yml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Update Snap
 

--- a/.github/workflows/source-checksums-reusable.yml
+++ b/.github/workflows/source-checksums-reusable.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Create and publish source checksum
 on:

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: "Reusable ci test workflow"
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: "📝 Update Changelog"
 

--- a/.github/workflows/winget-reusable.yml
+++ b/.github/workflows/winget-reusable.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 name: Publish Desktop Release to WinGet
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ actionlint .github/workflows/*.yml
 All source files must include:
 ```rust
 // Copyright 2026 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 ```
 
 ### Rust Code Style

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 [package]
 name = "mdns-browser-ui"

--- a/cliff-tauri-plugin-android-update.toml
+++ b/cliff-tauri-plugin-android-update.toml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 [changelog]
 # changelog header

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright 2026 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use reactive_stores::Store;
 use serde::{Deserialize, Serialize};

--- a/crates/shared_constants/src/lib.rs
+++ b/crates/shared_constants/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use std::time::Duration;
 pub const MDNS_SD_META_SERVICE: &str = "_services._dns-sd._udp.local.";

--- a/crates/tauri-plugin-android-update/Cargo.toml
+++ b/crates/tauri-plugin-android-update/Cargo.toml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 [package]
 name = "tauri-plugin-android-update"

--- a/crates/tauri-plugin-android-update/build.rs
+++ b/crates/tauri-plugin-android-update/build.rs
@@ -1,5 +1,5 @@
 // Copyright 2026 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 const COMMANDS: &[&str] = &["check", "download_and_install"];
 

--- a/crates/tauri-plugin-android-update/src/lib.rs
+++ b/crates/tauri-plugin-android-update/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright 2026 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 //! # tauri-plugin-android-update
 //!

--- a/crates/webkit2gtk-nvidia-quirk/Cargo.toml
+++ b/crates/webkit2gtk-nvidia-quirk/Cargo.toml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 [package]
 name = "webkit2gtk-nvidia-quirk"

--- a/crates/webkit2gtk-nvidia-quirk/src/lib.rs
+++ b/crates/webkit2gtk-nvidia-quirk/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright 2026 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 //! # webkit2gtk-nvidia-quirk
 //!

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <!--
  Copyright 2024-2025 hrzlgnm
- SPDX-License-Identifier: MIT-0
+ SPDX-License-Identifier: MIT
 -->
 
 <html>

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /**
  * Copyright 2024-2025 hrzlgnm
- * SPDX-License-Identifier: MIT-0
+ * SPDX-License-Identifier: MIT
  */
 
 /**

--- a/packaging/aur/generate-mdns-browser-bin.sh
+++ b/packaging/aur/generate-mdns-browser-bin.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright 2024-2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 version=$1
 sha256sum=$2

--- a/packaging/aur/generate-mdns-browser.sh
+++ b/packaging/aur/generate-mdns-browser.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright 2024-2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 version=$1
 sha256sum=$2

--- a/packaging/aur/makepkg-lint.sh
+++ b/packaging/aur/makepkg-lint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright 2024-2025 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 set -e
 

--- a/public/splashscreen.html
+++ b/public/splashscreen.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!--
  Copyright 2024-2025 hrzlgnm
- SPDX-License-Identifier: MIT-0
+ SPDX-License-Identifier: MIT
 -->
 
 <html lang="en">

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 # Copyright 2026 hrzlgnm
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT
 
 [package]
 name = "mdns-browser"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 fn main() {
     tauri_build::build()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2026 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 #[cfg(desktop)]
 use clap::builder::TypedValueParser as _;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 fn main() {
     mdns_browser_lib::run();

--- a/src/app/about.rs
+++ b/src/app/about.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use leptos::prelude::*;
 use leptos::task::spawn_local;

--- a/src/app/backtop.rs
+++ b/src/app/backtop.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use js_sys::{
     Function,

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -1,5 +1,5 @@
 // Copyright 2026 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use chrono::{DateTime, Local};
 use leptos::prelude::*;

--- a/src/app/clipboard.rs
+++ b/src/app/clipboard.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use leptos::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/src/app/css.rs
+++ b/src/app/css.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use leptos::prelude::{Get, ReadSignal, Signal};
 

--- a/src/app/invoke.rs
+++ b/src/app/invoke.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use tauri_sys::core::invoke;
 

--- a/src/app/is_desktop.rs
+++ b/src/app/is_desktop.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use leptos::prelude::{ReadSignal, Update, WriteSignal, expect_context};
 use tauri_sys::core::invoke;

--- a/src/app/listen.rs
+++ b/src/app/listen.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use super::invoke::invoke_no_args;
 use futures::{StreamExt, select};

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use super::{
     about::About,

--- a/src/app/metrics.rs
+++ b/src/app/metrics.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use leptos::prelude::*;
 use models::MetricsChangedEvent;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 mod about;
 mod backtop;

--- a/src/app/network_interfaces.rs
+++ b/src/app/network_interfaces.rs
@@ -1,5 +1,5 @@
 // Copyright 2026 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use leptos::prelude::*;
 use models::*;

--- a/src/app/protocol_flags.rs
+++ b/src/app/protocol_flags.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use leptos::prelude::*;
 use reactive_stores::Store;

--- a/src/app/theme_switcher.rs
+++ b/src/app/theme_switcher.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use leptos::prelude::*;
 use models::ThemeChangedEvent;

--- a/src/app/values_table.rs
+++ b/src/app/values_table.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 use leptos::prelude::*;
 use thaw::{Table, TableBody, TableCell, TableCellLayout, TableHeader, TableHeaderCell, TableRow};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 // Copyright 2024-2025 hrzlgnm
-// SPDX-License-Identifier: MIT-0
+// SPDX-License-Identifier: MIT
 
 mod app;
 

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
 /**
  * Copyright 2024-2025 hrzlgnm
- * SPDX-License-Identifier: MIT-0
+ * SPDX-License-Identifier: MIT
  */
 
 /** common styles for all components **/


### PR DESCRIPTION
LICENSE is the standard MIT license (attribution required). Source and config files declared MIT-0 (No Attribution), a different license. Update all SPDX-License-Identifier tags to MIT to match LICENSE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated SPDX license identifiers across project source files, build configuration, packaging metadata, automation, and documentation from `MIT-0` to `MIT`.
  - Aligned file-header guidance with the standard `MIT` identifier.

- **Chores**
  - Standardized licensing metadata throughout the project.
  - No functional, behavioral, or user interface changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->