### PR TITLE
feat(ci): add shared retry wrapper and use for downloads

### DIFF
--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -1,0 +1,42 @@
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT-0
+
+name: Retry command
+description: Shared wrapper around nick-fields/retry with repo defaults (node24)
+
+inputs:
+  command:
+    description: The command to run
+    required: true
+  timeout_minutes:
+    description: Minutes to wait before attempt times out
+    required: false
+    default: '5'
+  max_attempts:
+    description: Number of attempts to make before failing
+    required: false
+    default: '5'
+  retry_wait_seconds:
+    description: Number of seconds to wait before next retry
+    required: false
+    default: '10'
+  warning_on_retry:
+    description: Whether to output a warning on retry
+    required: false
+    default: 'true'
+  shell:
+    description: Alternate shell to use
+    required: false
+    default: 'bash'
+
+runs:
+  using: composite
+  steps:
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        command: ${{ inputs.command }}
+        timeout_minutes: ${{ inputs.timeout_minutes }}
+        max_attempts: ${{ inputs.max_attempts }}
+        retry_wait_seconds: ${{ inputs.retry_wait_seconds }}
+        warning_on_retry: ${{ inputs.warning_on_retry }}
+        shell: ${{ inputs.shell }}

--- a/.github/workflows/aur-reusable.yml
+++ b/.github/workflows/aur-reusable.yml
@@ -180,16 +180,19 @@ jobs:
                 \$GENERATE_SCRIPT \"\$RELEASE_VERSION\" \"\$SHA256\" \"\$TAG_NAME\" > ~/aur/PKGBUILD
               fi
               cd ~/aur
-              if [[ -z \$(git status --porcelain) ]]; then
-                echo \"No changes\"
-                exit 0
+              if [[ -n \$(git status --porcelain) ]]; then
+                makepkg --printsrcinfo > .SRCINFO
+                makepkg
+                makepkg --install --noconfirm
+                git config user.name \"hrzlgnm\"
+                git config user.email \"hrzlgnm@users.noreply.github.com\"
+                git add PKGBUILD .SRCINFO
+                git commit -m \"New upstream release \$RELEASE_VERSION\"
+              else
+                echo "No changes (already committed on previous retry or up to date)"
               fi
-              makepkg --printsrcinfo > .SRCINFO
-              makepkg
-              makepkg --install --noconfirm
-              git config user.name \"hrzlgnm\"
-              git config user.email \"hrzlgnm@users.noreply.github.com\"
-              git add PKGBUILD .SRCINFO
-              git commit -m \"New upstream release \$RELEASE_VERSION\"
+              # Always push: on retry after commit-but-push-failed the
+              # worktree is clean, so exiting early would skip the push.
+              # A failed push stays a failed attempt and is retried.
               git push origin master
             "

--- a/.github/workflows/aur-reusable.yml
+++ b/.github/workflows/aur-reusable.yml
@@ -51,36 +51,38 @@ jobs:
 
       - name: 🔢 Get sha256sums
         id: sha256sums
-        shell: bash
+        uses: ./.github/actions/retry
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ needs.release-info.outputs.tagName }}
           PACKAGE_NAME: ${{ matrix.package.name }}
           RELEASE_VERSION: ${{ needs.release-info.outputs.version }}
           NEEDS_EXE: ${{ matrix.package.needs_exe }}
-        run: |
-          if [[ "$PACKAGE_NAME" == "mdns-browser-bin" ]]; then
-            ASSETS=$(gh release view "$TAG_NAME" --repo hrzlgnm/mdns-browser --json assets --jq '.assets | map(select(.name | test("\\.sha256$") | not))')
-            SUM=$(echo "$ASSETS" | jq -r --arg name "mdns-browser_${RELEASE_VERSION}_amd64.deb" '.[] | select(.name == $name) | .digest')
-            if [[ -z "$SUM" ]]; then
-              echo "Error: Failed to get checksum from GitHub API for release $TAG_NAME"
-              exit 1
-            fi
-            echo "sha256=$SUM" >> "$GITHUB_OUTPUT"
-            if [[ "$NEEDS_EXE" == "true" ]]; then
-              SUM_EXE=$(echo "$ASSETS" | jq -r --arg name "mdns-browser_linux_x64" '.[] | select(.name == $name) | .digest')
-              if [[ -z "$SUM_EXE" ]]; then
-                echo "Error: Failed to get exe checksum from GitHub API for release $TAG_NAME"
+        with:
+          command: |
+            set -o pipefail
+            if [[ "$PACKAGE_NAME" == "mdns-browser-bin" ]]; then
+              ASSETS=$(gh release view "$TAG_NAME" --repo hrzlgnm/mdns-browser --json assets --jq '.assets | map(select(.name | test("\\.sha256$") | not))')
+              SUM=$(echo "$ASSETS" | jq -r --arg name "mdns-browser_${RELEASE_VERSION}_amd64.deb" '.[] | select(.name == $name) | .digest')
+              if [[ -z "$SUM" ]]; then
+                echo "Error: Failed to get checksum from GitHub API for release $TAG_NAME"
                 exit 1
               fi
