### PR TITLE
chore(ci): share versioned sources via single build artifact

### DIFF
--- a/.github/workflows/android-reusable.yml
+++ b/.github/workflows/android-reusable.yml
@@ -43,11 +43,12 @@ jobs:
           targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android,wasm32-unknown-unknown
           save-cache: ${{ inputs.branch == 'main' }}
 
-      - name: 🎯 Sync version from tag
+      - name: 📥 Download versioned sources
         if: inputs.tagName
-        uses: ./.github/actions/sync-version
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          tagName: ${{ inputs.tagName }}
+          name: versioned-sources
+          path: .
 
       - name: 📝 Extract version from tauri.conf.json
         id: get-version

--- a/.github/workflows/cache-tools-reusable.yml
+++ b/.github/workflows/cache-tools-reusable.yml
@@ -79,10 +79,3 @@ jobs:
 
       - name: 🛠️🐂
         uses: ./.github/actions/setup-tauri
-
-      - name: 🔧 Install cargo-edit
-        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
-        with:
-          crate: cargo-edit
-          version: 0.13.13
-          locked: true

--- a/.github/workflows/desktop-reusable.yml
+++ b/.github/workflows/desktop-reusable.yml
@@ -63,11 +63,12 @@ jobs:
           targets: ${{ matrix.os == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin,wasm32-unknown-unknown' || 'wasm32-unknown-unknown' }}
           save-cache: ${{ inputs.branch == 'main' }}
 
-      - name: 🎯 Sync version from tag
+      - name: 📥 Download versioned sources
         if: inputs.tagName
-        uses: ./.github/actions/sync-version
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          tagName: ${{ inputs.tagName }}
+          name: versioned-sources
+          path: .
 
       - name: 📝 Extract version from tauri.conf.json
         id: get-version
@@ -75,19 +76,6 @@ jobs:
         run: |
           CURRENT_VERSION=$(jq -r '.version' src-tauri/tauri.conf.json)
           echo "current-version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: 📥 Download versioned changelog (linux bundles only)
-        if: inputs.tagName && contains(matrix.os, 'ubuntu')
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: changelog
-          path: changelog-artifact
-
-      - name: 📝 Replace CHANGELOG.md with the versioned changelog
-        if: inputs.tagName && contains(matrix.os, 'ubuntu')
-        shell: bash
-        run: |
-          cp changelog-artifact/CHANGELOG.md CHANGELOG.md
 
       - name: 📜 Create and 🔍 scan SBOM for vulnerabilities
         uses: ./.github/actions/sbom

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,23 @@ jobs:
         run: |
           git-cliff --config .github/cliff/cliff.toml --output CHANGELOG.md
 
-      - name: 📤 Upload versioned changelog artifact
+      - name: 🎯 Sync version from tag
+        uses: ./.github/actions/sync-version
+        with:
+          tagName: ${{ github.ref_name }}
+
+      - name: 📤 Upload versioned sources artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: changelog
-          path: CHANGELOG.md
+          name: versioned-sources
+          path: |
+            CHANGELOG.md
+            Cargo.toml
+            Cargo.lock
+            src-tauri/Cargo.toml
+            src-tauri/tauri.conf.json
+            crates/models/Cargo.toml
+            crates/shared_constants/Cargo.toml
 
       - name: 🗒️ Generate release notes with git-cliff
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   create_release_draft:
     permissions:
-      contents: write # to create and update releases and drafts and upload the changelog artifact
+      contents: write # to create and update releases and drafts and upload the versioned-sources artifact
     runs-on: ubuntu-slim
     name: 📝 Draft a new release
     steps:


### PR DESCRIPTION
Run the cargo-edit version sync once in the release draft job and upload the synced manifests, Tauri config, and CHANGELOG.md as one versioned-sources artifact. The desktop matrix and Android jobs download it instead of installing cargo-edit and re-syncing per job, and the separate changelog download/copy steps collapse into the same download.

Testing: actionlint clean on .github/workflows/*.yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release automation to consistently apply the release version across packaged Android and desktop builds.
  - Release builds now use a shared set of versioned source files, helping ensure package metadata matches the published tag.
  - Updated release artifact handling to include required project manifests alongside the changelog.
  - Simplified desktop release processing by using the shared versioned sources for changelog and version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->