### PR TITLE
chore(ci): Install cargo-edit in cache-tools workflow

### DIFF
--- a/.github/workflows/cache-tools-reusable.yml
+++ b/.github/workflows/cache-tools-reusable.yml
@@ -77,3 +77,10 @@ jobs:
 
       - name: 🛠️🐂
         uses: ./.github/actions/setup-tauri
+
+      - name: 🔧 Install cargo-edit
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+        with:
+          crate: cargo-edit
+          version: 0.13.13
+          locked: true


### PR DESCRIPTION
Added step to install cargo edit for all platforms to warm cache for release builds
Closes #2582 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release workflow tooling to ensure required command-line tools are consistently available during release preparation.
  - Improved consistency between tool-caching steps used by release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->