-              echo "sha256_exe=$SUM_EXE" >> "$GITHUB_OUTPUT"
+              echo "sha256=$SUM" >> "$GITHUB_OUTPUT"
+              if [[ "$NEEDS_EXE" == "true" ]]; then
+                SUM_EXE=$(echo "$ASSETS" | jq -r --arg name "mdns-browser_linux_x64" '.[] | select(.name == $name) | .digest')
+                if [[ -z "$SUM_EXE" ]]; then
+                  echo "Error: Failed to get exe checksum from GitHub API for release $TAG_NAME"
+                  exit 1
+                fi
+                echo "sha256_exe=$SUM_EXE" >> "$GITHUB_OUTPUT"
+              fi
+            else
+              URL="https://github.com/hrzlgnm/mdns-browser/releases/download/$TAG_NAME/$TAG_NAME.tar.gz.sha256"
+              echo "getting $URL"
+              SUM=$(curl -LfsS --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 15 "$URL" | cut -d' ' -f1)
+              echo "sha256=$SUM" >> "$GITHUB_OUTPUT"
             fi
-          else
-            URL="https://github.com/hrzlgnm/mdns-browser/releases/download/$TAG_NAME/$TAG_NAME.tar.gz.sha256"
-            echo "getting $URL"
-            SUM=$(curl -LfsS "$URL" | cut -d' ' -f1)
-            echo "sha256=$SUM" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: 📐 Lint generated PKGBUILD
         shell: bash
@@ -91,7 +93,8 @@ jobs:
           GENERATE_SCRIPT: ${{ matrix.package.generate_script }}
           RELEASE_VERSION: ${{ needs.release-info.outputs.version }}
           SHA256: ${{ steps.sha256sums.outputs.sha256 }}
-        run: |
+        with:
+          command: |
           su runner -c "
             set -o errexit
             mkdir -p ~/lint
@@ -106,10 +109,11 @@ jobs:
           "
       - name: 🛠️ Setup Deployment keys
         if: github.event.release.tag_name
-        shell: bash
+        uses: ./.github/actions/retry
         env:
           AUR_DEPLOY_KEY: ${{ secrets.AUR_DEPLOY_KEY }}
-        run: |
+        with:
+          command: |
           chown -R runner:runner .
           su runner -c "
             set -o errexit
@@ -124,10 +128,11 @@ jobs:
 
       - name: 🔄 Clone AUR Repo
         if: github.event.release.tag_name
-        shell: bash
+        uses: ./.github/actions/retry
         env:
           PACKAGE_NAME: ${{ matrix.package.name }}
-        run: |
+        with:
+          command: |
           su runner -c "
             set -o errexit
             git clone --depth=1 \"ssh://aur@aur.archlinux.org/\$PACKAGE_NAME.git\" ~/aur
@@ -153,7 +158,7 @@ jobs:
 
       - name: 🌀 Generate PKGBUILD update and publish
         if: github.event.release.tag_name
-        shell: bash
+        uses: ./.github/actions/retry
         env:
           SHA256_EXE: ${{ steps.sha256sums.outputs.sha256_exe }}
           TAG_NAME: ${{ needs.release-info.outputs.tagName }}
@@ -161,7 +166,8 @@ jobs:
           GENERATE_SCRIPT: ${{ matrix.package.generate_script }}
           RELEASE_VERSION: ${{ needs.release-info.outputs.version }}
           SHA256: ${{ steps.sha256sums.outputs.sha256 }}
