### PR TITLE
fix: publish gzipped SBOMs as release assets

### DIFF
--- a/.github/workflows/android-reusable.yml
+++ b/.github/workflows/android-reusable.yml
@@ -147,6 +147,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ inputs.tagName }}
         run: |
+          cp sbom.spdx.json.gz sbom.android.spdx.json.gz
           gh release upload "$TAG_NAME" "sbom.android.spdx.json.gz" --clobber
 
       - name: 🛡️ Attest build provenance (publish only)

--- a/.github/workflows/android-reusable.yml
+++ b/.github/workflows/android-reusable.yml
@@ -140,6 +140,15 @@ jobs:
             exit 1
           fi
 
+      - name: 📤 Publish SBOM to release
+        if: inputs.tagName
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tagName }}
+        run: |
+          gh release upload "$TAG_NAME" "sbom.android.spdx.json.gz" --clobber
+
       - name: 🛡️ Attest build provenance (publish only)
         if: inputs.tagName
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4

--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -287,6 +287,18 @@ jobs:
           fi
           gh release upload "$TAG_NAME" "${ASSETS[@]}" --clobber
 
+      - name: 📤 Publish SBOM to release
+        if: inputs.tagName
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tagName }}
+          SBOM_PLATFORM: ${{ matrix.platform }}
+        run: |
+          SBOM_FILE="sbom.${SBOM_PLATFORM}.spdx.json.gz"
+          cp sbom.spdx.json.gz "$SBOM_FILE"
+          gh release upload "$TAG_NAME" "$SBOM_FILE" --clobber
+
       - name: 🛡️ Attest build provenance (bundles)
         if: inputs.tagName
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4


### PR DESCRIPTION
## Summary

PR #2527 gzipped the SBOM output in `.github/actions/sbom/action.yml` and disabled `anchore/sbom-action`'s `upload-release-assets`, but nothing re-wired the compressed file into `gh release upload`. As a result, SBOMs disappeared from GitHub release assets entirely.

This restores them by publishing the gzipped SBOM per platform:
- **desktop-reusable.yml**: uploads `sbom.<Platform>.spdx.json.gz` (Linux/macOS/Windows) beside the debug-symbols publish step, gated on `inputs.tagName`.
- **android-reusable.yml**: uploads `sbom.android.spdx.json.gz` beside the APK publish step.

Both steps `cp sbom.spdx.json.gz` to the platform-named file before upload, since the sbom action only produces `sbom.spdx.json.gz` on disk.

## Testing

- `actionlint .github/workflows/*.yml` passes clean.

## Notes

The branch contains a `fixup!` commit correcting the initial Android `cp`; fold it in with `git rebase --autosquash` on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Software Bill of Materials (SBOM) files are now automatically published to Android and desktop release pages.
  * Release SBOM files use platform-specific names and replace existing versions when re-uploaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->