### PR TITLE
feat: add JavaScript bindings for tauri-plugin-android-update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       branch: ${{ steps.branch.outputs.branch }}
       desktop: ${{ steps.filter.outputs.desktop }}
       docker: ${{ steps.filter.outputs.docker }}
+      js: ${{ steps.filter.outputs.js }}
       lint: ${{ steps.filter.outputs.lint }}
       tauri: ${{ steps.filter.outputs.tauri }}
       tests: ${{ steps.filter.outputs.tests }}
@@ -87,6 +88,13 @@ jobs:
               - 'src-tauri/tauri.conf.json'
             docker:
               - '.github/docker/**'
+            js:
+              - '.github/workflows/js-reusable.yml'
+              - 'crates/tauri-plugin-android-update/guest-js/**'
+              - 'crates/tauri-plugin-android-update/package.json'
+              - 'crates/tauri-plugin-android-update/package-lock.json'
+              - 'crates/tauri-plugin-android-update/rollup.config.js'
+              - 'crates/tauri-plugin-android-update/tsconfig.json'
             tauri:
               - '.github/actions/setup-*/**'
               - 'crates/**/src/**'
@@ -147,6 +155,13 @@ jobs:
       - actionlint
     if: needs.changes.outputs.tauri == 'true' || needs.changes.outputs.lint == 'true'
     uses: ./.github/workflows/lint-reusable.yml
+
+  js:
+    needs:
+      - changes
+      - actionlint
+    if: needs.changes.outputs.js == 'true'
+    uses: ./.github/workflows/js-reusable.yml
 
   tests:
     permissions:
@@ -216,6 +231,7 @@ jobs:
       - aur
       - winget
       - lint
+      - js
       - tests
       - android
       - desktop
@@ -230,6 +246,7 @@ jobs:
             aur,
             winget,
             lint,
+            js,
             tests,
             android,
             desktop,

--- a/.github/workflows/js-reusable.yml
+++ b/.github/workflows/js-reusable.yml
@@ -1,0 +1,43 @@
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT
+
+name: "Reusable ci js workflow"
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  js:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: crates/tauri-plugin-android-update
+    steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: crates/tauri-plugin-android-update/package-lock.json
+
+      - name: 📥 Install dependencies
+        shell: bash
+        run: npm ci
+
+      - name: 🔍 Typecheck bindings
+        shell: bash
+        run: npx tsc --noEmit -p tsconfig.json
+
+      - name: 🏗️ Build bindings
+        shell: bash
+        run: npm run build
+
+      - name: 📦 Verify package contents
+        shell: bash
+        run: npm pack --dry-run

--- a/.github/workflows/js-reusable.yml
+++ b/.github/workflows/js-reusable.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   js:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -18,6 +20,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: 🟢 Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6

--- a/.github/workflows/publish-crate-reusable.yml
+++ b/.github/workflows/publish-crate-reusable.yml
@@ -33,6 +33,11 @@ on:
         description: git-cliff config file for the crate CHANGELOG
         required: true
         type: string
+      npm_package_dir:
+        description: Repo-relative dir of the companion npm package to version and publish (empty skips npm)
+        required: false
+        type: string
+        default: ''
     secrets:
       GH_ADMIN_TOKEN:
         required: true
@@ -77,6 +82,11 @@ jobs:
         with:
           save-cache: false
 
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
       - name: 🔧 Install cargo-edit
         uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
         with:
@@ -91,6 +101,7 @@ jobs:
           BUMP_VERSION: ${{ inputs.bump_version }}
           DRY_RUN: ${{ inputs.dry_run }}
           CRATE_NAME: ${{ inputs.crate_name }}
+          NPM_PACKAGE_DIR: ${{ inputs.npm_package_dir }}
         run: |
           set -euo pipefail
           CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r --arg name "$CRATE_NAME" '.packages[] | select(.name == $name) | .version')
@@ -117,6 +128,9 @@ jobs:
             if [ "$BUMP_VERSION" != "none" ]; then
               cargo set-version --package "$CRATE_NAME" --bump "$BUMP_VERSION"
               CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r --arg name "$CRATE_NAME" '.packages[] | select(.name == $name) | .version')
+              if [ -n "$NPM_PACKAGE_DIR" ]; then
+                npm version --no-git-tag-version --prefix "$NPM_PACKAGE_DIR" "$CURRENT_VERSION"
+              fi
             fi
             echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
             echo "Version: $CURRENT_VERSION"
@@ -221,3 +235,48 @@ jobs:
         run: |
           set -euo pipefail
           cargo publish --package "$CRATE_NAME"