-        run: |
+        with:
+          command: |
           su runner -c "
             set -o errexit
             if [[ \"\$NEEDS_EXE\" == \"true\" ]]; then

--- a/.github/workflows/aur-reusable.yml
+++ b/.github/workflows/aur-reusable.yml
@@ -156,6 +156,7 @@ jobs:
           command: |
             su runner -c "
               set -o errexit
+              rm -rf ~/aur
               git clone --depth=1 \"ssh://aur@aur.archlinux.org/\$PACKAGE_NAME.git\" ~/aur
             "
 

--- a/.github/workflows/aur-reusable.yml
+++ b/.github/workflows/aur-reusable.yml
@@ -127,7 +127,24 @@ jobs:
               echo \"Host aur.archlinux.org\" >> ~/.ssh/config
               echo \"  IdentityFile ~/.ssh/aur\" >> ~/.ssh/config
               echo \"  User aur\" >> ~/.ssh/config
-              ssh-keyscan -H aur.archlinux.org >> ~/.ssh/known_hosts
+              # Arch-published AUR SSH host key fingerprints, see
+              # https://archlinux.org/news/aur-migration-new-ssh-hostkeys/
+              AUR_SSH_FPS="SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4 SHA256:uTa/0PndEgPZTf76e1DFqXKJEXKsn7m9ivhLQtzGOCI SHA256:5s5cIyReIfNNVGRFdDbe3hdYiI5OelHGpw2rOUud3Q8"
+              ssh-keyscan -H aur.archlinux.org > ~/.ssh/aur-known-hosts.tmp
+              if [ ! -s ~/.ssh/aur-known-hosts.tmp ]; then
+                echo "::error::ssh-keyscan returned no host keys for aur.archlinux.org"
+                exit 1
+              fi
+              while read -r host type key; do
+                case "\$host" in #*|"") continue;; esac
+                fp=\$(printf '%s %s' "\$type" "\$key" | ssh-keygen -lf /dev/stdin -E sha256 | awk '{print \$2}')
+                case " \$AUR_SSH_FPS " in
+                  *" \$fp "*) ;;
+                  *) echo "::error::AUR host key \$type fingerprint \$fp not in Arch-published set, refusing" ; exit 1 ;;
+                esac
+              done < ~/.ssh/aur-known-hosts.tmp
+              cat ~/.ssh/aur-known-hosts.tmp >> ~/.ssh/known_hosts
+              rm -f ~/.ssh/aur-known-hosts.tmp
             "
 
       - name: 🔄 Clone AUR Repo

--- a/.github/workflows/aur-reusable.yml
+++ b/.github/workflows/aur-reusable.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: 🔢 Get sha256sums
         id: sha256sums
-        uses: ./.github/actions/retry
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ needs.release-info.outputs.tagName }}
@@ -59,6 +59,10 @@ jobs:
           RELEASE_VERSION: ${{ needs.release-info.outputs.version }}
           NEEDS_EXE: ${{ matrix.package.needs_exe }}
         with:
+          timeout_minutes: 5
+          max_attempts: 5
+          retry_wait_seconds: 10
+          warning_on_retry: true
           command: |
             set -o pipefail
             if [[ "$PACKAGE_NAME" == "mdns-browser-bin" ]]; then
@@ -85,7 +89,7 @@ jobs:
             fi
 
       - name: 📐 Lint generated PKGBUILD
-        shell: bash
+        uses: ./.github/actions/retry
         env:
           SHA256_EXE: ${{ steps.sha256sums.outputs.sha256_exe }}
           TAG_NAME: ${{ needs.release-info.outputs.tagName }}
@@ -95,18 +99,18 @@ jobs:
           SHA256: ${{ steps.sha256sums.outputs.sha256 }}
         with:
           command: |
