### PR TITLE
fix: attest plain-binary provenance before bundle recompile

### DIFF
--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -293,6 +293,7 @@ jobs:
         with:
           subject-path: |
             target/release/bundle/nsis/*
+            target/release/bundle/msi/*
             target/**/release/bundle/macos/*.tar.gz*
             target/**/release/bundle/dmg/*.dmg
             target/release/bundle/deb/*.deb

--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -150,6 +150,14 @@ jobs:
           retryAttempts: 1
           uploadPlainBinary: true
 
+      - name: 🛡️ Attest build provenance (plain binary)
+        if: inputs.tagName
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-path: |
+            target/**/release/mdns-browser
+            target/release/mdns-browser.exe
+
       - name: 🔨 Build bundles using tauri action (publish artifacts on release)
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
         env:
@@ -269,14 +277,6 @@ jobs:
             exit 1
           fi
           gh release upload "$TAG_NAME" "${ASSETS[@]}" --clobber
-
-      - name: 🛡️ Attest build provenance (plain binary)
-        if: inputs.tagName
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
-        with:
-          subject-path: |
-            target/**/release/mdns-browser
-            target/release/mdns-browser.exe
 
       - name: 🛡️ Attest SBOM (plain binary)
         if: inputs.tagName

--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -158,6 +158,15 @@ jobs:
             target/**/release/mdns-browser
             target/release/mdns-browser.exe
 
+      - name: 🛡️ Attest SBOM (plain binary)
+        if: inputs.tagName
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-path: |
+            target/**/release/mdns-browser
+            target/release/mdns-browser.exe
+          sbom-path: "sbom.spdx.json"
+
       - name: 🔨 Build bundles using tauri action (publish artifacts on release)
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
         env:
@@ -277,15 +286,6 @@ jobs:
             exit 1
           fi
           gh release upload "$TAG_NAME" "${ASSETS[@]}" --clobber
-
-      - name: 🛡️ Attest SBOM (plain binary)
-        if: inputs.tagName
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
-        with:
-          subject-path: |
-            target/**/release/mdns-browser
-            target/release/mdns-browser.exe
-          sbom-path: "sbom.spdx.json"
 
       - name: 🛡️ Attest build provenance (bundles)
         if: inputs.tagName


### PR DESCRIPTION
## Summary

The plain-binary build uploads `mdns-browser_linux_x64` via tauri-action's
`uploadPlainBinary`, but both the SLSA build-provenance attest step and the
plain-binary SBOM attest step ran **after** the separate bundle build
recompiled the binary. They therefore attested the recompiled binary's
digest, not the one shipped in the release — so `gh attestation verify
mdns-browser_linux_x64` found no matching attestation (only the auto release
attestation).

This moves both plain-binary attest steps to immediately after the
plain-binary build (mirroring the zux workflow), so they attest the released
artifact. The bundle build keeps its own provenance attest step afterwards.

It also adds `bundle/msi/*` to the bundles provenance attest step, which
only covered nsis/dmg/deb/rpm and left the `.msi` Windows installer without
provenance (the zux workflow attests its msi bundles).

## Issue

None.

## Testing performed

- Validated `.github/workflows/desktop-reusable.yml` parses
  (`python3 -c "import yaml"`).
- Confirmed step ordering: Build plain (135) -> Attest provenance (plain)
  (153) -> Attest SBOM (plain) (161) -> Build bundles (170) -> Attest
  provenance (bundles) (292, now including `bundle/msi/*`).
- Could not run the release CI in this environment; the real check is to cut
  a release from this branch and confirm
  `gh attestation verify mdns-browser_linux_x64 --repo hrzlgnm/mdns-browser`
  exits 0 with predicate `https://slsa.dev/provenance/v1`, and that
  `mdns-browser-snap`'s verification passes once its `source-tag` is bumped
  to that release.
