### PR TITLE
docs: require Node.js 24 or newer for GitHub Actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,4 +278,8 @@ When a task could be done by tacking onto existing code or by first restructurin
 
 - No `unsafe` code anywhere - CI rejects it
 - No `#[allow(warnings)]` attributes - fix the underlying issue instead
+- New GitHub Actions must run on Node.js 24 or newer: when adding or
+  updating an action pin, verify upstream that its runtime (`runs.using`)
+  is `node24` or later. Node.js 20 and older are deprecated and emit a
+  warning on every run.
 - Leave crate versions in `Cargo.toml` and `CHANGELOG.md` entries untouched: the crate publishing workflow bumps versions and generates changelogs automatically (git-cliff, based on conventional commits). Only change source, tests, and docs.


### PR DESCRIPTION
## Summary

Adds a Hard Rules bullet to `AGENTS.md`: new (and updated) action pins must run on Node.js 24 or newer (`runs.using` check). Node.js 20 and older are deprecated and warn on every run.

## Motivation

The `actions/cache/restore@v4` pin added for tag-scoped cache restores immediately produced Node 20 deprecation annotations. Making the floor explicit prevents repeat occurrences.

## Testing

- Docs-only change; two-axis code review clean (0 findings both axes)
- No workflow/Rust changes, so the full check does not apply beyond review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance requiring new or updated GitHub Actions to use Node.js 24 or newer.
  * Noted that Node.js 20 and earlier versions are deprecated and generate warnings on each run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->