### PR TITLE
refactor: extract AUR workflow inline bash into packaging/aur scripts

### DIFF
--- a/.github/workflows/aur-reusable.yml
+++ b/.github/workflows/aur-reusable.yml
@@ -27,9 +27,26 @@ jobs:
         id: version
         uses: ./.github/actions/latest-release-info
 
+  lint-scripts:
+    name: "🧹 Lint shell scripts"
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+      - name: 🧹 Check shell scripts
+        env:
+          SCRIPTS_DIR: packaging/aur
+        run: |
+          sudo apt-get update && sudo apt-get install -y shellcheck shfmt
+          shellcheck -S warning "$SCRIPTS_DIR"/*.sh
+          shfmt --diff --indent 4 --case-indent --binary-next-line "$SCRIPTS_DIR"/*.sh
+
   update-aur:
     needs:
       - release-info
+      - lint-scripts
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/hrzlgnm/mdns-browser-arch-aur-builder:v1@sha256:d344e8162f5bcf9bb52750adee123f17eeaa565138bf75096b58e97bad00db0e
@@ -63,30 +80,7 @@ jobs:
           max_attempts: 5
           retry_wait_seconds: 10
           warning_on_retry: true
-          command: |
-            set -o pipefail
-            if [[ "$PACKAGE_NAME" == "mdns-browser-bin" ]]; then
-              ASSETS=$(gh release view "$TAG_NAME" --repo hrzlgnm/mdns-browser --json assets --jq '.assets | map(select(.name | test("\\.sha256$") | not))')
-              SUM=$(echo "$ASSETS" | jq -r --arg name "mdns-browser_${RELEASE_VERSION}_amd64.deb" '.[] | select(.name == $name) | .digest')
-              if [[ -z "$SUM" ]]; then
-                echo "Error: Failed to get checksum from GitHub API for release $TAG_NAME"
-                exit 1
-              fi
-              echo "sha256=$SUM" >> "$GITHUB_OUTPUT"
-              if [[ "$NEEDS_EXE" == "true" ]]; then
-                SUM_EXE=$(echo "$ASSETS" | jq -r --arg name "mdns-browser_linux_x64" '.[] | select(.name == $name) | .digest')
-                if [[ -z "$SUM_EXE" ]]; then
-                  echo "Error: Failed to get exe checksum from GitHub API for release $TAG_NAME"
-                  exit 1
-                fi
-                echo "sha256_exe=$SUM_EXE" >> "$GITHUB_OUTPUT"
-              fi
-            else
-              URL="https://github.com/hrzlgnm/mdns-browser/releases/download/$TAG_NAME/$TAG_NAME.tar.gz.sha256"
-              echo "getting $URL"
-              SUM=$(curl -LfsS --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 15 "$URL" | cut -d' ' -f1)
-              echo "sha256=$SUM" >> "$GITHUB_OUTPUT"
-            fi
+          command: ./packaging/aur/resolve-sha256.sh
 
       - name: 📐 Lint generated PKGBUILD
         uses: hrzlgnm/actions/.github/actions/retry@d2c23efb5ed3a9f91dd4b2b898db20aeb5aa788f # v2.9.0
@@ -98,54 +92,16 @@ jobs:
           RELEASE_VERSION: ${{ needs.release-info.outputs.version }}
           SHA256: ${{ steps.sha256sums.outputs.sha256 }}
         with:
-          command: |
-            su runner -c "
-              set -o errexit
-              mkdir -p ~/lint
-              o=\$(pwd)
-              if [[ \"\$NEEDS_EXE\" == \"true\" ]]; then
-                \$GENERATE_SCRIPT \"\$RELEASE_VERSION\" \"\$SHA256\" \"\$SHA256_EXE\" \"\$TAG_NAME\" > ~/lint/PKGBUILD
-              else
-                \$GENERATE_SCRIPT \"\$RELEASE_VERSION\" \"\$SHA256\" \"\$TAG_NAME\" > ~/lint/PKGBUILD
-              fi
-              cd ~/lint
-              \"\$o/packaging/aur/makepkg-lint.sh\"
-            "
+          # su without --login keeps the step env and only resets
+          # HOME/SHELL/USER/LOGNAME, so the script reads inputs from env.
+          command: su runner -c "./packaging/aur/lint-pkgbuild.sh"
       - name: 🛠️ Setup Deployment keys
         if: github.event.release.tag_name
         uses: hrzlgnm/actions/.github/actions/retry@d2c23efb5ed3a9f91dd4b2b898db20aeb5aa788f # v2.9.0
         env:
           AUR_DEPLOY_KEY: ${{ secrets.AUR_DEPLOY_KEY }}
         with:
-          command: |
-            chown -R runner:runner .
-            su runner -c "
-              set -o errexit
-              mkdir -p ~/.ssh
-              printf '%s\n' \"\$AUR_DEPLOY_KEY\" > ~/.ssh/aur
-              chmod 600 ~/.ssh/aur
-              echo \"Host aur.archlinux.org\" >> ~/.ssh/config
-              echo \"  IdentityFile ~/.ssh/aur\" >> ~/.ssh/config
-              echo \"  User aur\" >> ~/.ssh/config
-              # Arch-published AUR SSH host key fingerprints, see
-              # https://archlinux.org/news/aur-migration-new-ssh-hostkeys/
-              AUR_SSH_FPS="SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4 SHA256:uTa/0PndEgPZTf76e1DFqXKJEXKsn7m9ivhLQtzGOCI SHA256:5s5cIyReIfNNVGRFdDbe3hdYiI5OelHGpw2rOUud3Q8"
-              ssh-keyscan -H aur.archlinux.org > ~/.ssh/aur-known-hosts.tmp
-              if [ ! -s ~/.ssh/aur-known-hosts.tmp ]; then
-                echo "::error::ssh-keyscan returned no host keys for aur.archlinux.org"
-                exit 1
-              fi
-              while read -r host type key; do
-                case "\$host" in '#'*|"") continue;; esac
-                fp=\$(printf '%s %s' "\$type" "\$key" | ssh-keygen -lf /dev/stdin -E sha256 | awk '{print \$2}')
-                case " \$AUR_SSH_FPS " in
-                  *" \$fp "*) ;;
-                  *) echo "::error::AUR host key \$type fingerprint \$fp not in Arch-published set, refusing" ; exit 1 ;;
-                esac
-              done < ~/.ssh/aur-known-hosts.tmp
-              cat ~/.ssh/aur-known-hosts.tmp >> ~/.ssh/known_hosts
-              rm -f ~/.ssh/aur-known-hosts.tmp
-            "
+          command: ./packaging/aur/fix-ownership.sh && su runner -c "./packaging/aur/setup-aur-ssh.sh"
 
       - name: 🔄 Clone AUR Repo
         if: github.event.release.tag_name
@@ -153,30 +109,14 @@ jobs:
         env:
           PACKAGE_NAME: ${{ matrix.package.name }}
         with:
-          command: |
-            su runner -c "
-              set -o errexit
-              rm -rf ~/aur
-              git clone --depth=1 \"ssh://aur@aur.archlinux.org/\$PACKAGE_NAME.git\" ~/aur
-            "
+          command: su runner -c "./packaging/aur/clone-aur-repo.sh"
 
       - name: 🔍 Check version
         if: github.event.release.tag_name
         shell: bash
         env:
           RELEASE_VERSION: ${{ needs.release-info.outputs.version }}
-        run: |
-          su runner -c "
-            set -o errexit
-            cd ~/aur
-            if [[ -f PKGBUILD ]]; then
-              CURRENT_VERSION=\$(source PKGBUILD && echo \$pkgver)
-              if [[ \"\$(printf \"%s\n%s\" \"\$CURRENT_VERSION\" \"\$RELEASE_VERSION\" | sort -V | head -n1)\" != \"\$CURRENT_VERSION\" ]] || [[ \"\$CURRENT_VERSION\" == \"\$RELEASE_VERSION\" ]]; then
-                echo \"New version (\$RELEASE_VERSION) is not higher than the current version (\$CURRENT_VERSION). Exiting.\"
-                exit 1
-              fi
-            fi
-          "
+        run: su runner -c "./packaging/aur/check-aur-version.sh"
 
       - name: 🌀 Generate PKGBUILD update and publish
         if: github.event.release.tag_name
@@ -189,28 +129,4 @@ jobs:
           RELEASE_VERSION: ${{ needs.release-info.outputs.version }}
           SHA256: ${{ steps.sha256sums.outputs.sha256 }}
         with:
-          command: |
-            su runner -c "
-              set -o errexit
-              if [[ \"\$NEEDS_EXE\" == \"true\" ]]; then
-                \$GENERATE_SCRIPT \"\$RELEASE_VERSION\" \"\$SHA256\" \"\$SHA256_EXE\" \"\$TAG_NAME\" > ~/aur/PKGBUILD
-              else
-                \$GENERATE_SCRIPT \"\$RELEASE_VERSION\" \"\$SHA256\" \"\$TAG_NAME\" > ~/aur/PKGBUILD
-              fi
-              cd ~/aur
-              if [[ -n \$(git status --porcelain) ]]; then
-                makepkg --printsrcinfo > .SRCINFO
-                makepkg
-                makepkg --install --noconfirm
-                git config user.name \"hrzlgnm\"
-                git config user.email \"hrzlgnm@users.noreply.github.com\"
-                git add PKGBUILD .SRCINFO
-                git commit -m \"New upstream release \$RELEASE_VERSION\"
-              else
-                echo "No changes (already committed on previous retry or up to date)"
-              fi
-              # Always push: on retry after commit-but-push-failed the
-              # worktree is clean, so exiting early would skip the push.
-              # A failed push stays a failed attempt and is retried.
-              git push origin master
-            "
+          command: su runner -c "./packaging/aur/publish-aur.sh"

--- a/packaging/aur/check-aur-version.sh
+++ b/packaging/aur/check-aur-version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT
+#
+# Fail unless RELEASE_VERSION is strictly higher than the pkgver recorded
+# in the ~/aur checkout. A missing PKGBUILD (new package) passes.
+#
+# Env:
+#   RELEASE_VERSION  release version without leading v, e.g. 1.13.0
+#
+# Idempotent: read-only check.
+
+set -euo pipefail
+
+: "${RELEASE_VERSION:?RELEASE_VERSION must be set}"
+
+cd "${HOME}/aur" || exit 1
+if [[ -f PKGBUILD ]]; then
+    # shellcheck disable=SC1091,SC2154 # PKGBUILD is generated into ~/aur at runtime
+    current_version=$(source PKGBUILD && echo "$pkgver")
+    if [[ "$(printf '%s\n%s' "$current_version" "$RELEASE_VERSION" | sort -V | head -n1)" != "$current_version" ]] || [[ "$current_version" == "$RELEASE_VERSION" ]]; then
+        echo "New version ($RELEASE_VERSION) is not higher than the current version ($current_version). Exiting." >&2
+        exit 1
+    fi
+fi

--- a/packaging/aur/clone-aur-repo.sh
+++ b/packaging/aur/clone-aur-repo.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT
+#
+# Clone the AUR package repository to ~/aur.
+#
+# Env:
+#   PACKAGE_NAME  AUR package name, e.g. mdns-browser or mdns-browser-bin
+#
+# Idempotent: any previous checkout is discarded before cloning.
+
+set -euo pipefail
+
+: "${PACKAGE_NAME:?PACKAGE_NAME must be set}"
+rm -rf "${HOME}/aur"
+git clone --depth=1 "ssh://aur@aur.archlinux.org/${PACKAGE_NAME}.git" "${HOME}/aur"

--- a/packaging/aur/fix-ownership.sh
+++ b/packaging/aur/fix-ownership.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT
+#
+# Ensure the checkout is owned by the runner user. The container runs as
+# root, while builds run as runner via `su runner -c`.
+# Idempotent: chown is a fixed-point operation.
+
+set -euo pipefail
+
+chown -R runner:runner .

--- a/packaging/aur/lint-pkgbuild.sh
+++ b/packaging/aur/lint-pkgbuild.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT
+#
+# Generate the PKGBUILD into ~/lint and run the namcap/source checks on it.
+# Must run from the repository root (GENERATE_SCRIPT is repo-relative).
+#
+# Env:
+#   GENERATE_SCRIPT  generator script, e.g. ./packaging/aur/generate-mdns-browser-bin.sh
+#   RELEASE_VERSION  release version without leading v, e.g. 1.13.0
+#   SHA256           .deb checksum (binary package) or tarball checksum file
+#                    content (source package)
+#   SHA256_EXE       unbundled binary checksum (binary package)
+#   TAG_NAME         release tag, e.g. v1.13.0
+#   NEEDS_EXE        "true" for mdns-browser-bin, anything else for mdns-browser
+#
+# Idempotent: the PKGBUILD is regenerated with overwrite on every run.
+
+set -euo pipefail
+
+: "${GENERATE_SCRIPT:?GENERATE_SCRIPT must be set}"
+: "${RELEASE_VERSION:?RELEASE_VERSION must be set}"
+: "${SHA256:?SHA256 must be set}"
+: "${TAG_NAME:?TAG_NAME must be set}"
+: "${NEEDS_EXE:?NEEDS_EXE must be set}"
+
+repo_root="$PWD"
+mkdir -p "${HOME}/lint"
+if [[ "$NEEDS_EXE" == "true" ]]; then
+    : "${SHA256_EXE:?SHA256_EXE must be set for binary packages}"
+    "$GENERATE_SCRIPT" "$RELEASE_VERSION" "$SHA256" "$SHA256_EXE" "$TAG_NAME" >"${HOME}/lint/PKGBUILD"
+else
+    "$GENERATE_SCRIPT" "$RELEASE_VERSION" "$SHA256" "$TAG_NAME" >"${HOME}/lint/PKGBUILD"
+fi
+cd "${HOME}/lint" || exit 1
+"$repo_root/packaging/aur/makepkg-lint.sh"

--- a/packaging/aur/publish-aur.sh
+++ b/packaging/aur/publish-aur.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT
+#
+# Regenerate ~/aur/PKGBUILD, verify it builds, and push the update.
+# Must run from the repository root (GENERATE_SCRIPT is repo-relative).
+#
+# Env:
+#   GENERATE_SCRIPT  generator script, e.g. ./packaging/aur/generate-mdns-browser-bin.sh
+#   RELEASE_VERSION  release version without leading v, e.g. 1.13.0
+#   SHA256           .deb checksum (binary package) or tarball checksum file
+#                    content (source package)
+#   SHA256_EXE       unbundled binary checksum (binary package)
+#   TAG_NAME         release tag, e.g. v1.13.0
+#   NEEDS_EXE        "true" for mdns-browser-bin, anything else for mdns-browser
+#
+# Idempotent: regeneration overwrites and the commit happens only on actual
+# changes, while the push always runs, so a retry after a committed-but-
+# unpushed run just pushes instead of failing on an empty commit.
+
+set -euo pipefail
+
+: "${GENERATE_SCRIPT:?GENERATE_SCRIPT must be set}"
+: "${RELEASE_VERSION:?RELEASE_VERSION must be set}"
+: "${SHA256:?SHA256 must be set}"
+: "${TAG_NAME:?TAG_NAME must be set}"
+: "${NEEDS_EXE:?NEEDS_EXE must be set}"
+
+if [[ "$NEEDS_EXE" == "true" ]]; then
+    : "${SHA256_EXE:?SHA256_EXE must be set for binary packages}"
+    "$GENERATE_SCRIPT" "$RELEASE_VERSION" "$SHA256" "$SHA256_EXE" "$TAG_NAME" >"${HOME}/aur/PKGBUILD"
+else
+    "$GENERATE_SCRIPT" "$RELEASE_VERSION" "$SHA256" "$TAG_NAME" >"${HOME}/aur/PKGBUILD"
+fi
+cd "${HOME}/aur" || exit 1
+if [[ -n "$(git status --porcelain)" ]]; then
+    makepkg --printsrcinfo >.SRCINFO
+    makepkg
+    makepkg --install --noconfirm
+    git config user.name "hrzlgnm"
+    git config user.email "hrzlgnm@users.noreply.github.com"
+    git add PKGBUILD .SRCINFO
+    git commit -m "New upstream release $RELEASE_VERSION"
+else
+    echo "No changes (already committed on previous retry or up to date)"
+fi
+# Always push: on retry after commit-but-push-failed the worktree is clean,
+# so exiting early would skip the push. A failed push stays a failed attempt
+# and is retried.
+git push origin master

--- a/packaging/aur/resolve-sha256.sh
+++ b/packaging/aur/resolve-sha256.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT
+#
+# Resolve release artifact SHA256 checksums and expose them as step outputs.
+#
+# Env:
+#   PACKAGE_NAME     AUR package name, e.g. mdns-browser or mdns-browser-bin
+#   RELEASE_VERSION  release version without leading v, e.g. 1.13.0
+#   TAG_NAME         release tag, e.g. v1.13.0
+#   NEEDS_EXE        "true" for mdns-browser-bin (also resolves the
+#                    unbundled binary checksum), anything else to skip it
+#   GH_TOKEN         token for `gh` (injected by the workflow)
+#   GITHUB_OUTPUT    file receiving step outputs (injected by Actions)
+#
+# Idempotent: outputs are recomputed from scratch on every run; a retry
+# appends identical lines and Actions uses the last value for each key.
+
+set -euo pipefail
+
+: "${PACKAGE_NAME:?PACKAGE_NAME must be set}"
+: "${RELEASE_VERSION:?RELEASE_VERSION must be set}"
+: "${TAG_NAME:?TAG_NAME must be set}"
+: "${NEEDS_EXE:?NEEDS_EXE must be set}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
+
+if [[ "$PACKAGE_NAME" == "mdns-browser-bin" ]]; then
+    assets=$(gh release view "$TAG_NAME" --repo hrzlgnm/mdns-browser --json assets --jq '.assets | map(select(.name | test("\\.sha256$") | not))')
+    sum=$(jq -r --arg name "mdns-browser_${RELEASE_VERSION}_amd64.deb" '.[] | select(.name == $name) | .digest' <<<"$assets")
+    if [[ -z "$sum" ]]; then
+        echo "Error: Failed to get checksum from GitHub API for release $TAG_NAME" >&2
+        exit 1
+    fi
+    echo "sha256=$sum" >>"$GITHUB_OUTPUT"
+    if [[ "$NEEDS_EXE" == "true" ]]; then
+        sum_exe=$(jq -r --arg name "mdns-browser_linux_x64" '.[] | select(.name == $name) | .digest' <<<"$assets")
+        if [[ -z "$sum_exe" ]]; then
+            echo "Error: Failed to get exe checksum from GitHub API for release $TAG_NAME" >&2
+            exit 1
+        fi
+        echo "sha256_exe=$sum_exe" >>"$GITHUB_OUTPUT"
+    fi
+else
+    url="https://github.com/hrzlgnm/mdns-browser/releases/download/$TAG_NAME/$TAG_NAME.tar.gz.sha256"
+    echo "getting $url"
+    sum=$(curl -LfsS --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 15 "$url" | cut -d' ' -f1)
+    echo "sha256=$sum" >>"$GITHUB_OUTPUT"
+fi

--- a/packaging/aur/setup-aur-ssh.sh
+++ b/packaging/aur/setup-aur-ssh.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT
+#
+# Install the AUR SSH deploy key and pin the aur.archlinux.org host keys
+# to the Arch-published fingerprints.
+#
+# Env:
+#   AUR_DEPLOY_KEY  SSH private key for the aur.archlinux.org service user
+#
+# Idempotent: the key file is overwritten, the ssh config stanza is
+# rewritten to exactly one copy, and previously recorded AUR host keys are
+# replaced, so a retry neither duplicates entries nor fails.
+
+set -euo pipefail
+
+: "${AUR_DEPLOY_KEY:?AUR_DEPLOY_KEY must be set}"
+
+mkdir -p "${HOME}/.ssh"
+chmod 700 "${HOME}/.ssh"
+printf '%s\n' "$AUR_DEPLOY_KEY" >"${HOME}/.ssh/aur"
+chmod 600 "${HOME}/.ssh/aur"
+
+config="${HOME}/.ssh/config"
+touch "$config"
+chmod 600 "$config"
+tmp_config=$(mktemp "${HOME}/.ssh/config.XXXXXX")
+scan_tmp=$(mktemp "${HOME}/.ssh/aur-known-hosts.XXXXXX")
+key_patterns=$(mktemp "${HOME}/.ssh/aur-key-patterns.XXXXXX")
+tmp_known_hosts=$(mktemp "${HOME}/.ssh/known-hosts.XXXXXX")
+trap 'rm -f "$tmp_config" "$scan_tmp" "$key_patterns" "$tmp_known_hosts"' EXIT
+awk '/^Host aur\.archlinux\.org([[:space:]]|$)/ { skip = 1; next } /^Host / { skip = 0 } !skip' "$config" >"$tmp_config"
+cat >>"$tmp_config" <<'EOF'
+Host aur.archlinux.org
+  IdentityFile ~/.ssh/aur
+  User aur
+EOF
+mv "$tmp_config" "$config"
+
+# Arch-published AUR SSH host key fingerprints, see
+# https://archlinux.org/news/aur-migration-new-ssh-hostkeys/
+aur_ssh_fps="SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4 SHA256:uTa/0PndEgPZTf76e1DFqXKJEXKsn7m9ivhLQtzGOCI SHA256:5s5cIyReIfNNVGRFdDbe3hdYiI5OelHGpw2rOUud3Q8"
+ssh-keyscan -H aur.archlinux.org >"$scan_tmp"
+if [[ ! -s "$scan_tmp" ]]; then
+    echo "::error::ssh-keyscan returned no host keys for aur.archlinux.org" >&2
+    exit 1
+fi
+verified=0
+while read -r host type key; do
+    case "$host" in '#'*) continue ;; "") continue ;; esac
+    fp=$(printf '%s %s' "$type" "$key" | ssh-keygen -lf /dev/stdin -E sha256 | awk '{print $2}')
+    case " $aur_ssh_fps " in
+        *" $fp "*) ;;
+        *)
+            echo "::error::AUR host key $type fingerprint $fp not in Arch-published set, refusing" >&2
+            exit 1
+            ;;
+    esac
+    echo "Verified AUR host key $type $fp"
+    verified=$((verified + 1))
+done <"$scan_tmp"
+if [[ "$verified" -eq 0 ]]; then
+    echo "::error::ssh-keyscan returned no verifiable host keys for aur.archlinux.org" >&2
+    exit 1
+fi
+touch "${HOME}/.ssh/known_hosts"
+ssh-keygen -R aur.archlinux.org -f "${HOME}/.ssh/known_hosts" >/dev/null 2>&1 || true
+# Drop previously recorded lines carrying the same key material. Key bodies
+# are stable across scans even though -H salts differ, so a retry keeps
+# exactly one copy of each key instead of accumulating stale hashed lines.
+awk '{print $3}' "$scan_tmp" >"$key_patterns"
+grep -v -F -f "$key_patterns" "${HOME}/.ssh/known_hosts" >"$tmp_known_hosts" || true
+mv "$tmp_known_hosts" "${HOME}/.ssh/known_hosts"
+cat "$scan_tmp" >>"${HOME}/.ssh/known_hosts"

--- a/typos.toml
+++ b/typos.toml
@@ -5,4 +5,4 @@ extend-exclude = [".git/", "cliff.toml", "cliff-webkit2gtk.toml", "cliff-tauri-p
 
 [default]
 check-filename = true
-extend-ignore-re = ["digest to \\b[0-9a-f]{7,}\\b", "AUR_SSH_FPS=\"[^\"]*\""]
+extend-ignore-re = ["digest to \\b[0-9a-f]{7,}\\b", "(?i)AUR_SSH_FPS=\"[^\"]*\""]


### PR DESCRIPTION
Ports the zux AUR cleanup: extracts every inline bash block from `aur-reusable.yml` (216 → 132 lines, no more `\\$`/\`"\` escape hell inside `su runner -c`/`retry` wrappers) into seven env-driven, idempotent scripts under `packaging/aur/`:

- `fix-ownership.sh`, `resolve-sha256.sh`, `lint-pkgbuild.sh`, `setup-aur-ssh.sh`, `clone-aur-repo.sh`, `check-aur-version.sh`, `publish-aur.sh`

Each retry `command:` is now a one-liner (`su` without `--login` keeps the step env and only resets HOME/SHELL/USER/LOGNAME). Generator CLI (`VERSION SHA256 [SHA256_EXE] TAG`) and the commit-if-dirty/always-push publish flow are preserved verbatim; idempotency hardening vs the originals: ssh config rewritten to exactly one stanza, `known_hosts` entries deduplicated by key material, temp files via mktemp+trap.

Also adds a `lint-scripts` job in `aur-reusable.yml` running `shellcheck -S warning` and `shfmt --diff -i 4 -ci` over `packaging/aur/*.sh`, gating `update-aur`, and widens the typos fingerprint ignore to both variable casings (`(?i)AUR_SSH_FPS`).

No issue references.

Testing:
- `shellcheck -S warning`, `shfmt --diff` (CI flags), `actionlint .github/workflows/*.yml`, and full-repo `typos` all pass.
- `resolve-sha256.sh` both branches against real v1.20.4 data, deterministic, checksums cross-checked with `test-aur-local` output.
- `lint-pkgbuild.sh` both branches deterministic (real namcap run); `check-aur-version.sh` higher/equal/lower/retry cases; `setup-aur-ssh.sh` full stubbed success path x2 with exactly-once stanza/keys; `publish-aur.sh` clean-tree path x2 (skip build, no-op push).
- `test-aur-local --no-build` source and bin variants: namcap clean, sha256sums passed (same pre-existing `--no-build` exit-1 helper quirk as observed on zux, on unmodified helper code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - AUR package publishing now uses dedicated validation and publishing steps for more consistent releases.
  - Added checks for release versions, package metadata, buildability, and artifact checksums.
  - Improved SSH setup with verified AUR host keys and safer retry behavior.
  - Added automated ShellCheck and formatting checks for packaging scripts.

- **Bug Fixes**
  - Improved handling of package ownership and repository updates during AUR builds.
  - Checksum resolution now reports missing release artifacts as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->