### PR TITLE
fix(ci): restore checkout credentials in update-changelog workflow

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: 🦀 Install Rust toolchain for git-cliff build fallback
         uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable


### PR DESCRIPTION
Restores persisted checkout credentials in the nightly changelog workflow.

The `persist-credentials: false` added for read-only checkouts breaks the nightly run: the signed-commit push loses git auth (`fatal: could not read Username`) and the `gh pr create/merge` step cannot create the update PR. This checkout is not read-only, so persist the credentials again.

Validation: actionlint clean. Review: standards/spec axes, 0 findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the changelog workflow’s repository checkout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->