+
+  publish_npm:
+    needs: [bump_version]
+    if: (inputs.publish && !inputs.dry_run && inputs.npm_package_dir != '')
+    permissions:
+      contents: read
+      id-token: write # required for npm trusted publishing (OIDC)
+    runs-on: ubuntu-latest
+    name: 📦 Publish to npm
+    steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.bump_version == 'none' && github.ref_name || format('{0}{1}', inputs.tag_prefix, needs.bump_version.outputs.version) }}
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: 🔍 Verify lockstep versions
+        shell: bash
+        env:
+          CRATE_NAME: ${{ inputs.crate_name }}
+          NPM_PACKAGE_DIR: ${{ inputs.npm_package_dir }}
+          VERSION: ${{ needs.bump_version.outputs.version }}
+        run: |
+          set -euo pipefail
+          NPM_VERSION=$(npm pkg get version --prefix "$NPM_PACKAGE_DIR" | tr -d '"')
+          if [ "$NPM_VERSION" != "$VERSION" ]; then
+            echo "Error: npm package version ($NPM_VERSION) does not match crate version ($VERSION)."
+            exit 1
+          fi
+
+      - name: 📦 Publish to npm
+        shell: bash
+        env:
+          NPM_PACKAGE_DIR: ${{ inputs.npm_package_dir }}
+        run: |
+          set -euo pipefail
+          npm ci --prefix "$NPM_PACKAGE_DIR"
+          npm publish --prefix "$NPM_PACKAGE_DIR"

--- a/.github/workflows/publish-tauri-plugin-android-update.yml
+++ b/.github/workflows/publish-tauri-plugin-android-update.yml
@@ -44,6 +44,7 @@ jobs:
       crate_name: tauri-plugin-android-update
       tag_prefix: tauri-plugin-android-update-v
       git_cliff_config: cliff-tauri-plugin-android-update.toml
+      npm_package_dir: crates/tauri-plugin-android-update
     secrets:
       GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
       RULESET_ID: ${{ secrets.RULESET_ID }}

--- a/.github/workflows/publish-tauri-plugin-android-update.yml
+++ b/.github/workflows/publish-tauri-plugin-android-update.yml
@@ -36,6 +36,7 @@ jobs:
     permissions:
       actions: write
       contents: write
