### PR TITLE
fix: fail release when a draft already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,29 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 🧹 Delete pre-existing draft releases
-        uses: hugo19941994/delete-draft-releases@3f19a25abf2ce87850c2268938f98f14e4d3d1f1 # v3.0.0
+      - name: 🛑 Fail if any draft release exists
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          DRAFTS=$(gh api "repos/${REPOSITORY}/releases?per_page=100" --paginate \
+            -q '[.[] | select(.draft == true) | .tag_name] | join(", ")')
+          if [ -n "$DRAFTS" ]; then
+            echo "Error: refusing to clobber existing draft release(s): $DRAFTS" >&2
+            echo "Delete or publish the draft(s) manually, then re-run." >&2
+            exit 1
+          fi
+
+      - name: 🛑 Fail if release already exists for this tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if gh release view "$TAG_NAME" --repo "${REPOSITORY}" >/dev/null 2>&1; then
+            echo "Error: release '$TAG_NAME' already exists" >&2
+            exit 1
+          fi
 
       - name: 🦀 Install Rust toolchain for git-cliff build fallback
         uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable


### PR DESCRIPTION
Replaces silent draft deletion with explicit fail-fast guards.

- Fails if any draft release exists (preserves manually prepared drafts).
- Fails if a release already exists for the pushed tag.
- Drops hugo19941994/delete-draft-releases dependency.

Testing: actionlint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release creation now checks for existing draft releases and releases matching the current tag.
  * Release generation stops when duplicates are detected, preventing accidental overwrites.
  * Existing draft releases are no longer removed automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->