### PR TITLE
feat(ci): pin shellcheck/shfmt in AUR lint job

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -74,5 +74,17 @@
             ],
             depTypeTemplate: "sccache",
         },
+        {
+            description: "Track pinned shellcheck/shfmt binaries via renovate marker comments (per-arch checksums stay pinned in the script and fail closed until refreshed)",
+            matchStringsStrategy: "any",
+            customType: "regex",
+            managerFilePatterns: [
+                "/^packaging\\/aur\\/install-lint-tools\\.sh$/",
+            ],
+            matchStrings: [
+                "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s+\\w+_version=\"?(?<currentValue>v[0-9][^\"'\\s]*)\"?",
+            ],
+            depTypeTemplate: "build-dependencies",
+        },
     ],
 }

--- a/.github/workflows/aur-reusable.yml
+++ b/.github/workflows/aur-reusable.yml
@@ -37,11 +37,17 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
+      - name: 📥 Install pinned lint tools
+        uses: hrzlgnm/actions/.github/actions/retry@d2c23efb5ed3a9f91dd4b2b898db20aeb5aa788f # v2.9.0
+        with:
+          # Downloads only; the lint below stays plain so a real
+          # finding fails fast instead of being retried.
+          command: ./packaging/aur/install-lint-tools.sh
       - name: 🧹 Check shell scripts
         env:
           SCRIPTS_DIR: packaging/aur
         run: |