+      id-token: write # required for npm trusted publishing (OIDC) in the reusable workflow
     uses: ./.github/workflows/publish-crate-reusable.yml
     with:
       bump_version: ${{ inputs.bump_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 # Gradle build output inside Tauri plugin android modules
 **/android/build/
 **/android/.tauri/
+
+# Node dependencies and built JS bindings inside Tauri plugin packages
+**/node_modules/
+**/dist-js/

--- a/crates/tauri-plugin-android-update/README.md
+++ b/crates/tauri-plugin-android-update/README.md
@@ -1,6 +1,7 @@
 # tauri-plugin-android-update
 
 [![Crates.io](https://img.shields.io/crates/v/tauri-plugin-android-update)](https://crates.io/crates/tauri-plugin-android-update)
+[![npm](https://img.shields.io/npm/v/tauri-plugin-android-update-api)](https://www.npmjs.com/package/tauri-plugin-android-update-api)
 [![License: MIT-0](https://img.shields.io/badge/License-MIT--0-blue.svg)](https://opensource.org/license/mit-0)
 
 A Tauri plugin that surfaces new GitHub releases for manual download on
@@ -65,9 +66,30 @@ tauri_plugin_android_update::Builder::new()
 The plugin registers its commands under the `plugin:android-update|` namespace,
 so the frontend invokes them as `plugin:android-update|check` and
 `plugin:android-update|download_and_install`. The command names mirror the
-`tauri-plugin-updater` plugin's, but the payloads are this plugin's own — the
-`tauri-plugin-updater` JavaScript API does not exist on these platforms, so the
-frontend invokes them directly:
+`tauri-plugin-updater` plugin's, but the payloads are this plugin's own.
+
+## JavaScript API
+
+The
+[`tauri-plugin-android-update-api`](https://www.npmjs.com/package/tauri-plugin-android-update-api)
+package wraps these commands for JavaScript frontends:
+
+```sh
+npm add tauri-plugin-android-update-api
+```
+
+```ts
+import { check, downloadAndInstall } from 'tauri-plugin-android-update-api';
+
+const update = await check();
+if (update) {
+  console.log(`update ${update.version} available (installed: ${update.currentVersion})`);
+  await downloadAndInstall();
+}
+```
+
+Frontends without a JavaScript runtime (e.g. the Leptos frontend in this
+workspace) invoke the commands directly instead:
 
 - `check` — fetches the `latest.json` update manifest from the latest release,
   compares its version against the installed one, and resolves to the update

--- a/crates/tauri-plugin-android-update/guest-js/index.ts
+++ b/crates/tauri-plugin-android-update/guest-js/index.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 hrzlgnm
+// SPDX-License-Identifier: MIT
+
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * Metadata about an available update, as returned by {@link check}.
+ *
+ * Mirrors the `UpdateMetadata` struct serialized by the plugin's `check`
+ * command (`version` is the newer release, `currentVersion` the installed
+ * one).
+ */
+export interface UpdateMetadata {
+    version: string;
+    currentVersion: string;
+}
+
+/**
+ * Checks the GitHub releases of the configured repository for a version
+ * newer than the installed one.
+ *
+ * Resolves to the update metadata when a newer release exists — which is
+ * also stored as the pending update for {@link downloadAndInstall} — or
+ * `null` when the app is up to date.
+ */
+export async function check(): Promise<UpdateMetadata | null> {
+    return invoke('plugin:android-update|check');
+}
+
+/**
+ * Opens the release page for the pending update in the default browser,
+ * where the user can download the new version manually.
+ *
+ * Rejects when no update is pending (i.e. {@link check} found nothing or
+ * has not run).
+ */
+export async function downloadAndInstall(): Promise<void> {
+    return invoke('plugin:android-update|download_and_install');
+}

--- a/crates/tauri-plugin-android-update/package-lock.json
+++ b/crates/tauri-plugin-android-update/package-lock.json
@@ -1,0 +1,691 @@
+{
+    "name": "tauri-plugin-android-update-api",
+    "version": "0.1.2",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "tauri-plugin-android-update-api",
+            "version": "0.1.2",
+            "license": "MIT-0",
+            "dependencies": {
+                "@tauri-apps/api": "^2.0.0"
+            },
+            "devDependencies": {
+                "@rollup/plugin-typescript": "^12.0.0",
+                "rollup": "^4.9.6",
+                "tslib": "^2.6.2",
+                "typescript": "^5.9.0"
+            }
+        },
+        "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+            "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^22.20 || ^24.12 || >=25"
+            }
+        },
+        "node_modules/@rollup/plugin-typescript": {
+            "version": "12.3.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.3.0.tgz",
+            "integrity": "sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.1.0",
+                "resolve": "^1.22.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.14.0||^3.0.0||^4.0.0",
+                "tslib": "*",
+                "typescript": ">=3.7.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                },
+                "tslib": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+            "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+            "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+            "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+            "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+            "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+            "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+            "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+            "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+            "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+            "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+            "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+            "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+            "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+            "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+            "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+            "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+            "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+            "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+            "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+            "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+            "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+            "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+            "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+            "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+            "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+            "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@tauri-apps/api": {
+            "version": "2.11.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
+            "integrity": "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==",
+            "license": "Apache-2.0 OR MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/tauri"
+            }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/rollup": {
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+            "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.9"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+                "@rollup/rollup-android-arm-eabi": "4.63.1",
+                "@rollup/rollup-android-arm64": "4.63.1",
+                "@rollup/rollup-darwin-arm64": "4.63.1",
+                "@rollup/rollup-darwin-x64": "4.63.1",
+                "@rollup/rollup-freebsd-arm64": "4.63.1",
+                "@rollup/rollup-freebsd-x64": "4.63.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+                "@rollup/rollup-linux-arm64-musl": "4.63.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+                "@rollup/rollup-linux-loong64-musl": "4.63.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+                "@rollup/rollup-linux-x64-gnu": "4.63.1",
+                "@rollup/rollup-linux-x64-musl": "4.63.1",
+                "@rollup/rollup-openbsd-x64": "4.63.1",
+                "@rollup/rollup-openharmony-arm64": "4.63.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+                "@rollup/rollup-win32-x64-gnu": "4.63.1",
+                "@rollup/rollup-win32-x64-msvc": "4.63.1",
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        }
+    }
+}

--- a/crates/tauri-plugin-android-update/package.json
+++ b/crates/tauri-plugin-android-update/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "tauri-plugin-android-update-api",
+    "version": "0.1.2",
+    "description": "JavaScript bindings for tauri-plugin-android-update",
+    "author": "hrzlgnm",
+    "license": "MIT-0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/hrzlgnm/mdns-browser",
+        "directory": "crates/tauri-plugin-android-update"
+    },
+    "type": "module",
+    "types": "./dist-js/index.d.ts",
+    "main": "./dist-js/index.cjs",
+    "module": "./dist-js/index.js",
+    "exports": {
+        "types": "./dist-js/index.d.ts",
+        "import": "./dist-js/index.js",
+        "require": "./dist-js/index.cjs"
+    },
+    "files": [
+        "dist-js",
+        "README.md"
+    ],
+    "scripts": {
+        "build": "rollup -c",
+        "prepublishOnly": "npm run build"
+    },
+    "dependencies": {
+        "@tauri-apps/api": "^2.0.0"
+    },
+    "devDependencies": {
+        "@rollup/plugin-typescript": "^12.0.0",
+        "rollup": "^4.9.6",
+        "tslib": "^2.6.2",
+        "typescript": "^5.9.0"
+    }
+}

--- a/crates/tauri-plugin-android-update/package.json
+++ b/crates/tauri-plugin-android-update/package.json
@@ -6,7 +6,7 @@
     "license": "MIT-0",
     "repository": {
         "type": "git",
-        "url": "https://github.com/hrzlgnm/mdns-browser",
+        "url": "git+https://github.com/hrzlgnm/mdns-browser.git",
         "directory": "crates/tauri-plugin-android-update"
     },
     "type": "module",

--- a/crates/tauri-plugin-android-update/rollup.config.js
+++ b/crates/tauri-plugin-android-update/rollup.config.js
@@ -1,0 +1,30 @@
+// Copyright 2026 hrzlgnm
+// SPDX-License-Identifier: MIT
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { cwd } from 'node:process';
+import typescript from '@rollup/plugin-typescript';
+
+const pkg = JSON.parse(readFileSync(join(cwd(), 'package.json'), 'utf8'));
+
+export default {
+    input: 'guest-js/index.ts',
+    output: [
+        {
+            file: pkg.exports.import,
+            format: 'esm'
+        },
+        {
+            file: pkg.exports.require,
+            format: 'cjs'
+        }
+    ],
+    plugins: [
+        typescript({
+            declaration: true,
+            declarationDir: dirname(pkg.exports.import)
+        })
+    ],
+    external: [/^@tauri-apps\/api/, ...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})]
+};

