### PR TITLE
fix(ci): quote # in host-key validation case pattern

### DIFF
--- a/.github/workflows/aur-reusable.yml
+++ b/.github/workflows/aur-reusable.yml
@@ -136,7 +136,7 @@ jobs:
                 exit 1
               fi
               while read -r host type key; do
-                case "\$host" in #*|"") continue;; esac
+                case "\$host" in '#'*|"") continue;; esac
                 fp=\$(printf '%s %s' "\$type" "\$key" | ssh-keygen -lf /dev/stdin -E sha256 | awk '{print \$2}')
                 case " \$AUR_SSH_FPS " in
                   *" \$fp "*) ;;


### PR DESCRIPTION
A bare `#` at word start comments out the rest of the line inside `su runner -c "..."\,` leaving `case` unterminated — a syntax error that only fires on release runs (PR CI skips the SSH setup step). Quoted `'#'*` preserves comment/empty-host skipping; verified with `bash -n` plus positive/negative fingerprint tests.

Validation: `actionlint` 0.

Co-authored-by: opencode <noreply@opencode.ai>
Assisted-by: opencode (muse-spark-1.2-contributor-free)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed verification of Arch-published SSH host key fingerprints so comment and empty lines are handled correctly during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->