-          sudo apt-get update && sudo apt-get install -y shellcheck shfmt
+          export PATH="$HOME/.local/bin:$PATH"
           shellcheck -S warning "$SCRIPTS_DIR"/*.sh
           shfmt --diff --indent 4 --case-indent --binary-next-line "$SCRIPTS_DIR"/*.sh
 

--- a/packaging/aur/install-lint-tools.sh
+++ b/packaging/aur/install-lint-tools.sh
@@ -4,14 +4,36 @@
 #
 # Install pinned shellcheck and shfmt binaries into ~/.local/bin.
 # Pinned releases keep lint results reproducible across runner image updates.
-# Bump the versions together with their checksums below.
+#
+# Renovate bumps the versions below (see the "shell lint tools" manager in
+# .github/renovate.json5). Neither upstream publishes a checksum file, so the
+# per-arch checksums stay pinned here: after a version bump the install fails
+# closed on mismatch until the checksums are refreshed from the upstream
+# release digests.
 #
 # Idempotent: archives are re-downloaded and binaries overwritten on every
 # run, so a retry leaves the same final state.
 
 set -euo pipefail
 
+verify_checksum() {
+    local file="$1"
+    local expected="$2"
+    local actual
+    actual="$(sha256sum "$file" | cut -d' ' -f1)"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "Error: checksum mismatch for $file" >&2
+        echo "  expected: $expected" >&2
+        echo "  actual:   $actual" >&2
+        echo "If renovate bumped the tool version, refresh the checksums" >&2
+        echo "above from the upstream release digests." >&2
+        return 1
+    fi
+}
+
+# renovate: datasource=github-releases depName=koalaman/shellcheck versioning=semver
 shellcheck_version="v0.11.0"
+# renovate: datasource=github-releases depName=mvdan/sh versioning=semver
 shfmt_version="v3.14.1"
 
 arch="$(uname -m)"
@@ -43,8 +65,8 @@ curl_flags=(-LfsS --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout
 curl "${curl_flags[@]}" -o "$workdir/$shellcheck_asset" "https://github.com/koalaman/shellcheck/releases/download/${shellcheck_version}/${shellcheck_asset}"
 curl "${curl_flags[@]}" -o "$workdir/$shfmt_asset" "https://github.com/mvdan/sh/releases/download/${shfmt_version}/${shfmt_asset}"
 
-printf '%s  %s\n' "$shellcheck_sha256" "$workdir/$shellcheck_asset" | sha256sum -c -
-printf '%s  %s\n' "$shfmt_sha256" "$workdir/$shfmt_asset" | sha256sum -c -
+verify_checksum "$workdir/$shellcheck_asset" "$shellcheck_sha256"
+verify_checksum "$workdir/$shfmt_asset" "$shfmt_sha256"
 
 tar -xJf "$workdir/$shellcheck_asset" -C "$workdir"
 install -m 755 "$workdir/shellcheck-${shellcheck_version}/shellcheck" "$bindir/shellcheck"

--- a/packaging/aur/install-lint-tools.sh
+++ b/packaging/aur/install-lint-tools.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT
+#
+# Install pinned shellcheck and shfmt binaries into ~/.local/bin.
+# Pinned releases keep lint results reproducible across runner image updates.
+# Bump the versions together with their checksums below.
+#
+# Idempotent: archives are re-downloaded and binaries overwritten on every
+# run, so a retry leaves the same final state.
+
+set -euo pipefail
+
+shellcheck_version="v0.11.0"
+shfmt_version="v3.14.1"
+
+arch="$(uname -m)"
+case "$arch" in
+    x86_64 | amd64)
+        shellcheck_asset="shellcheck-${shellcheck_version}.linux.x86_64.tar.xz"
+        shellcheck_sha256="8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
+        shfmt_asset="shfmt_${shfmt_version}_linux_amd64"
+        shfmt_sha256="76e77641faa025814b77f153b29796b8e6fa2fca03e0c76a691608b86c7ea7bf"
+        ;;
+    aarch64 | arm64)
+        shellcheck_asset="shellcheck-${shellcheck_version}.linux.aarch64.tar.xz"
+        shellcheck_sha256="12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e261eaa7e7c14588"
+        shfmt_asset="shfmt_${shfmt_version}_linux_arm64"
+        shfmt_sha256="5f2db09dae91fca848f7adbdd014632e921a383863a2ad7e0450ad3aba0c6489"
+        ;;
+    *)
+        echo "Error: unsupported architecture '$arch'" >&2
+        exit 1
+        ;;
+esac
+
+bindir="${HOME}/.local/bin"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+mkdir -p "$bindir"
+
+curl_flags=(-LfsS --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 15)
+curl "${curl_flags[@]}" -o "$workdir/$shellcheck_asset" "https://github.com/koalaman/shellcheck/releases/download/${shellcheck_version}/${shellcheck_asset}"
+curl "${curl_flags[@]}" -o "$workdir/$shfmt_asset" "https://github.com/mvdan/sh/releases/download/${shfmt_version}/${shfmt_asset}"
+
+printf '%s  %s\n' "$shellcheck_sha256" "$workdir/$shellcheck_asset" | sha256sum -c -
+printf '%s  %s\n' "$shfmt_sha256" "$workdir/$shfmt_asset" | sha256sum -c -
+
+tar -xJf "$workdir/$shellcheck_asset" -C "$workdir"
+install -m 755 "$workdir/shellcheck-${shellcheck_version}/shellcheck" "$bindir/shellcheck"
+install -m 755 "$workdir/$shfmt_asset" "$bindir/shfmt"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+    printf '%s\n' "$bindir" >>"$GITHUB_PATH"
+fi
+
+"$bindir/shellcheck" --version
+"$bindir/shfmt" --version


### PR DESCRIPTION
## Summary
- `lint-scripts` in `aur-reusable.yml` no longer installs floating `shellcheck`/`shfmt` via `apt-get`. It downloads pinned release binaries (shellcheck v0.11.0, shfmt v3.14.1) with sha256 verification via the new `packaging/aur/install-lint-tools.sh`.
- Only the download runs under the shared retry action; the actual shellcheck/shfmt findings stay plain fail-fast with no retry.
- Renovate tracks the pins via marker comments + a new regex manager in `.github/renovate.json5`. Neither upstream publishes a checksum file, so per-arch checksums stay pinned and fail closed with an actionable message until refreshed from upstream release digests.

## Testing
- Full check green: `cargo fmt` (both manifests), `leptosfmt`, `clippy` (debug + release, `-D warnings`), `nextest --profile ci` (84 passed), `actionlint`.
- `install-lint-tools.sh` passes `shellcheck -S warning` and `shfmt --diff` with the pinned versions; E2E install into a temp HOME verified, plus the tampered-checksum path (fails closed, exit 1, prints expected/actual).
- Renovate config validated with `kokuwaio/renovate-config-validator`; new regex verified to match both pins (and no cross-matches with other managers).
- Code-review gate (Standards + Spec sub-agents): no findings on the first commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shell linting in the AUR workflow to use pinned versions of ShellCheck and shfmt.
  * Added architecture-aware installation with checksum verification and retry handling for improved reliability.
  * Linting tools are now installed in a consistent local location and made available automatically during workflow runs.
  * Added automated tracking for updates to the pinned linting tool versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->