### PR TITLE
chore(ci): pin sccache binary to v0.17.0

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -10,6 +10,7 @@ runs:
     - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       with:
         # Pin the binary: the action pin fixes the action, the binary floats on default.
+        # renovate: datasource=github-releases depName=mozilla/sccache versioning=semver
         version: "v0.17.0"
 
     - shell: bash

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -8,6 +8,9 @@ runs:
   using: "composite"
   steps:
     - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+      with:
+        # Pin the binary: the action pin fixes the action, the binary floats on default.
+        version: "v0.17.0"
 
     - shell: bash
       run: |

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -75,5 +75,18 @@
             datasourceTemplate: "crate",
             versioningTemplate: "semver",
         },
+        {
+            description: "Track the sccache binary pinned via a renovate marker comment (the action pin does not cover it)",
+            matchStringsStrategy: "any",
+            customType: "regex",
+            managerFilePatterns: [
+                "/^\\.github/workflows/.*\\.yml$/",
+                "/^\\.github/actions/.*/.*\\.yml$/",
+            ],
+            matchStrings: [
+                "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s+version:\\s*[\"']?(?<currentValue>v[0-9][^\"'\\s]*)[\"']?",
+            ],
+            depTypeTemplate: "sccache",
+        },
     ],
 }


### PR DESCRIPTION
Pin the sccache binary to v0.17.0 in the shared setup-sccache action (the action pin fixes the action, the binary floats on default) and teach renovate to track it via a marker comment plus a regex custom manager (github-releases, mozilla/sccache), so binary updates arrive as renovate PRs.

Validation: actionlint clean, renovate config validator clean, two-axis code review passed.