### PR TITLE
fix: stage the npm release instead of publishing directly

### DIFF
--- a/.github/workflows/publish-crate-reusable.yml
+++ b/.github/workflows/publish-crate-reusable.yml
@@ -272,14 +272,16 @@ jobs:
             exit 1
           fi
 
-      - name: 📦 Publish to npm
+      - name: 📦 Stage publish to npm
         shell: bash
         env:
           NPM_PACKAGE_DIR: ${{ inputs.npm_package_dir }}
         run: |
           set -euo pipefail
           # npm publish ignores --prefix when locating package.json, so run
-          # from the package directory instead.
+          # from the package directory instead. Staged (not direct)
+          # publishing: a maintainer approves each staged version before it
+          # goes live.
           cd "$NPM_PACKAGE_DIR"
           npm ci
-          npm publish
+          npm stage publish


### PR DESCRIPTION
## Summary

The npm release keeps failing with `403 OIDC permission denied`: the trusted publishers registered for `tauri-plugin-android-update-api` are stage-only, so direct `npm publish` is rejected. Stage the version instead; a maintainer approves each staged version before it goes live.

Also fixes the `--prefix` bug from the still-open #2594 (superset of that PR): `npm publish` ignores `--prefix` when locating `package.json`, so the step now runs from the package directory.

## Testing

- `npm stage publish --dry-run` from the package dir stages nothing and validates the command shape
- `actionlint` clean

After merge: re-dispatch `Publish tauri-plugin-android-update` with `bump_version=none`, `publish=true` to stage 0.2.0, then approve it (`npm stage approve` or npmjs.com). Close #2594 unmerged in favor of this.