### PR TITLE
fix: run npm publish from the package directory

### DIFF
--- a/.github/workflows/publish-crate-reusable.yml
+++ b/.github/workflows/publish-crate-reusable.yml
@@ -278,5 +278,8 @@ jobs:
           NPM_PACKAGE_DIR: ${{ inputs.npm_package_dir }}
         run: |
           set -euo pipefail
-          npm ci --prefix "$NPM_PACKAGE_DIR"
-          npm publish --prefix "$NPM_PACKAGE_DIR"
+          # npm publish ignores --prefix when locating package.json, so run
+          # from the package directory instead.
+          cd "$NPM_PACKAGE_DIR"
+          npm ci
+          npm publish


### PR DESCRIPTION
## Summary

The first npm release run failed in `publish_npm` with `ENOENT: no such file or directory, open '<root>/package.json'`. `npm publish --prefix <dir>` ignores `--prefix` when locating `package.json` and reads it from the working directory instead (reproduced locally; `npm ci` and `npm pkg` honor `--prefix`, publish does not). Change into the companion package directory before `npm ci` / `npm publish`.

## Testing

- Reproduced the exact ENOENT locally with `npm publish --dry-run --prefix <dir>` from the repo root
- `npm publish --dry-run` from the package dir resolves the manifest correctly
- `actionlint` clean

Follow-up after merge: re-dispatch `Publish tauri-plugin-android-update` with `bump_version=none` to ship the missed npm 0.2.0 (note: the crates.io step will report already-published; only the npm step matters). If that run fails with ENEEDAUTH instead, the trusted publisher on npmjs.com still needs registering — the previous run never got far enough to tell.