--- a/crates/tauri-plugin-android-update/tsconfig.json
+++ b/crates/tauri-plugin-android-update/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "rootDir": "guest-js",
+        "target": "es2021",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "skipLibCheck": true,
+        "strict": true,
+        "noUnusedLocals": true,
+        "noImplicitAny": true,
+        "noEmit": true
+    },
+    "include": ["guest-js/*.ts"],
+    "exclude": ["dist-js", "node_modules"]
+}


### PR DESCRIPTION
## Summary

The android-update Tauri plugin shipped only its Rust commands, so JavaScript frontends had to invoke raw command names. This adds the companion npm package `tauri-plugin-android-update-api`, modeled on `@tauri-apps/plugin-updater`'s layout and cut down to the two commands this plugin exposes (`check` / `downloadAndInstall`).

- `crates/tauri-plugin-android-update/{package.json,guest-js/index.ts,rollup.config.js,tsconfig.json}` + committed lockfile; builds ESM+CJS `dist-js` with declarations
- CI: path-filtered `js` job (typecheck, build, `npm pack --dry-run`) wired into CI status
- Release: companion package version synced during the crate bump and published to npm via OIDC trusted publishing (opt-in, so the other crate on the reusable workflow is unaffected)
- Package stays under `crates/tauri-plugin-android-update/` so the later repo extraction is a clean move; the Leptos frontend keeps its direct invokes (no JS runtime there)

One-time manual step (not in code): configure the trusted publisher (repo + `publish-crate-reusable.yml`… note: npm matches on the workflow *filename* that runs `npm publish` — since this publishes from a reusable workflow, verify which filename npm validates against and register accordingly) on npmjs.com for `tauri-plugin-android-update-api`.

Note: `typescript` is pinned to ^5.9, not the ^7 in the Tauri CLI template — TS 7's native-port layout breaks `@rollup/plugin-typescript` 12 (`ScriptTarget.ES2015` lookup fails).

## Standards

No hard documented-standard breaches found. Checked each rule against the diff:

* Pinning (`docs/agents/github-actions.md`: "Pin actions to commit SHAs with a `# vN` comment") — compliant: `actions/checkout@3d3c42e5… # v7`, `actions/setup-node@2499707… # v6` in `js-reusable.yml` and `publish-crate-reusable.yml`.
* Template injection (`docs/agents/github-actions.md`: "Never use `${{ }}` expansion inside `run` blocks") — compliant: `CRATE_NAME/NPM_PACKAGE_DIR/VERSION` passed via `env:` and referenced as `"$VAR"` in `publish-crate-reusable.yml` bump/verify/publish steps; `ref:` interpolation stays in `with:`, outside `run:`.
* Shell selection (`docs/agents/github-actions.md`: "Always specify `shell: bash` on steps using bash-specific syntax … when the workflow runs on Windows") — compliant: all new `run:` steps in `js-reusable.yml` and `publish_npm` declare `shell: bash`; runners are `ubuntu-latest`.
* File headers (`AGENTS.md`: "All source files must include" copyright/SPDX header) — compliant: `guest-js/index.ts`, `rollup.config.js`, `js-reusable.yml` carry it; `package.json`/`tsconfig.json`/`package-lock.json` cannot carry comments.
* Hard rules (`AGENTS.md`: "No `unsafe`", "No `#[allow(warnings)]`", "New GitHub Actions must run on Node.js 24 or newer", "Leave crate versions in `Cargo.toml` and `CHANGELOG.md` entries untouched") — compliant: no Rust touched, `node-version: 24`, no `Cargo.toml`/`CHANGELOG.md` edits (`npm version --prefix` touches only the companion `package.json`).
* Android guide (`docs/agents/android.md` `reqwest`/`rustls-tls` note) — not triggered; no `reqwest`/TLS/plugin-list change.

Judgement calls only (baseline never hard; standard overrides):

* Mysterious Name — `ci.yml` `js:` filter/job/output (`js: ${{ steps.filter.outputs.js }}`) doesn't reveal it means "android-update guest-js bindings"; consider `js-android-update`.
* Primitive Obsession — `npm_package_dir` empty-string sentinel (`default: ''` / `!= ''`) stands in for optional companion package; `type: string` with empty-means-absent.
* Duplicated Code — `Setup Node.js → npm ci → build/publish` shape recurs in `js-reusable.yml` vs `publish_npm` job; candidate for a composite setup action (kept separate today by CI-vs-publish contexts).

## Spec

**Verdict: all five agreed requirements appear met; no scope creep or incorrect implementation found.**

**(a) Missing / partial — none.**

- "create that package too" — delivered: `guest-js/index.ts`, `package.json`, `rollup.config.js`, `tsconfig.json`, CI (`js-reusable.yml`) and publish wiring.
- "(1) template is `@tauri-apps/plugin-updater`'s JS package design" — followed: rollup ESM+CJS via `pkg.exports`, `dist-js` outputs, `@tauri-apps/api` dependency, `tsc --noEmit` + `npm run build` + `npm pack --dry-run` in CI.
- "(2) package-first in this repo, repo extraction later" — followed: package lives at `crates/tauri-plugin-android-update/`; no extraction attempted.
- "(3) deliver a public npm package with release automation, versions lockstep with the Rust crate" — followed: `publish_npm` job with OIDC trusted publishing, `npm version --prefix` bump alongside `cargo set-version`, `Verify lockstep versions` gate; `package.json` 0.1.2 matches `Cargo.toml` 0.1.2.
- "(4) unscoped package name … (`tauri-plugin-android-update-api`)" — followed verbatim in `package.json` `name` and README badge/link.
- "(5) the Rust API surface is exactly two commands — `plugin:android-update|check` returning `{version, currentVersion} | null`, and `plugin:android-update|download_and_install` returning void and rejecting with no pending update" — followed: `check(): Promise<UpdateMetadata | null>` and `downloadAndInstall(): Promise<void>` invoke those exact channels with no arguments.
- "The updater template's Resource/rid/channel/progress/options machinery does not apply since the Rust backend takes no arguments" — correctly omitted; no options/rid/progress types in the diff.

**(b) Scope creep — none.** CI path-filter, `.gitignore` (`node_modules/`, `dist-js/`), README JS section/badge are supporting changes for the requested package.

**(c) Implemented-but-wrong — none.**

## Testing

- `tsc --noEmit`, `rollup -c` build, `npm pack --dry-run` (5 files: README, package.json, dist-js x3)
- Full repo check: `cargo fmt` x2, `leptosfmt --check`, `clippy` (dev + release, `-D warnings`), `cargo nextest run --profile ci --workspace` (84 passed), `actionlint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a JavaScript API for checking Android updates and opening pending updates for installation.
  * Added the `tauri-plugin-android-update-api` npm package with ESM, CommonJS, and TypeScript support.
  * Added automated packaging and publishing support for the JavaScript API.

* **Documentation**
  * Added usage guidance, API details, and an npm package badge to the Android update plugin documentation.

* **CI**
  * Added change-aware validation for JavaScript bindings, including type checking, builds, and package-content verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->