### PR TITLE
docs: mount .github for renovate validator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ leptosfmt src                                   # format Leptos components
 cargo clippy --workspace --tests -- -D warnings # lint
 
 # Validate renovate configuration (when .github/renovate.json5 changed)
-docker run --rm --volume=$(pwd):$(pwd):ro --workdir=$(pwd) kokuwaio/renovate-config-validator:latest
+docker run --rm --volume=$(pwd)/.github:/github:ro --workdir=/github kokuwaio/renovate-config-validator:latest
 ```
 
 ### Full check (run before every commit)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ leptosfmt src                                   # format Leptos components
 cargo clippy --workspace --tests -- -D warnings # lint
 
 # Validate renovate configuration (when .github/renovate.json5 changed)
-docker run --rm --volume=$(pwd)/.github:/github:ro --workdir=/github kokuwaio/renovate-config-validator:latest
+docker run --rm --volume=$(pwd)/.github/renovate.json5:/github/renovate.json5:ro kokuwaio/renovate-config-validator:latest
 ```
 
 ### Full check (run before every commit)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ leptosfmt src                                   # format Leptos components
 cargo clippy --workspace --tests -- -D warnings # lint
 
 # Validate renovate configuration (when .github/renovate.json5 changed)
-docker run --rm --volume=$(pwd)/.github/renovate.json5:/github/renovate.json5:ro kokuwaio/renovate-config-validator:latest
+docker run --rm --volume=$(pwd)/.github/renovate.json5:/github/renovate.json5:ro --workdir=/github kokuwaio/renovate-config-validator:latest
 ```
 
 ### Full check (run before every commit)


### PR DESCRIPTION
Avoid false positive when validating Renovate config.

The validator image's entrypoint does:
```bash
find "$PWD" -type f \( -name 'default.json' -o -name 'renovate.json5' ... \) -not -path '*/node_modules/*'
```

Mounting the whole repo (`--volume=$(pwd):$(pwd)`) causes `src-tauri/capabilities/default.json` (Tauri capability, not Renovate) to be matched and validated as Renovate config, failing with `Invalid configuration option: identifier/permissions/windows` (seen in zux). Mounting only the config file isolates it:

```bash
docker run --rm --volume=$(pwd)/.github/renovate.json5:/github/renovate.json5:ro --workdir=/github kokuwaio/renovate-config-validator:latest
```

**Changes:**
- `AGENTS.md:59` – `$(pwd):$(pwd)` → `$(pwd)/.github:/github:ro` → `$(pwd)/.github/renovate.json5:/github/renovate.json5:ro --workdir=/github` (least exposure, consistent with zux fix).
- Validated both repos with file mount → `Config validated successfully against 1 file(s)` (previously `zux` failed on whole-repo mount due to `default.json` match; `mdns-browser` `migrated.json`/`mobile.json` currently safe but future-proof).

**Testing:**
- `docker run --rm --volume=$(pwd)/.github/renovate.json5:/github/renovate.json5:ro --workdir=/github kokuwaio/renovate-config-validator:latest` – `zux` and `mdns-browser` both exit 0.
- `git diff main...HEAD` – 1 file: `AGENTS.md` (1 line).

Follow-up to https://github.com/hrzlgnm/zux/pull/244 discussion.
