### PR TITLE
fix: harden AUR release scripts and workflow checkout

### DIFF
--- a/.github/workflows/aur-reusable.yml
+++ b/.github/workflows/aur-reusable.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: 🧹 Check shell scripts
         env:
           SCRIPTS_DIR: packaging/aur

--- a/.github/workflows/aur-reusable.yml
+++ b/.github/workflows/aur-reusable.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: 🏷️ Get version info
         id: version
@@ -66,6 +67,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: 🔢 Get sha256sums
         id: sha256sums

--- a/packaging/aur/check-aur-version.sh
+++ b/packaging/aur/check-aur-version.sh
@@ -16,8 +16,23 @@ set -euo pipefail
 
 cd "${HOME}/aur" || exit 1
 if [[ -f PKGBUILD ]]; then
-    # shellcheck disable=SC1091,SC2154 # PKGBUILD is generated into ~/aur at runtime
-    current_version=$(source PKGBUILD && echo "$pkgver")
+    pkgver_line=$(grep -E '^pkgver=' PKGBUILD | head -n1 || true)
+    if [[ -z "$pkgver_line" ]]; then
+        echo "Error: no literal pkgver= assignment found in PKGBUILD." >&2
+        exit 1
+    fi
+    current_version="${pkgver_line#pkgver=}"
+    if [[ "$current_version" == "'*'" ]]; then
+        current_version="${current_version#\'}"
+        current_version="${current_version%\'}"
+    elif [[ "$current_version" == '"*"' ]]; then
+        current_version="${current_version#\"}"
+        current_version="${current_version%\"}"
+    fi
+    if [[ ! "$current_version" =~ ^[A-Za-z0-9._+]+$ ]]; then
+        echo "Error: PKGBUILD pkgver is not a plain literal version: $pkgver_line" >&2
+        exit 1
+    fi
     if [[ "$(printf '%s\n%s' "$current_version" "$RELEASE_VERSION" | sort -V | head -n1)" != "$current_version" ]] || [[ "$current_version" == "$RELEASE_VERSION" ]]; then
         echo "New version ($RELEASE_VERSION) is not higher than the current version ($current_version). Exiting." >&2
         exit 1

--- a/packaging/aur/resolve-sha256.sh
+++ b/packaging/aur/resolve-sha256.sh
@@ -31,11 +31,19 @@ if [[ "$PACKAGE_NAME" == "mdns-browser-bin" ]]; then
         echo "Error: Failed to get checksum from GitHub API for release $TAG_NAME" >&2
         exit 1
     fi
+    if [[ ! "$sum" =~ ^(sha256:)?[0-9a-fA-F]{64}$ ]]; then
+        echo "Error: Invalid sha256 checksum from GitHub API for release $TAG_NAME" >&2
+        exit 1
+    fi
     echo "sha256=$sum" >>"$GITHUB_OUTPUT"
     if [[ "$NEEDS_EXE" == "true" ]]; then
         sum_exe=$(jq -r --arg name "mdns-browser_linux_x64" '.[] | select(.name == $name) | .digest' <<<"$assets")
         if [[ -z "$sum_exe" ]]; then
             echo "Error: Failed to get exe checksum from GitHub API for release $TAG_NAME" >&2
+            exit 1
+        fi
+        if [[ ! "$sum_exe" =~ ^(sha256:)?[0-9a-fA-F]{64}$ ]]; then
+            echo "Error: Invalid sha256 exe checksum from GitHub API for release $TAG_NAME" >&2
             exit 1
         fi
         echo "sha256_exe=$sum_exe" >>"$GITHUB_OUTPUT"
@@ -44,5 +52,9 @@ else
     url="https://github.com/hrzlgnm/mdns-browser/releases/download/$TAG_NAME/$TAG_NAME.tar.gz.sha256"
     echo "getting $url"
     sum=$(curl -LfsS --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 15 "$url" | cut -d' ' -f1)
+    if [[ ! "$sum" =~ ^(sha256:)?[0-9a-fA-F]{64}$ ]]; then
+        echo "Error: Invalid sha256 checksum from $url" >&2
+        exit 1
+    fi
     echo "sha256=$sum" >>"$GITHUB_OUTPUT"
 fi


### PR DESCRIPTION
Summary:
- check-aur-version.sh no longer sources PKGBUILD (arbitrary code execution from the AUR clone); parses and validates a literal pkgver assignment instead, failing clearly on missing/dynamic values.
- resolve-sha256.sh validates all extracted checksums as 64 hex chars with optional sha256: prefix; values exported unchanged, prefix stripping stays in the generate scripts.
- All three checkout steps in aur-reusable.yml set persist-credentials: false (release-info is read-only, AUR pushes go over ssh), matching other reusable workflows.

Testing:
- shellcheck -S warning clean, bash -n clean, actionlint clean, cargo fmt --check clean.
- check-aur-version.sh exercised against literal, equal, missing, and dynamic pkgver cases (dynamic rejected without execution).
- checksum regex exercised against prefixed, raw, and malformed values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved workflow checkout security by preventing credential persistence.
  * Added validation for release package checksums before they are used.
* **Bug Fixes**
  * Improved version detection by requiring a valid, literal package version and reporting errors for invalid or missing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->