### PR TITLE
chore(ci): remove idle sccache from clippy job

### DIFF
--- a/.github/workflows/lint-reusable.yml
+++ b/.github/workflows/lint-reusable.yml
@@ -74,10 +74,7 @@ jobs:
           components: clippy
           targets: ${{ matrix.os == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin,wasm32-unknown-unknown' || 'wasm32-unknown-unknown' }}
 
-      - name: 🛠️🚀
-        if: runner.os != 'Windows'
-        uses: ./.github/actions/setup-sccache
-
+      # No sccache here: clippy emits metadata only, which sccache cannot cache.
       - name: 📎 Run clippy and fail if any warnings
         shell: bash
         run: |

--- a/.github/workflows/lint-reusable.yml
+++ b/.github/workflows/lint-reusable.yml
@@ -74,7 +74,7 @@ jobs:
           components: clippy
           targets: ${{ matrix.os == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin,wasm32-unknown-unknown' || 'wasm32-unknown-unknown' }}
 
-      # No sccache here: clippy emits metadata only, which sccache cannot cache.
+      # Clippy emits metadata only, which sccache cannot cache.
       - name: 📎 Run clippy and fail if any warnings
         shell: bash
         run: |


### PR DESCRIPTION
Clippy builds workspace units metadata-only (no link in --emit), which sccache rejects by design, so this step only ever produced 0-hit reports while setup-rust-cache does the real caching. Drop it from the clippy matrix (all three OSes); the shared setup-sccache action stays for the test/desktop/android jobs.

Validation: actionlint clean; two-axis code review passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the lint workflow to streamline Clippy checks.
  * Removed an unused caching step from the lint process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->