-          su runner -c "
-            set -o errexit
-            mkdir -p ~/lint
-            o=\$(pwd)
-            if [[ \"\$NEEDS_EXE\" == \"true\" ]]; then
-              \$GENERATE_SCRIPT \"\$RELEASE_VERSION\" \"\$SHA256\" \"\$SHA256_EXE\" \"\$TAG_NAME\" > ~/lint/PKGBUILD
-            else
-              \$GENERATE_SCRIPT \"\$RELEASE_VERSION\" \"\$SHA256\" \"\$TAG_NAME\" > ~/lint/PKGBUILD
-            fi
-            cd ~/lint
-            \"\$o/packaging/aur/makepkg-lint.sh\"
-          "
+            su runner -c "
+              set -o errexit
+              mkdir -p ~/lint
+              o=\$(pwd)
+              if [[ \"\$NEEDS_EXE\" == \"true\" ]]; then
+                \$GENERATE_SCRIPT \"\$RELEASE_VERSION\" \"\$SHA256\" \"\$SHA256_EXE\" \"\$TAG_NAME\" > ~/lint/PKGBUILD
+              else
+                \$GENERATE_SCRIPT \"\$RELEASE_VERSION\" \"\$SHA256\" \"\$TAG_NAME\" > ~/lint/PKGBUILD
+              fi
+              cd ~/lint
+              \"\$o/packaging/aur/makepkg-lint.sh\"
+            "
       - name: 🛠️ Setup Deployment keys
         if: github.event.release.tag_name
         uses: ./.github/actions/retry
@@ -114,17 +118,17 @@ jobs:
           AUR_DEPLOY_KEY: ${{ secrets.AUR_DEPLOY_KEY }}
         with:
           command: |
-          chown -R runner:runner .
-          su runner -c "
-            set -o errexit
-            mkdir -p ~/.ssh
-            printf '%s\n' \"\$AUR_DEPLOY_KEY\" > ~/.ssh/aur
-            chmod 600 ~/.ssh/aur
-            echo \"Host aur.archlinux.org\" >> ~/.ssh/config
-            echo \"  IdentityFile ~/.ssh/aur\" >> ~/.ssh/config
-            echo \"  User aur\" >> ~/.ssh/config
-            ssh-keyscan -H aur.archlinux.org >> ~/.ssh/known_hosts
-          "
+            chown -R runner:runner .
+            su runner -c "
+              set -o errexit
+              mkdir -p ~/.ssh
+              printf '%s\n' \"\$AUR_DEPLOY_KEY\" > ~/.ssh/aur
+              chmod 600 ~/.ssh/aur
+              echo \"Host aur.archlinux.org\" >> ~/.ssh/config
+              echo \"  IdentityFile ~/.ssh/aur\" >> ~/.ssh/config
+              echo \"  User aur\" >> ~/.ssh/config
+              ssh-keyscan -H aur.archlinux.org >> ~/.ssh/known_hosts
+            "
 
       - name: 🔄 Clone AUR Repo
         if: github.event.release.tag_name
@@ -133,10 +137,10 @@ jobs:
           PACKAGE_NAME: ${{ matrix.package.name }}
         with:
           command: |
-          su runner -c "
-            set -o errexit
-            git clone --depth=1 \"ssh://aur@aur.archlinux.org/\$PACKAGE_NAME.git\" ~/aur
-          "
+            su runner -c "
+              set -o errexit
+              git clone --depth=1 \"ssh://aur@aur.archlinux.org/\$PACKAGE_NAME.git\" ~/aur
+            "
 
       - name: 🔍 Check version
         if: github.event.release.tag_name
@@ -168,24 +172,24 @@ jobs:
           SHA256: ${{ steps.sha256sums.outputs.sha256 }}
         with:
           command: |
-          su runner -c "
-            set -o errexit
-            if [[ \"\$NEEDS_EXE\" == \"true\" ]]; then
-              \$GENERATE_SCRIPT \"\$RELEASE_VERSION\" \"\$SHA256\" \"\$SHA256_EXE\" \"\$TAG_NAME\" > ~/aur/PKGBUILD
-            else
-              \$GENERATE_SCRIPT \"\$RELEASE_VERSION\" \"\$SHA256\" \"\$TAG_NAME\" > ~/aur/PKGBUILD
-            fi
-            cd ~/aur
-            if [[ -z \$(git status --porcelain) ]]; then
-              echo \"No changes\"
-              exit 0
-            fi
-            makepkg --printsrcinfo > .SRCINFO
-            makepkg
-            makepkg --install --noconfirm
-            git config user.name \"hrzlgnm\"
-            git config user.email \"hrzlgnm@users.noreply.github.com\"
-            git add PKGBUILD .SRCINFO
-            git commit -m \"New upstream release \$RELEASE_VERSION\"
-            git push origin master
-          "
+            su runner -c "
+              set -o errexit
+              if [[ \"\$NEEDS_EXE\" == \"true\" ]]; then
+                \$GENERATE_SCRIPT \"\$RELEASE_VERSION\" \"\$SHA256\" \"\$SHA256_EXE\" \"\$TAG_NAME\" > ~/aur/PKGBUILD
+              else
+                \$GENERATE_SCRIPT \"\$RELEASE_VERSION\" \"\$SHA256\" \"\$TAG_NAME\" > ~/aur/PKGBUILD
+              fi
+              cd ~/aur
+              if [[ -z \$(git status --porcelain) ]]; then
+                echo \"No changes\"
+                exit 0
+              fi
+              makepkg --printsrcinfo > .SRCINFO
+              makepkg
+              makepkg --install --noconfirm
+              git config user.name \"hrzlgnm\"
+              git config user.email \"hrzlgnm@users.noreply.github.com\"
+              git add PKGBUILD .SRCINFO
+              git commit -m \"New upstream release \$RELEASE_VERSION\"
+              git push origin master
+            "

--- a/.github/workflows/homebrew-reusable.yml
+++ b/.github/workflows/homebrew-reusable.yml
@@ -32,6 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     name: 🍺 Update Homebrew Tap
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+
       - name: 🔄 Checkout Tap Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -40,11 +44,12 @@ jobs:
           path: homebrew-tap
 
       - name: 📥 Download DMG Checksum
-        shell: bash
+        uses: ./.github/actions/retry
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.release-info.outputs.tagName }}
-        run: |
+        with:
+          command: |
           CHECKSUM=$(gh release view "$TAG" --repo hrzlgnm/mdns-browser --json assets --jq '.assets[] | select(.name | endswith(".dmg")) | select(.name | test("universal"; "i")) | select(.name | test("\\.sha256$") | not) | .digest')
           if [ -z "$CHECKSUM" ]; then
             echo "Error: No checksum found for universal.dmg in release $TAG"
@@ -70,12 +75,18 @@ jobs:
           sed -i "s/sha256 \".*\"/sha256 \"$CHECKSUM\"/" "$CASK_PATH"
 
       - name: 💾 Commit & Push to Tap
-        working-directory: homebrew-tap
-        run: |
-          git add Casks/mdns-browser.rb
-          if ! git diff --cached --quiet; then
-            git commit -m "chore: update mdns-browser to v${{ needs.release-info.outputs.version }}"
+        uses: ./.github/actions/retry
+        env:
+          VERSION: ${{ needs.release-info.outputs.version }}
+        with:
+          command: |
+            cd homebrew-tap
+            git add Casks/mdns-browser.rb
+            if ! git diff --cached --quiet; then
+              git commit -m "chore: update mdns-browser to v$VERSION"
+            else
+              echo "No staged changes (already committed on previous retry or no update needed)"
+            fi
             git push
-          else
-            echo "No changes to commit"
+          # git push handled above
           fi

--- a/.github/workflows/homebrew-reusable.yml
+++ b/.github/workflows/homebrew-reusable.yml
@@ -50,14 +50,14 @@ jobs:
           TAG: ${{ needs.release-info.outputs.tagName }}
         with:
           command: |
-          CHECKSUM=$(gh release view "$TAG" --repo hrzlgnm/mdns-browser --json assets --jq '.assets[] | select(.name | endswith(".dmg")) | select(.name | test("universal"; "i")) | select(.name | test("\\.sha256$") | not) | .digest')
-          if [ -z "$CHECKSUM" ]; then
-            echo "Error: No checksum found for universal.dmg in release $TAG"
-            exit 1
-          fi
-          # strip prefix sha256:
-          CHECKSUM="${CHECKSUM#sha256:}"
-          echo "DMG_CHECKSUM=$CHECKSUM" >> "$GITHUB_ENV"
+            CHECKSUM=$(gh release view "$TAG" --repo hrzlgnm/mdns-browser --json assets --jq '.assets[] | select(.name | endswith(".dmg")) | select(.name | test("universal"; "i")) | select(.name | test("\\.sha256$") | not) | .digest')
+            if [ -z "$CHECKSUM" ]; then
+              echo "Error: No checksum found for universal.dmg in release $TAG"
+              exit 1
+            fi
+            # strip prefix sha256:
+            CHECKSUM="${CHECKSUM#sha256:}"
+            echo "DMG_CHECKSUM=$CHECKSUM" >> "$GITHUB_ENV"
 
       - name: 🔑 Configure Git Identity
         run: |
@@ -88,5 +88,3 @@ jobs:
               echo "No staged changes (already committed on previous retry or no update needed)"
             fi
             git push
-          # git push handled above
-          fi

--- a/.github/workflows/source-checksums-reusable.yml
+++ b/.github/workflows/source-checksums-reusable.yml
@@ -50,15 +50,21 @@ jobs:
       matrix:
         algorithm: [sha256]
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+
       - name: 📥🔢☑️
+        uses: ./.github/actions/retry
         env:
           TAG: ${{ needs.tag.outputs.tag }}
           ALGORITHM: ${{ matrix.algorithm }}
-        run: |
+        with:
+          command: |
           set -o errexit
           mkdir -p downloads && cd downloads
-          curl -sLO "https://github.com/hrzlgnm/mdns-browser/archive/refs/tags/${TAG}.tar.gz"
-          curl -sLO "https://github.com/hrzlgnm/mdns-browser/archive/refs/tags/${TAG}.zip"
+          curl -f -sL --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 15 -O "https://github.com/hrzlgnm/mdns-browser/archive/refs/tags/${TAG}.tar.gz"
+          curl -f -sL --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 15 -O "https://github.com/hrzlgnm/mdns-browser/archive/refs/tags/${TAG}.zip"
           for file in *; do
             if [ -f "$file" ] && [[ "$file" != *.sha* ]]; then
               "$ALGORITHM"sum "$file" > "$file.$ALGORITHM"

--- a/.github/workflows/source-checksums-reusable.yml
+++ b/.github/workflows/source-checksums-reusable.yml
@@ -61,15 +61,15 @@ jobs:
           ALGORITHM: ${{ matrix.algorithm }}
         with:
           command: |
-          set -o errexit
-          mkdir -p downloads && cd downloads
-          curl -f -sL --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 15 -O "https://github.com/hrzlgnm/mdns-browser/archive/refs/tags/${TAG}.tar.gz"
-          curl -f -sL --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 15 -O "https://github.com/hrzlgnm/mdns-browser/archive/refs/tags/${TAG}.zip"
-          for file in *; do
-            if [ -f "$file" ] && [[ "$file" != *.sha* ]]; then
-              "$ALGORITHM"sum "$file" > "$file.$ALGORITHM"
-            fi
-          done
+            set -o errexit
+            mkdir -p downloads && cd downloads
+            curl -f -sL --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 15 -O "https://github.com/hrzlgnm/mdns-browser/archive/refs/tags/${TAG}.tar.gz"
+            curl -f -sL --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 15 -O "https://github.com/hrzlgnm/mdns-browser/archive/refs/tags/${TAG}.zip"
+            for file in *; do
+              if [ -f "$file" ] && [[ "$file" != *.sha* ]]; then
+                "$ALGORITHM"sum "$file" > "$file.$ALGORITHM"
+              fi
+            done
       - name: 📤
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/winget-reusable.yml
+++ b/.github/workflows/winget-reusable.yml
@@ -49,23 +49,29 @@ jobs:
           locked: true
 
       - name: 🆙 sync our fork of winget-pkgs
+        uses: ./.github/actions/retry
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
-        run: |
-          komac sync-fork
+        with:
+          command: |
+            komac sync-fork
 
       - name: 🆙 winget package
+        uses: ./.github/actions/retry
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
-        run: |
-          komac update hrzlgnm.mdns-browser \
+        with:
+          command: |
+            komac update hrzlgnm.mdns-browser \
             --version "$VERSION" \
             --urls "$URL" \
             --submit
 
       - name: 🧹 Cleanup merged branches
         if: always()
+        uses: ./.github/actions/retry
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
-        run: |
-          komac cleanup --only-merged
+        with:
+          command: |
+            komac cleanup --only-merged

--- a/typos.toml
+++ b/typos.toml
@@ -5,4 +5,4 @@ extend-exclude = [".git/", "cliff.toml", "cliff-webkit2gtk.toml", "cliff-tauri-p
 
 [default]
 check-filename = true
-extend-ignore-re = ["digest to \\b[0-9a-f]{7,}\\b"]
+extend-ignore-re = ["digest to \\b[0-9a-f]{7,}\\b", "AUR_SSH_FPS=\"[^\"]*\""]


### PR DESCRIPTION
Follow-up to hrzlgnm/zux#286, #287 — apply same retry pattern:

- Add `.github/actions/retry` composite wrapper around `nick-fields/retry@v4` (node24, 5/5/10s) like `zux`.
- Wrap `gh release view`, `curl --retry 5 --retry-delay 5 --retry-all-errors`, and `komac sync-fork|update|cleanup` which previously had no retry.

Related to hrzlgnm/zux#286.

Co-authored-by: opencode <noreply@opencode.ai>
Assisted-by: opencode (muse-spark-1.2-contributor-free)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable retry mechanism for automated commands, with configurable timeouts, attempts, delays, and shells.

* **Bug Fixes**
  * Improved reliability of checksum downloads and package publishing workflows through automatic retries and connection timeouts.
  * Added stronger download failure handling to reduce incomplete or interrupted artifact retrievals.
  * Improved automation for repository synchronization, updates, cleanup, and publishing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->