### PR TITLE
fix(ci): stop writing cargo-install caches on tag refs

### DIFF
--- a/.github/actions/install-cargo-tool/action.yml
+++ b/.github/actions/install-cargo-tool/action.yml
@@ -1,0 +1,150 @@
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT
+
+name: Install cargo tool
+description: >-
+  Installs a Rust binary crate from crates.io. On branches it uses a cached
+  install; on tags it only restores from the shared cache and otherwise builds
+  without saving, because a cache entry saved on refs/tags/* can never be
+  reused. Only exact versions are supported so the cache key stays stable.
+
+inputs:
+  crate:
+    description: "Name of the crate to install"
+    required: true
+  version:
+    description: "Exact version of the crate to install"
+    required: true
+  features:
+    description: "Space or comma-separated list of crate features to enable"
+    required: false
+    default: ""
+  args:
+    description: "Extra arguments for cargo install (simple space-separated flags)"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    # NOTE: keep crate: and version: non-adjacent below so the renovate
+    # crate:/version: regex manager does not match the ${{ inputs.* }}
+    # expressions here.
+    - name: Install ${{ inputs.crate }} (cached)
+      if: github.ref_type != 'tag'
+      uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+      with:
+        crate: ${{ inputs.crate }}
+        locked: true
+        features: ${{ inputs.features }}
+        args: ${{ inputs.args }}
+        version: ${{ inputs.version }}
+
+    # The steps below replicate the cache key of
+    # baptiste0928/cargo-install so tag runs hit the entries warmed on main:
+    # cargo-install-{crate}-{version}-{sha256(...)[0:24]} over
+    # RUNNER_OS + RUNNER_ARCH + osVersion + cargo args.
+    - name: Compute ${{ inputs.crate }} cache key (tags)
+      if: github.ref_type == 'tag'
+      id: key
+      shell: bash
+      env:
+        INPUT_CRATE: ${{ inputs.crate }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_FEATURES: ${{ inputs.features }}
+        INPUT_ARGS: ${{ inputs.args }}
+      run: |
+        set -euo pipefail
+
+        if command -v node >/dev/null 2>&1; then
+          INSTALL_PATH="$(node -e 'const path = require("node:path"); const home = process.env.HOME ?? process.env.USERPROFILE; console.log(path.join(home, ".cargo-install", process.argv[1]));' "$INPUT_CRATE")"
+        else
+          INSTALL_PATH="$HOME/.cargo-install/$INPUT_CRATE"
+        fi
+
+        FEATURES_CSV=""
+        if [ -n "$INPUT_FEATURES" ]; then
+          FEATURES_CSV="$(printf '%s' "$INPUT_FEATURES" | tr ', ' '\n' | sed '/^$/d' | paste -sd ',' -)"
+        fi
+
+        ARGS_STR="install $INPUT_CRATE --force --root $INSTALL_PATH --version $INPUT_VERSION"
+        if [ -n "$FEATURES_CSV" ]; then
+          ARGS_STR="$ARGS_STR --features $FEATURES_CSV"
+        fi
+        if [ -n "$INPUT_ARGS" ]; then
+          ARGS_STR="$ARGS_STR $INPUT_ARGS"
+        fi
+        ARGS_STR="$ARGS_STR --locked"
+
+        OS_VERSION=""
+        case "$RUNNER_OS" in
+          Linux)
+            OS_VERSION="$(sed -n 's/^VERSION_ID="\(.*\)"$/\1/p' /etc/os-release | head -n 1)"
+            ;;
+          macOS)
+            OS_VERSION="$(sw_vers -productVersion)"
+            ;;
+          Windows)
+            MAJOR="$(pwsh -NoProfile -Command '[System.Environment]::OSVersion.Version.Major' 2>/dev/null | tr -d '\r' || pwsh.exe -NoProfile -Command '[System.Environment]::OSVersion.Version.Major' | tr -d '\r' || true)"
+            MINOR="$(pwsh -NoProfile -Command '[System.Environment]::OSVersion.Version.Minor' 2>/dev/null | tr -d '\r' || pwsh.exe -NoProfile -Command '[System.Environment]::OSVersion.Version.Minor' | tr -d '\r' || true)"
+            OS_VERSION="$MAJOR.$MINOR"
+            ;;
+        esac
+
+        HASH_KEY="${RUNNER_OS}${RUNNER_ARCH}${OS_VERSION}${ARGS_STR}"
+        if command -v sha256sum >/dev/null 2>&1; then
+          HASH="$(printf '%s' "$HASH_KEY" | sha256sum | cut -c1-24)"
+        else
+          HASH="$(printf '%s' "$HASH_KEY" | shasum -a 256 | cut -c1-24)"
+        fi
+
+        {
+          echo "key=cargo-install-$INPUT_CRATE-$INPUT_VERSION-$HASH"
+          echo "path=$INSTALL_PATH"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Restore ${{ inputs.crate }} from cache (tags)
+      if: github.ref_type == 'tag'
+      id: restore
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ${{ steps.key.outputs.path }}
+        key: ${{ steps.key.outputs.key }}
+
+    - name: Install ${{ inputs.crate }} without saving cache (tags)
+      if: github.ref_type == 'tag' && steps.restore.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        INPUT_CRATE: ${{ inputs.crate }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_FEATURES: ${{ inputs.features }}
+        INPUT_ARGS: ${{ inputs.args }}
+        INSTALL_PATH: ${{ steps.key.outputs.path }}
+      run: |
+        set -euo pipefail
+        set -f
+
+        FEATURES_CSV=""
+        if [ -n "$INPUT_FEATURES" ]; then
+          FEATURES_CSV="$(printf '%s' "$INPUT_FEATURES" | tr ', ' '\n' | sed '/^$/d' | paste -sd ',' -)"
+        fi
+
+        ARGS=(install "$INPUT_CRATE" --force --root "$INSTALL_PATH" --version "$INPUT_VERSION")
+        if [ -n "$FEATURES_CSV" ]; then
+          ARGS+=(--features "$FEATURES_CSV")
+        fi
+        if [ -n "$INPUT_ARGS" ]; then
+          # Word-splitting mirrors the action's shell-like arg parsing for
+          # simple flags; quoted args with spaces are not supported here.
+          EXTRA=($INPUT_ARGS)
+          ARGS+=("${EXTRA[@]}")
+        fi
+        ARGS+=(--locked)
+        CARGO_INSTALL_ROOT="$INSTALL_PATH" cargo "${ARGS[@]}"
+
+    - name: Add ${{ inputs.crate }} to PATH (tags)
+      if: github.ref_type == 'tag'
+      shell: bash
+      env:
+        INSTALL_PATH: ${{ steps.key.outputs.path }}
+      run: echo "$INSTALL_PATH/bin" >> "$GITHUB_PATH"

--- a/.github/actions/install-cargo-tool/action.yml
+++ b/.github/actions/install-cargo-tool/action.yml
@@ -56,6 +56,9 @@ runs:
       run: |
         set -euo pipefail
 
+        # Prefer node for the install path so it matches path.join exactly
+        # (backslash separators on Windows). Without node the key may miss
+        # and the tool is rebuilt; a miss never restores a wrong entry.
         if command -v node >/dev/null 2>&1; then
           INSTALL_PATH="$(node -e 'const path = require("node:path"); const home = process.env.HOME ?? process.env.USERPROFILE; console.log(path.join(home, ".cargo-install", process.argv[1]));' "$INPUT_CRATE")"
         else
@@ -82,7 +85,7 @@ runs:
             OS_VERSION="$(sed -n 's/^VERSION_ID="\(.*\)"$/\1/p' /etc/os-release | head -n 1)"
             ;;
           macOS)
-            OS_VERSION="$(sw_vers -productVersion)"
+            OS_VERSION="$(sw_vers -productVersion | tr -d '\r')"
             ;;
           Windows)
             MAJOR="$(pwsh -NoProfile -Command '[System.Environment]::OSVersion.Version.Major' 2>/dev/null | tr -d '\r' || pwsh.exe -NoProfile -Command '[System.Environment]::OSVersion.Version.Major' | tr -d '\r' || true)"
@@ -101,6 +104,7 @@ runs:
         {
           echo "key=cargo-install-$INPUT_CRATE-$INPUT_VERSION-$HASH"
           echo "path=$INSTALL_PATH"
+          echo "features_csv=$FEATURES_CSV"
         } >> "$GITHUB_OUTPUT"
 
     - name: Restore ${{ inputs.crate }} from cache (tags)
@@ -117,17 +121,12 @@ runs:
       env:
         INPUT_CRATE: ${{ inputs.crate }}
         INPUT_VERSION: ${{ inputs.version }}
-        INPUT_FEATURES: ${{ inputs.features }}
         INPUT_ARGS: ${{ inputs.args }}
+        FEATURES_CSV: ${{ steps.key.outputs.features_csv }}
         INSTALL_PATH: ${{ steps.key.outputs.path }}
       run: |
         set -euo pipefail
         set -f
-
-        FEATURES_CSV=""
-        if [ -n "$INPUT_FEATURES" ]; then
-          FEATURES_CSV="$(printf '%s' "$INPUT_FEATURES" | tr ', ' '\n' | sed '/^$/d' | paste -sd ',' -)"
-        fi
 
         ARGS=(install "$INPUT_CRATE" --force --root "$INSTALL_PATH" --version "$INPUT_VERSION")
         if [ -n "$FEATURES_CSV" ]; then

--- a/.github/actions/install-cargo-tool/action.yml
+++ b/.github/actions/install-cargo-tool/action.yml
@@ -115,7 +115,7 @@ runs:
     - name: Restore ${{ inputs.crate }} from cache (tags)
       if: github.ref_type == 'tag'
       id: restore
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
       with:
         path: ${{ steps.key.outputs.path }}
         key: ${{ steps.key.outputs.key }}

--- a/.github/actions/install-cargo-tool/action.yml
+++ b/.github/actions/install-cargo-tool/action.yml
@@ -62,7 +62,12 @@ runs:
         if command -v node >/dev/null 2>&1; then
           INSTALL_PATH="$(node -e 'const path = require("node:path"); const home = process.env.HOME ?? process.env.USERPROFILE; console.log(path.join(home, ".cargo-install", process.argv[1]));' "$INPUT_CRATE")"
         else
-          INSTALL_PATH="$HOME/.cargo-install/$INPUT_CRATE"
+          HOME_DIR="${HOME:-${USERPROFILE:-}}"
+          if [ -z "$HOME_DIR" ]; then
+            echo "Could not determine home directory" >&2
+            exit 1
+          fi
+          INSTALL_PATH="$HOME_DIR/.cargo-install/$INPUT_CRATE"
         fi
 
         FEATURES_CSV=""

--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -7,22 +7,22 @@ description: Sets up tauri
 runs:
   using: "composite"
   steps:
-    - uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+    - name: Install trunk
+      uses: ./.github/actions/install-cargo-tool
       with:
         crate: trunk
         version: 0.21.14
-        locked: true
         args: --no-default-features
         features: rustls
 
-    - uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+    - name: Install cargo-auditable
+      uses: ./.github/actions/install-cargo-tool
       with:
         crate: cargo-auditable
         version: 0.7.5
-        locked: true
 
-    - uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+    - name: Install tauri-cli
+      uses: ./.github/actions/install-cargo-tool
       with:
         crate: tauri-cli
         version: 2.11.4
-        locked: true

--- a/.github/actions/sync-version/action.yml
+++ b/.github/actions/sync-version/action.yml
@@ -12,11 +12,10 @@ runs:
   using: "composite"
   steps:
     - name: Install cargo-edit
-      uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+      uses: ./.github/actions/install-cargo-tool
       with:
         crate: cargo-edit
         version: 0.13.13
-        locked: true
 
     - name: Sync versions from tag
       shell: bash

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -51,6 +51,20 @@
             matchStringsStrategy: "any",
             customType: "regex",
             managerFilePatterns: [
+                "/^\\.github/workflows/.*\\.yml$/",
+                "/^\\.github/actions/.*/.*\\.yml$/",
+            ],
+            matchStrings: [
+                "cargo\\s+install\\s+(?:--locked\\s+)?(?<depName>[A-Za-z0-9_-]+)\\s+--version\\s+(?<currentValue>[0-9][^\\s]*)",
+            ],
+            depTypeTemplate: "build-dependencies",
+            datasourceTemplate: "crate",
+            versioningTemplate: "semver",
+        },
+        {
+            matchStringsStrategy: "any",
+            customType: "regex",
+            managerFilePatterns: [
                 "/^\\.github/docker/.*/Dockerfile$/",
                 "/^packaging/aur/.*\\.sh$/",
             ],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,10 @@ jobs:
         uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
 
       - name: 🔧 Install git-cliff
-        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+        uses: ./.github/actions/install-cargo-tool
         with:
           crate: git-cliff
           version: 2.14.1
-          locked: true
 
       - name: 📝 Update CHANGELOG.md with the new version
         run: |

--- a/.github/workflows/winget-reusable.yml
+++ b/.github/workflows/winget-reusable.yml
@@ -42,11 +42,10 @@ jobs:
           save-cache: false
 
       - name: 🔧 Install komac
-        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+        uses: ./.github/actions/install-cargo-tool
         with:
           crate: komac
           version: 2.16.0
-          locked: true
 
       - name: 🆙 sync our fork of winget-pkgs
         uses: hrzlgnm/actions/.github/actions/retry@d2c23efb5ed3a9f91dd4b2b898db20aeb5aa788f # v2.9.0


### PR DESCRIPTION
## Summary

`baptiste0928/cargo-install` saves a cache entry on every miss with no opt-out, and entries saved on `refs/tags/*` are invisible to `main`, PRs and later tags (GitHub restores only from the current ref or the default branch). Since shared entries expire after 7 days, any release cut later misses and writes a tag-scoped orphan (e.g. `cargo-edit` on `refs/tags/v1.20.4`).

New shared wrapper `.github/actions/install-cargo-tool`: branches keep the cached install; tag runs restore the branch-warmed entry by a byte-identical recomputed key (`actions/cache/restore`, never saves) and otherwise build without saving. Key parity verified 6/6 against the pinned dist algorithm.

Rewired single-step call sites: `release.yml` (git-cliff), `sync-version` (cargo-edit), `setup-tauri` (trunk, cargo-auditable, tauri-cli), `winget` (komac). Also adds a Renovate regex manager tracking `cargo install … --version …` pins in workflows/actions (safety net; call-site versions stay covered by the existing `crate:/version:` manager).

## Testing

- `actionlint` clean; Renovate config validator passes
- Key-parity script: bash port vs exact pinned algorithm, 6/6 identical
- `rg` preview: existing manager matches all 6 call sites, no false positive in wrapper internals; new manager dormant by design
- Live tag-path validation via probe tag `v0.0.0-cache-probe` to follow (restore-hit check + no new tag-scoped entry, then delete tag/draft)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Standardized installation and caching for Rust-based build and release tools.
  - Updated automated release, packaging, version synchronization, and application setup workflows to use the standardized installation process.
  - Preserved existing tool versions and installation settings where applicable.

- **Maintenance**
  - Added automated dependency tracking for Rust tools configured in workflows, helping keep build tooling versions up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->